### PR TITLE
SpreadsheetHistoryHashToken.formulaHistoryHashToken() was formula

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellClearHistoryHashToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellClearHistoryHashToken.java
@@ -51,7 +51,7 @@ public final class SpreadsheetCellClearHistoryHashToken extends SpreadsheetCellH
     }
 
     @Override
-    SpreadsheetNameHistoryHashToken formula() {
+    SpreadsheetNameHistoryHashToken formulaHistoryHashToken() {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellDeleteHistoryHashToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellDeleteHistoryHashToken.java
@@ -51,7 +51,7 @@ public final class SpreadsheetCellDeleteHistoryHashToken extends SpreadsheetCell
     }
 
     @Override
-    SpreadsheetNameHistoryHashToken formula() {
+    SpreadsheetNameHistoryHashToken formulaHistoryHashToken() {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormulaHistoryHashToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormulaHistoryHashToken.java
@@ -46,7 +46,7 @@ abstract public class SpreadsheetCellFormulaHistoryHashToken extends Spreadsheet
     abstract UrlFragment formulaUrlFragment();
 
     @Override
-    final SpreadsheetNameHistoryHashToken formula() {
+    final SpreadsheetNameHistoryHashToken formulaHistoryHashToken() {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFreezeHistoryHashToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFreezeHistoryHashToken.java
@@ -51,7 +51,7 @@ public final class SpreadsheetCellFreezeHistoryHashToken extends SpreadsheetCell
     }
 
     @Override
-    SpreadsheetNameHistoryHashToken formula() {
+    SpreadsheetNameHistoryHashToken formulaHistoryHashToken() {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellMenuHistoryHashToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellMenuHistoryHashToken.java
@@ -51,7 +51,7 @@ public final class SpreadsheetCellMenuHistoryHashToken extends SpreadsheetCellHi
     }
 
     @Override
-    SpreadsheetNameHistoryHashToken formula() {
+    SpreadsheetNameHistoryHashToken formulaHistoryHashToken() {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternHistoryHashToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternHistoryHashToken.java
@@ -42,7 +42,7 @@ abstract public class SpreadsheetCellPatternHistoryHashToken extends Spreadsheet
     abstract UrlFragment patternUrlFragment();
 
     @Override
-    final SpreadsheetNameHistoryHashToken formula() {
+    final SpreadsheetNameHistoryHashToken formulaHistoryHashToken() {
         return this;
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSelectHistoryHashToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSelectHistoryHashToken.java
@@ -51,7 +51,7 @@ public final class SpreadsheetCellSelectHistoryHashToken extends SpreadsheetCell
     }
 
     @Override
-    SpreadsheetNameHistoryHashToken formula() {
+    SpreadsheetNameHistoryHashToken formulaHistoryHashToken() {
         return formula(
                 this.id(),
                 this.name(),

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleHistoryHashToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleHistoryHashToken.java
@@ -56,7 +56,7 @@ abstract public class SpreadsheetCellStyleHistoryHashToken<T> extends Spreadshee
     abstract UrlFragment styleUrlFragment();
 
     @Override
-    final SpreadsheetNameHistoryHashToken formula() {
+    final SpreadsheetNameHistoryHashToken formulaHistoryHashToken() {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellUnfreezeHistoryHashToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellUnfreezeHistoryHashToken.java
@@ -51,7 +51,7 @@ public final class SpreadsheetCellUnfreezeHistoryHashToken extends SpreadsheetCe
     }
 
     @Override
-    SpreadsheetNameHistoryHashToken formula() {
+    SpreadsheetNameHistoryHashToken formulaHistoryHashToken() {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnHistoryHashToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnHistoryHashToken.java
@@ -62,7 +62,7 @@ abstract public class SpreadsheetColumnHistoryHashToken extends SpreadsheetViewp
     }
 
     @Override
-    final SpreadsheetNameHistoryHashToken formula() {
+    final SpreadsheetNameHistoryHashToken formulaHistoryHashToken() {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingHistoryHashToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingHistoryHashToken.java
@@ -52,7 +52,7 @@ public abstract class SpreadsheetLabelMappingHistoryHashToken extends Spreadshee
     }
 
     @Override
-    final SpreadsheetNameHistoryHashToken formula() {
+    final SpreadsheetNameHistoryHashToken formulaHistoryHashToken() {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNameHistoryHashToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNameHistoryHashToken.java
@@ -97,7 +97,7 @@ public abstract class SpreadsheetNameHistoryHashToken extends SpreadsheetHistory
     /**
      * Creates a formula {@link SpreadsheetNameHistoryHashToken}.
      */
-    abstract SpreadsheetNameHistoryHashToken formula();
+    abstract SpreadsheetNameHistoryHashToken formulaHistoryHashToken();
 
     /**
      * Creates a freeze {@link SpreadsheetNameHistoryHashToken}.

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowHistoryHashToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowHistoryHashToken.java
@@ -62,7 +62,7 @@ abstract public class SpreadsheetRowHistoryHashToken extends SpreadsheetViewport
     }
 
     @Override
-    final SpreadsheetNameHistoryHashToken formula() {
+    final SpreadsheetNameHistoryHashToken formulaHistoryHashToken() {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectHistoryHashToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectHistoryHashToken.java
@@ -190,7 +190,7 @@ public final class SpreadsheetSelectHistoryHashToken extends SpreadsheetNameHist
     }
 
     @Override
-    SpreadsheetNameHistoryHashToken formula() {
+    SpreadsheetNameHistoryHashToken formulaHistoryHashToken() {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectionHistoryHashToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectionHistoryHashToken.java
@@ -56,7 +56,7 @@ abstract public class SpreadsheetSelectionHistoryHashToken extends SpreadsheetNa
                 result = this.delete();
                 break;
             case "formula":
-                result = this.formula();
+                result = this.formulaHistoryHashToken();
                 break;
             case "freeze":
                 result = this.freeze();


### PR DESCRIPTION
- Rename necessary to avoid clash with SpreadsheetCellFormulaSaveHistoryHashToken formula getter (TODO).