### PR TITLE
SpreadsheetViewportCache labels reset fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/SpreadsheetViewportCache.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/SpreadsheetViewportCache.java
@@ -69,6 +69,7 @@ final class SpreadsheetViewportCache implements Consumer<SpreadsheetDelta> {
 
         for (final SpreadsheetCellReference cell : delta.deletedCells()) {
             cells.remove(cell);
+            labels.remove(cell);
         }
 
         for (final SpreadsheetCell cell : delta.cells()) {
@@ -77,13 +78,16 @@ final class SpreadsheetViewportCache implements Consumer<SpreadsheetDelta> {
                     cellReference,
                     cell
             );
+            labels.remove(cellReference);
         }
+
+        final Set<SpreadsheetLabelMapping> labelMappings = delta.labels();
 
         final SpreadsheetViewportCacheUpdatingSpreadsheetSelectionVisitor labelUpdater = SpreadsheetViewportCacheUpdatingSpreadsheetSelectionVisitor.with(
                 labels,
                 windows
         );
-        for (final SpreadsheetLabelMapping mapping : delta.labels()) {
+        for (final SpreadsheetLabelMapping mapping : labelMappings) {
             labelUpdater.accept(mapping);
         }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/SpreadsheetViewportCacheTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/SpreadsheetViewportCacheTest.java
@@ -262,6 +262,84 @@ public final class SpreadsheetViewportCacheTest implements ClassTesting<Spreadsh
     }
 
     @Test
+    public void testAcceptTwiceLabelsReplaced() {
+        final SpreadsheetViewportCache cache = SpreadsheetViewportCache.empty();
+
+        cache.accept(
+                SpreadsheetDelta.EMPTY
+                        .setLabels(
+                                Sets.of(
+                                        LABEL_MAPPINGA1A
+                                )
+                        )
+        );
+
+        cache.accept(
+                SpreadsheetDelta.EMPTY
+                        .setDeletedCells(
+                                Sets.of(
+                                        A1
+                                )
+                        )
+                        .setLabels(
+                                Sets.of(
+                                        LABEL_MAPPINGA1B
+                                )
+                        )
+        );
+
+        this.checkLabels(
+                cache,
+                LABEL_MAPPINGA1B
+        );
+
+        this.checkWindow(
+                cache,
+                ""
+        );
+    }
+
+    @Test
+    public void testAcceptTwiceLabelsReplaced2() {
+        final SpreadsheetViewportCache cache = SpreadsheetViewportCache.empty();
+
+        cache.accept(
+                SpreadsheetDelta.EMPTY
+                        .setLabels(
+                                Sets.of(
+                                        SpreadsheetSelection.labelName("LostLabel").mapping(A1)
+                                )
+                        )
+        );
+
+        cache.accept(
+                SpreadsheetDelta.EMPTY
+                        .setDeletedCells(
+                                Sets.of(
+                                        A1
+                                )
+                        )
+                        .setLabels(
+                                Sets.of(
+                                        LABEL_MAPPINGA1A,
+                                        LABEL_MAPPINGA1B
+                                )
+                        )
+        );
+
+        this.checkLabels(
+                cache,
+                LABEL_MAPPINGA1A,
+                LABEL_MAPPINGA1B
+        );
+
+        this.checkWindow(
+                cache,
+                ""
+        );
+    }
+
+    @Test
     public void testAcceptTwiceMergedDifferentNoWindow() {
         final SpreadsheetViewportCache cache = SpreadsheetViewportCache.empty();
 


### PR DESCRIPTION
- any cells updated or deleted have their labels reset with updates expected in the SpreadsheetDelta.labels()