### PR TITLE
SpreadsheetCreateHistoryToken implements SpreadsheetMetadataWatcher

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/App.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/App.java
@@ -150,6 +150,18 @@ public class App implements EntryPoint, AppContext, UncaughtExceptionHandler {
     }
 
     public void fireSpreadsheetMetadata(final SpreadsheetMetadata metadata) {
+        final Optional<HistoryToken> maybeToken = this.historyToken();
+        if(maybeToken.isPresent()) {
+            final HistoryToken token = maybeToken.get();
+            if(token instanceof SpreadsheetMetadataWatcher) {
+                final SpreadsheetMetadataWatcher watcher = (SpreadsheetMetadataWatcher)token;
+                watcher.onSpreadsheetMetadata(
+                        metadata,
+                        this
+                );
+            }
+        }
+
         for(final SpreadsheetMetadataWatcher watcher : this.metadataWatchers) {
             watcher.onSpreadsheetMetadata(
                     metadata,

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCreateHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCreateHistoryToken.java
@@ -21,12 +21,15 @@ import walkingkooka.net.Url;
 import walkingkooka.net.UrlFragment;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.dominokit.AppContext;
+import walkingkooka.spreadsheet.dominokit.SpreadsheetMetadataWatcher;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.text.cursor.TextCursor;
 
 /**
  * A token that represents a spreadsheet create action.
  */
-public final class SpreadsheetCreateHistoryToken extends SpreadsheetHistoryToken {
+public final class SpreadsheetCreateHistoryToken extends SpreadsheetHistoryToken implements SpreadsheetMetadataWatcher {
 
     static SpreadsheetCreateHistoryToken with() {
         return new SpreadsheetCreateHistoryToken();
@@ -54,6 +57,20 @@ public final class SpreadsheetCreateHistoryToken extends SpreadsheetHistoryToken
         context.spreadsheetMetadataFetcher().post(
                 Url.parseAbsolute("http://localhost:12345/api/spreadsheet"),
                 ""
+        );
+    }
+
+    /**
+     * When the spreadsheet is created and a new {@link SpreadsheetMetadata} is returned update the history token.
+     */
+    @Override
+    public void onSpreadsheetMetadata(final SpreadsheetMetadata metadata,
+                                      final AppContext context) {
+        context.pushHistoryToken(
+                spreadsheetSelect(
+                        metadata.getOrFail(SpreadsheetMetadataPropertyName.SPREADSHEET_ID),
+                        metadata.getOrFail(SpreadsheetMetadataPropertyName.SPREADSHEET_NAME)
+                )
         );
     }
 }


### PR DESCRIPTION
- Updates history token to spreadsheet select when SpreadsheetMetadata returns.