### PR TITLE
SpreadsheetViewportCache label to label support

### DIFF
--- a/src/test/java/walkingkooka/spreadsheet/dominokit/SpreadsheetViewportCacheUpdatingSpreadsheetSelectionVisitorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/SpreadsheetViewportCacheUpdatingSpreadsheetSelectionVisitorTest.java
@@ -22,11 +22,15 @@ import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelectionVisitorTesting;
 
+import java.util.Collections;
+
 public final class SpreadsheetViewportCacheUpdatingSpreadsheetSelectionVisitorTest implements SpreadsheetSelectionVisitorTesting<SpreadsheetViewportCacheUpdatingSpreadsheetSelectionVisitor> {
     @Override
     public SpreadsheetViewportCacheUpdatingSpreadsheetSelectionVisitor createVisitor() {
-        return SpreadsheetViewportCacheUpdatingSpreadsheetSelectionVisitor.with(
+        return SpreadsheetViewportCacheUpdatingSpreadsheetSelectionVisitor.accept(
+                Collections.emptyList(),
                 Maps.empty(),
+                Collections.emptyMap(),
                 SpreadsheetSelection.parseWindow("A1:Z99")
         );
     }


### PR DESCRIPTION
- I think previously labels to ranges would meant only one of the cells for the range would have been present in cells to labels etc, this is now definitely working and tested.
- This should help make it easy for SpreadsheetViewportWidget to select columns/rows/cells when reading given the current spreadsheet selection.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/167
- SpreadsheetViewportCache support label to label mappings (currently throws UOE)