### PR TITLE
SpreadsheetViewportWidget.loadViewportCell missing selectionAnchor fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/SpreadsheetDeltaFetcher.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/SpreadsheetDeltaFetcher.java
@@ -28,6 +28,8 @@ import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.engine.SpreadsheetDelta;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
+import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelectionAnchor;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -43,13 +45,13 @@ public class SpreadsheetDeltaFetcher implements Fetcher {
      * selectionType=cell
      * </pre>
      */
-    public static UrlQueryString appendSelectionAndWindow(final SpreadsheetSelection selection,
-                                                          final Set<SpreadsheetCellRange> window,
-                                                          final UrlQueryString queryString) {
+    public static UrlQueryString appendViewportSelectionAndWindow(final SpreadsheetViewportSelection viewportSelection,
+                                                                  final Set<SpreadsheetCellRange> window,
+                                                                  final UrlQueryString queryString) {
         return appendWindow(
                 window,
-                appendSelection(
-                        selection,
+                appendViewportSelection(
+                        viewportSelection,
                         queryString
                 )
         );
@@ -63,23 +65,36 @@ public class SpreadsheetDeltaFetcher implements Fetcher {
      * selectionType=cell
      * </pre>
      */
-    public static UrlQueryString appendSelection(final SpreadsheetSelection selection,
-                                                 final UrlQueryString queryString) {
-        Objects.requireNonNull(selection, "selection");
+    public static UrlQueryString appendViewportSelection(final SpreadsheetViewportSelection viewportSelection,
+                                                         final UrlQueryString queryString) {
+        Objects.requireNonNull(viewportSelection, "viewportSelection");
         Objects.requireNonNull(queryString, "queryString");
 
-        return queryString.addParameter(
+        final SpreadsheetSelection selection = viewportSelection.selection();
+
+        UrlQueryString result = queryString.addParameter(
                 SELECTION,
                 selection.toString()
         ).addParameter(
                 SELECTION_TYPE,
                 selection.selectionTypeName()
         );
+
+        final SpreadsheetViewportSelectionAnchor anchor = viewportSelection.anchor();
+
+        return SpreadsheetViewportSelectionAnchor.NONE == anchor ?
+                result :
+                result.addParameter(
+                        SELECTION_ANCHOR,
+                        viewportSelection.anchor().kebabText()
+                );
     }
 
     private final static UrlParameterName SELECTION = UrlParameterName.with("selection");
 
     private final static UrlParameterName SELECTION_TYPE = UrlParameterName.with("selectionType");
+
+    private final static UrlParameterName SELECTION_ANCHOR = UrlParameterName.with("selectionAnchor");
 
     /**
      * Appends the given window to the given {@link UrlQueryString}

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/SpreadsheetViewportWidget.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/SpreadsheetViewportWidget.java
@@ -220,10 +220,9 @@ public final class SpreadsheetViewportWidget implements SpreadsheetDeltaWatcher,
                 .addParameter(INCLUDE_FROZEN_COLUMNS_ROWS, Boolean.TRUE.toString());
 
         final Optional<SpreadsheetViewportSelection> viewportSelection = metadata.get(SpreadsheetMetadataPropertyName.SELECTION);
-        if(viewportSelection.isPresent()) {
-            queryString = SpreadsheetDeltaFetcher.appendSelection(
-                    viewportSelection.get()
-                            .selection(),
+        if (viewportSelection.isPresent()) {
+            queryString = SpreadsheetDeltaFetcher.appendViewportSelection(
+                    viewportSelection.get(),
                     queryString
             );
         }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetViewportSelectionHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetViewportSelectionHistoryToken.java
@@ -27,7 +27,6 @@ import walkingkooka.spreadsheet.dominokit.SpreadsheetDeltaFetcher;
 import walkingkooka.spreadsheet.engine.SpreadsheetDelta;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
-import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
 
 import java.util.Objects;
@@ -81,19 +80,20 @@ public abstract class SpreadsheetViewportSelectionHistoryToken extends Spreadshe
      */
     final void deltaClear(AppContext context) {
         final SpreadsheetDeltaFetcher fetcher = context.spreadsheetDeltaFetcher();
-        final SpreadsheetSelection selection = this.selection().viewportSelection().selection();
+        final SpreadsheetViewportSelection viewportSelection = this.selection()
+                .viewportSelection();
 
         // clear row
         fetcher.postDelta(
                 fetcher.url(
                         this.id(),
-                        selection,
+                        viewportSelection.selection(),
                         Optional.of(
                                 UrlPath.parse("/clear")
                         )
                 ).setQuery(
-                        SpreadsheetDeltaFetcher.appendSelectionAndWindow(
-                                selection,
+                        SpreadsheetDeltaFetcher.appendViewportSelectionAndWindow(
+                                viewportSelection,
                                 context.viewportWindow(),
                                 UrlQueryString.EMPTY
                         )


### PR DESCRIPTION
- loading a cell-range/column-range/row-range selection without an anchor will default and update the url with the default anchor for that selection.