### PR TITLE
SpreadsheetNameHistoryToken.menu(SpreadsheetSelection)

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellHistoryToken.java
@@ -85,6 +85,18 @@ abstract public class SpreadsheetCellHistoryToken extends SpreadsheetViewportSel
     }
 
     @Override
+    final SpreadsheetNameHistoryToken menu0(final SpreadsheetSelection selection) {
+        return (false == this instanceof SpreadsheetCellFormulaHistoryToken) &&
+                selection.isCellReference() &&
+                this.viewportSelection()
+                        .selection()
+                        .testCell(selection.toCell()) ?
+                this :
+                this.selection(selection)
+                        .menu();
+    }
+
+    @Override
     final SpreadsheetViewportSelectionHistoryToken selection0() {
         return cell(
                 this.id(),

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnHistoryToken.java
@@ -89,6 +89,18 @@ abstract public class SpreadsheetColumnHistoryToken extends SpreadsheetViewportS
                 this.viewportSelection()
         );
     }
+
+    @Override
+    final SpreadsheetNameHistoryToken menu0(final SpreadsheetSelection selection) {
+        return selection.isColumnReference() &&
+                this.viewportSelection()
+                        .selection()
+                        .testColumn(selection.toColumn()) ?
+                this :
+                this.selection(selection)
+                        .menu();
+    }
+
     @Override
     SpreadsheetNameHistoryToken pattern(final SpreadsheetPatternKind patternKind) {
         return this; // TODO

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingHistoryToken.java
@@ -22,6 +22,7 @@ import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.tree.text.TextStylePropertyName;
 
 public abstract class SpreadsheetLabelMappingHistoryToken extends SpreadsheetSelectionHistoryToken {
@@ -64,6 +65,12 @@ public abstract class SpreadsheetLabelMappingHistoryToken extends SpreadsheetSel
     @Override
     final SpreadsheetNameHistoryToken menu() {
         return this;
+    }
+
+    @Override
+    final SpreadsheetNameHistoryToken menu0(final SpreadsheetSelection selection) {
+        return this.selection(selection)
+                .menu();
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataHistoryToken.java
@@ -21,6 +21,7 @@ import walkingkooka.net.UrlFragment;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.text.cursor.TextCursor;
 
 public abstract class SpreadsheetMetadataHistoryToken<T> extends SpreadsheetNameHistoryToken {
@@ -91,6 +92,12 @@ public abstract class SpreadsheetMetadataHistoryToken<T> extends SpreadsheetName
     @Override
     final SpreadsheetNameHistoryToken menu() {
         return this;
+    }
+
+    @Override
+    SpreadsheetNameHistoryToken menu0(final SpreadsheetSelection selection) {
+        return this.selection(selection)
+                .menu();
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNameHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNameHistoryToken.java
@@ -145,6 +145,21 @@ public abstract class SpreadsheetNameHistoryToken extends SpreadsheetIdHistoryTo
     abstract SpreadsheetNameHistoryToken menu();
 
     /**
+     * Creates a menu {@link SpreadsheetNameHistoryToken} for the given {@link SpreadsheetSelection}.
+     */
+    final SpreadsheetNameHistoryToken menu(final SpreadsheetSelection selection) {
+        Objects.requireNonNull(selection, "selection");
+
+        if(false == (selection.isCellReference() || selection.isColumnReference() || selection.isRowReference())) {
+            throw new IllegalArgumentException("Expected cell, column or row but got " + selection);
+        }
+
+        return this.menu0(selection);
+    }
+
+    abstract SpreadsheetNameHistoryToken menu0(final SpreadsheetSelection selection);
+
+    /**
      * Factory that creates a {@link SpreadsheetNameHistoryToken} with the given {@link SpreadsheetPatternKind}.
      */
     abstract SpreadsheetNameHistoryToken pattern(final SpreadsheetPatternKind patternKind);

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowHistoryToken.java
@@ -91,6 +91,17 @@ abstract public class SpreadsheetRowHistoryToken extends SpreadsheetViewportSele
     }
 
     @Override
+    final SpreadsheetNameHistoryToken menu0(final SpreadsheetSelection selection) {
+        return selection.isRowReference() &&
+                this.viewportSelection()
+                        .selection()
+                        .testRow(selection.toRow()) ?
+                this :
+                this.selection(selection)
+                        .menu();
+    }
+
+    @Override
     SpreadsheetNameHistoryToken pattern(final SpreadsheetPatternKind patternKind) {
         return this; // TODO
     }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectHistoryToken.java
@@ -263,6 +263,12 @@ public final class SpreadsheetSelectHistoryToken extends SpreadsheetNameHistoryT
         return this;
     }
 
+    @Override
+    SpreadsheetNameHistoryToken menu0(final SpreadsheetSelection selection) {
+        return this.selection(selection)
+                .menu();
+    }
+
     // factory for /spreadsheet-id/spreadsheet-name/metadata/pattern/*
     @Override
     SpreadsheetNameHistoryToken pattern(final SpreadsheetPatternKind patternKind) {

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellClearHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellClearHistoryTokenTest.java
@@ -46,6 +46,13 @@ public final class SpreadsheetCellClearHistoryTokenTest extends SpreadsheetCellH
         );
     }
 
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public void testMenuWithCell() {
+        this.menuWithCellAndCheck();
+    }
+
     @Override
     SpreadsheetCellClearHistoryToken createHistoryToken(final SpreadsheetId id,
                                                         final SpreadsheetName name,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellDeleteHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellDeleteHistoryTokenTest.java
@@ -46,6 +46,13 @@ public final class SpreadsheetCellDeleteHistoryTokenTest extends SpreadsheetCell
         );
     }
 
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public void testMenuWithCell() {
+        this.menuWithCellAndCheck();
+    }
+
     @Override
     SpreadsheetCellDeleteHistoryToken createHistoryToken(final SpreadsheetId id,
                                                          final SpreadsheetName name,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormulaHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormulaHistoryTokenTestCase.java
@@ -17,9 +17,54 @@
 
 package walkingkooka.spreadsheet.dominokit.history;
 
+import org.junit.jupiter.api.Test;
+import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+
 public abstract class SpreadsheetCellFormulaHistoryTokenTestCase<T extends SpreadsheetCellFormulaHistoryToken> extends SpreadsheetCellHistoryTokenTestCase<T> {
 
     SpreadsheetCellFormulaHistoryTokenTestCase() {
         super();
+    }
+
+    // menu with selection..............................................................................................
+
+    @Test
+    public final void testCellMenuWithSameCell() {
+        final SpreadsheetCellReference cell = SpreadsheetSelection.parseCell("A1");
+
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        cell.setDefaultAnchor()
+                ),
+                cell,
+                SpreadsheetHistoryToken.cellMenu(
+                        ID,
+                        NAME,
+                        cell.setDefaultAnchor()
+                )
+        );
+    }
+
+    @Test
+    public final void testCellMenuWithDifferentCell() {
+        final SpreadsheetCellReference cell = SpreadsheetSelection.parseCell("B2");
+
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        SpreadsheetSelection.parseCell("A1").setDefaultAnchor()
+                ),
+                cell,
+                SpreadsheetHistoryToken.cellMenu(
+                        ID,
+                        NAME,
+                        cell.setDefaultAnchor()
+                )
+        );
+    }
+
+    @Test
+    public void testMenuWithCell() {
+        this.menuWithCellAndCheck();
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFreezeHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFreezeHistoryTokenTest.java
@@ -75,6 +75,13 @@ public final class SpreadsheetCellFreezeHistoryTokenTest extends SpreadsheetCell
         );
     }
 
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public void testMenuWithCell() {
+        this.menuWithCellAndCheck();
+    }
+
     @Override
     SpreadsheetCellFreezeHistoryToken createHistoryToken(final SpreadsheetId id,
                                                          final SpreadsheetName name,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellHistoryTokenTestCase.java
@@ -70,7 +70,7 @@ public abstract class SpreadsheetCellHistoryTokenTestCase<T extends SpreadsheetC
                 "Got 1:2 expected cell, cell-range or label"
         );
     }
-    
+
     @Test
     public final void testSelection() {
         final T token = this.createHistoryToken();
@@ -85,6 +85,19 @@ public abstract class SpreadsheetCellHistoryTokenTestCase<T extends SpreadsheetC
                 selection
         );
     }
+
+    // menu with selection..............................................................................................
+
+    @Test
+    public final void testMenuWithColumn() {
+        this.menuWithColumnAndCheck();
+    }
+
+    @Test
+    public final void testMenuWithRow() {
+        this.menuWithRowAndCheck();
+    }
+
 
     final void urlFragmentAndCheck(final SpreadsheetExpressionReference reference,
                                    final String expected) {

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellMenuHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellMenuHistoryTokenTest.java
@@ -20,6 +20,8 @@ package walkingkooka.spreadsheet.dominokit.history;
 import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
+import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelectionAnchor;
 
@@ -43,6 +45,69 @@ public final class SpreadsheetCellMenuHistoryTokenTest extends SpreadsheetCellHi
         this.urlFragmentAndCheck(
                 LABEL,
                 "/123/SpreadsheetName456/cell/Label123/menu"
+        );
+    }
+
+    // menu with selection..............................................................................................
+
+    @Test
+    public void testCellMenuWithSameCell() {
+        final SpreadsheetCellReference cell = SpreadsheetSelection.parseCell("A1");
+
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        cell.setDefaultAnchor()
+                ),
+                cell,
+                SpreadsheetHistoryToken.cellMenu(
+                        ID,
+                        NAME,
+                        cell.setDefaultAnchor()
+                )
+        );
+    }
+
+    @Test
+    public void testCellMenuWithDifferentCell() {
+        final SpreadsheetCellReference cell = SpreadsheetSelection.parseCell("B2");
+
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        SpreadsheetSelection.parseCell("A1").setDefaultAnchor()
+                ),
+                cell,
+                SpreadsheetHistoryToken.cellMenu(
+                        ID,
+                        NAME,
+                        cell.setDefaultAnchor()
+                )
+        );
+    }
+
+    @Test
+    public void testCellRangeMenuWithCellInside() {
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        SpreadsheetSelection.parseCellRange("A1:C3").setDefaultAnchor()
+                ),
+                SpreadsheetSelection.parseCell("B2")
+        );
+    }
+
+    @Test
+    public void testCellRangeMenuWithCellOutside() {
+        final SpreadsheetCellReference cell = SpreadsheetSelection.parseCell("Z99");
+
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        SpreadsheetSelection.parseCellRange("B2:C4").setDefaultAnchor()
+                ),
+                cell,
+                SpreadsheetHistoryToken.cellMenu(
+                        ID,
+                        NAME,
+                        cell.setDefaultAnchor()
+                )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternHistoryTokenTestCase.java
@@ -17,9 +17,18 @@
 
 package walkingkooka.spreadsheet.dominokit.history;
 
+import org.junit.jupiter.api.Test;
+
 public abstract class SpreadsheetCellPatternHistoryTokenTestCase<T extends SpreadsheetCellPatternHistoryToken> extends SpreadsheetCellHistoryTokenTestCase<T> {
 
     SpreadsheetCellPatternHistoryTokenTestCase() {
         super();
+    }
+
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public final void testMenuWithCell() {
+        this.menuWithCellAndCheck();
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSelectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSelectHistoryTokenTest.java
@@ -46,6 +46,13 @@ public final class SpreadsheetCellSelectHistoryTokenTest extends SpreadsheetCell
         );
     }
 
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public void testMenuWithCell() {
+        this.menuWithCellAndCheck();
+    }
+
     @Override
     SpreadsheetCellSelectHistoryToken createHistoryToken(final SpreadsheetId id,
                                                          final SpreadsheetName name,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellUnfreezeHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellUnfreezeHistoryTokenTest.java
@@ -75,6 +75,13 @@ public final class SpreadsheetCellUnfreezeHistoryTokenTest extends SpreadsheetCe
         );
     }
 
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public void testMenuWithCell() {
+        this.menuWithCellAndCheck();
+    }
+
     @Override
     SpreadsheetCellUnfreezeHistoryToken createHistoryToken(final SpreadsheetId id,
                                                            final SpreadsheetName name,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnClearHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnClearHistoryTokenTest.java
@@ -40,6 +40,13 @@ public final class SpreadsheetColumnClearHistoryTokenTest extends SpreadsheetCol
         );
     }
 
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public void testMenuWithColumn() {
+        this.menuWithColumnAndCheck();
+    }
+
     @Override
     SpreadsheetColumnClearHistoryToken createHistoryToken(final SpreadsheetId id,
                                                           final SpreadsheetName name,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnDeleteHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnDeleteHistoryTokenTest.java
@@ -40,6 +40,13 @@ public final class SpreadsheetColumnDeleteHistoryTokenTest extends SpreadsheetCo
         );
     }
 
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public void testMenuWithColumn() {
+        this.menuWithColumnAndCheck();
+    }
+
     @Override
     SpreadsheetColumnDeleteHistoryToken createHistoryToken(final SpreadsheetId id,
                                                            final SpreadsheetName name,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnFreezeHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnFreezeHistoryTokenTest.java
@@ -54,6 +54,13 @@ public final class SpreadsheetColumnFreezeHistoryTokenTest extends SpreadsheetCo
         );
     }
 
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public void testMenuWithColumn() {
+        this.menuWithColumnAndCheck();
+    }
+
     @Override
     SpreadsheetColumnFreezeHistoryToken createHistoryToken(final SpreadsheetId id,
                                                            final SpreadsheetName name,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnHistoryTokenTestCase.java
@@ -90,6 +90,18 @@ public abstract class SpreadsheetColumnHistoryTokenTestCase<T extends Spreadshee
         );
     }
 
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public final void testMenuWithCell() {
+        this.menuWithCellAndCheck();
+    }
+
+    @Test
+    public final void testMenuWithRow() {
+        this.menuWithRowAndCheck();
+    }
+
     final void urlFragmentAndCheck(final SpreadsheetColumnReference reference,
                                    final String expected) {
         this.urlFragmentAndCheck(

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnMenuHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnMenuHistoryTokenTest.java
@@ -20,6 +20,8 @@ package walkingkooka.spreadsheet.dominokit.history;
 import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
+import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelectionAnchor;
 
@@ -37,6 +39,69 @@ public final class SpreadsheetColumnMenuHistoryTokenTest extends SpreadsheetColu
         this.urlFragmentAndCheck(
                 COLUMN_RANGE.setAnchor(SpreadsheetViewportSelectionAnchor.RIGHT),
                 "/123/SpreadsheetName456/column/B:C/right/menu"
+        );
+    }
+
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public void testColumnMenuWithSameColumn() {
+        final SpreadsheetColumnReference column = SpreadsheetSelection.parseColumn("B");
+
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        column.setDefaultAnchor()
+                ),
+                column,
+                SpreadsheetHistoryToken.columnMenu(
+                        ID,
+                        NAME,
+                        column.setDefaultAnchor()
+                )
+        );
+    }
+
+    @Test
+    public void testColumnMenuWithDifferentColumn() {
+        final SpreadsheetColumnReference column = SpreadsheetSelection.parseColumn("B");
+
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        SpreadsheetSelection.parseColumn("A").setDefaultAnchor()
+                ),
+                column,
+                SpreadsheetHistoryToken.columnMenu(
+                        ID,
+                        NAME,
+                        column.setDefaultAnchor()
+                )
+        );
+    }
+
+    @Test
+    public void testColumnRangeMenuWithColumnInside() {
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        SpreadsheetSelection.parseColumnRange("A:C").setDefaultAnchor()
+                ),
+                SpreadsheetSelection.parseColumn("B")
+        );
+    }
+
+    @Test
+    public void testColumnRangeMenuWithColumnOutside() {
+        final SpreadsheetColumnReference column = SpreadsheetSelection.parseColumn("Z");
+
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        SpreadsheetSelection.parseColumnRange("A:C").setDefaultAnchor()
+                ),
+                column,
+                SpreadsheetHistoryToken.columnMenu(
+                        ID,
+                        NAME,
+                        column.setDefaultAnchor()
+                )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnSelectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnSelectHistoryTokenTest.java
@@ -40,6 +40,13 @@ public final class SpreadsheetColumnSelectHistoryTokenTest extends SpreadsheetCo
         );
     }
 
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public void testMenuWithColumn() {
+        this.menuWithColumnAndCheck();
+    }
+
     @Override
     SpreadsheetColumnSelectHistoryToken createHistoryToken(final SpreadsheetId id,
                                                            final SpreadsheetName name,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnUnfreezeHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnUnfreezeHistoryTokenTest.java
@@ -54,6 +54,13 @@ public final class SpreadsheetColumnUnfreezeHistoryTokenTest extends Spreadsheet
         );
     }
 
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public void testMenuWithColumn() {
+        this.menuWithColumnAndCheck();
+    }
+
     @Override
     SpreadsheetColumnUnfreezeHistoryToken createHistoryToken(final SpreadsheetId id,
                                                              final SpreadsheetName name,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingHistoryTokenTestCase.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.dominokit.history;
 
+import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
@@ -31,6 +32,23 @@ public abstract class SpreadsheetLabelMappingHistoryTokenTestCase<T extends Spre
 
     SpreadsheetLabelMappingHistoryTokenTestCase() {
         super();
+    }
+
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public final void testMenuWithCell() {
+        this.menuWithCellAndCheck();
+    }
+
+    @Test
+    public final void testMenuWithColumn() {
+        this.menuWithColumnAndCheck();
+    }
+
+    @Test
+    public final void testMenuWithRow() {
+        this.menuWithRowAndCheck();
     }
 
     final void urlFragmentAndCheck(final SpreadsheetLabelName label,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataHistoryTokenTestCase.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.dominokit.history;
 
+import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 
@@ -24,6 +25,23 @@ public abstract class SpreadsheetMetadataHistoryTokenTestCase<T extends Spreadsh
 
     SpreadsheetMetadataHistoryTokenTestCase() {
         super();
+    }
+
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public final void testMenuWithCell() {
+        this.menuWithCellAndCheck();
+    }
+
+    @Test
+    public final void testMenuWithColumn() {
+        this.menuWithColumnAndCheck();
+    }
+
+    @Test
+    public final void testMenuWithRow() {
+        this.menuWithRowAndCheck();
     }
 
     abstract T createHistoryToken(final SpreadsheetId id,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNameHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNameHistoryTokenTestCase.java
@@ -20,6 +20,12 @@ package walkingkooka.spreadsheet.dominokit.history;
 import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
+import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetRowReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public abstract class SpreadsheetNameHistoryTokenTestCase<T extends SpreadsheetNameHistoryToken> extends SpreadsheetIdHistoryTokenTestCase<T> {
 
@@ -86,6 +92,128 @@ public abstract class SpreadsheetNameHistoryTokenTestCase<T extends SpreadsheetN
                 ID,
                 NAME,
                 token
+        );
+    }
+
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public void testMenuWithNullSelectionFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> this.createHistoryToken().menu(null)
+        );
+    }
+
+    @Test
+    public void testMenuWithCellRangeFails() {
+        this.menuWithSelectionFails(
+                SpreadsheetSelection.parseCellRange("A1:B2")
+        );
+    }
+
+    @Test
+    public void testMenuWithColumnRangeFails() {
+        this.menuWithSelectionFails(
+                SpreadsheetSelection.parseColumnRange("C:D")
+        );
+    }
+
+    @Test
+    public void testMenuWithRowRangeFails() {
+        this.menuWithSelectionFails(
+                SpreadsheetSelection.parseRowRange("5:6")
+        );
+    }
+
+    private void menuWithSelectionFails(final SpreadsheetSelection selection) {
+        final IllegalArgumentException thrown = assertThrows(
+                IllegalArgumentException.class,
+                () -> this.createHistoryToken()
+                        .menu(selection)
+        );
+
+        this.checkEquals(
+                "Expected cell, column or row but got " + selection,
+                thrown.getMessage(),
+                () -> "menu " + selection
+        );
+    }
+
+    final void menuWithCellAndCheck() {
+        this.menuWithCellAndCheck(
+                SpreadsheetSelection.parseCell("Z99")
+        );
+    }
+
+    final void menuWithCellAndCheck(final SpreadsheetCellReference cell) {
+        this.menuAndCheck(
+                SpreadsheetHistoryToken.cellMenu(
+                        ID,
+                        NAME,
+                        cell.setDefaultAnchor()
+                ),
+                cell
+        );
+    }
+    
+    final void menuWithColumnAndCheck() {
+        this.menuWithColumnAndCheck(
+                SpreadsheetSelection.parseColumn("C")
+        );
+    }
+
+    final void menuWithColumnAndCheck(final SpreadsheetColumnReference column) {
+        this.menuAndCheck(
+                SpreadsheetHistoryToken.columnMenu(
+                        ID,
+                        NAME,
+                        column.setDefaultAnchor()
+                ),
+                column
+        );
+    }
+
+    final void menuWithRowAndCheck() {
+        this.menuWithRowAndCheck(
+                SpreadsheetSelection.parseRow("4")
+        );
+    }
+
+    final void menuWithRowAndCheck(final SpreadsheetRowReference row) {
+        this.menuAndCheck(
+                SpreadsheetHistoryToken.rowMenu(
+                        ID,
+                        NAME,
+                        row.setDefaultAnchor()
+                ),
+                row
+        );
+    }
+
+    final void menuAndCheck(final SpreadsheetViewportSelectionHistoryToken token,
+                            final SpreadsheetSelection selection) {
+        this.menuAndCheck(
+                token,
+                selection,
+                token
+        );
+    }
+
+    final void menuAndCheck(final SpreadsheetNameHistoryToken before,
+                            final SpreadsheetSelection selection,
+                            final SpreadsheetViewportSelectionHistoryToken expected) {
+        final String className = expected.getClass().getSimpleName();
+        this.checkEquals(
+                true,
+                className.contains("Menu"),
+                () -> className + " is not a Menu"
+        );
+
+        this.checkEquals(
+                expected,
+                before.menu(selection),
+                () -> before + " menu " + selection
         );
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowClearHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowClearHistoryTokenTest.java
@@ -41,6 +41,13 @@ public final class SpreadsheetRowClearHistoryTokenTest extends SpreadsheetRowHis
         );
     }
 
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public void testMenuWithRow() {
+        this.menuWithRowAndCheck();
+    }
+
     @Override
     SpreadsheetRowClearHistoryToken createHistoryToken(final SpreadsheetId id,
                                                        final SpreadsheetName name,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowDeleteHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowDeleteHistoryTokenTest.java
@@ -41,6 +41,13 @@ public final class SpreadsheetRowDeleteHistoryTokenTest extends SpreadsheetRowHi
         );
     }
 
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public void testMenuWithRow() {
+        this.menuWithRowAndCheck();
+    }
+
     @Override
     SpreadsheetRowDeleteHistoryToken createHistoryToken(final SpreadsheetId id,
                                                         final SpreadsheetName name,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowFreezeHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowFreezeHistoryTokenTest.java
@@ -54,6 +54,13 @@ public final class SpreadsheetRowFreezeHistoryTokenTest extends SpreadsheetRowHi
                 )
         );
     }
+
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public void testMenuWithRow() {
+        this.menuWithRowAndCheck();
+    }
     
     @Override
     SpreadsheetRowFreezeHistoryToken createHistoryToken(final SpreadsheetId id,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowHistoryTokenTestCase.java
@@ -90,6 +90,18 @@ public abstract class SpreadsheetRowHistoryTokenTestCase<T extends SpreadsheetRo
         );
     }
 
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public final void testMenuWithCell() {
+        this.menuWithCellAndCheck();
+    }
+
+    @Test
+    public final void testMenuWithColumn() {
+        this.menuWithColumnAndCheck();
+    }
+
     final void urlFragmentAndCheck(final SpreadsheetRowReference reference,
                                    final String expected) {
         this.urlFragmentAndCheck(

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowMenuHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowMenuHistoryTokenTest.java
@@ -20,6 +20,8 @@ package walkingkooka.spreadsheet.dominokit.history;
 import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
+import walkingkooka.spreadsheet.reference.SpreadsheetRowReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelectionAnchor;
 
@@ -38,6 +40,69 @@ public final class SpreadsheetRowMenuHistoryTokenTest extends SpreadsheetRowHist
         this.urlFragmentAndCheck(
                 ROW_RANGE.setAnchor(SpreadsheetViewportSelectionAnchor.BOTTOM),
                 "/123/SpreadsheetName456/row/2:3/bottom/menu"
+        );
+    }
+
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public void testRowMenuWithSameRow() {
+        final SpreadsheetRowReference row = SpreadsheetSelection.parseRow("2");
+
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        row.setDefaultAnchor()
+                ),
+                row,
+                SpreadsheetHistoryToken.rowMenu(
+                        ID,
+                        NAME,
+                        row.setDefaultAnchor()
+                )
+        );
+    }
+
+    @Test
+    public void testRowMenuWithDifferentRow() {
+        final SpreadsheetRowReference row = SpreadsheetSelection.parseRow("2");
+
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        SpreadsheetSelection.parseRow("1").setDefaultAnchor()
+                ),
+                row,
+                SpreadsheetHistoryToken.rowMenu(
+                        ID,
+                        NAME,
+                        row.setDefaultAnchor()
+                )
+        );
+    }
+
+    @Test
+    public void testRowRangeMenuWithRowInside() {
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        SpreadsheetSelection.parseRowRange("1:3").setDefaultAnchor()
+                ),
+                SpreadsheetSelection.parseRow("2")
+        );
+    }
+
+    @Test
+    public void testRowRangeMenuWithRowOutside() {
+        final SpreadsheetRowReference row = SpreadsheetSelection.parseRow("99");
+
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        SpreadsheetSelection.parseRowRange("1:3").setDefaultAnchor()
+                ),
+                row,
+                SpreadsheetHistoryToken.rowMenu(
+                        ID,
+                        NAME,
+                        row.setDefaultAnchor()
+                )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowSelectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowSelectHistoryTokenTest.java
@@ -41,6 +41,13 @@ public final class SpreadsheetRowSelectHistoryTokenTest extends SpreadsheetRowHi
         );
     }
 
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public void testMenuWithRow() {
+        this.menuWithRowAndCheck();
+    }
+
     @Override
     SpreadsheetRowSelectHistoryToken createHistoryToken(final SpreadsheetId id,
                                                         final SpreadsheetName name,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowUnfreezeHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowUnfreezeHistoryTokenTest.java
@@ -55,6 +55,13 @@ public final class SpreadsheetRowUnfreezeHistoryTokenTest extends SpreadsheetRow
         );
     }
 
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public void testMenuWithRow() {
+        this.menuWithRowAndCheck();
+    }
+
     @Override
     SpreadsheetRowUnfreezeHistoryToken createHistoryToken(final SpreadsheetId id,
                                                           final SpreadsheetName name,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectHistoryTokenTest.java
@@ -41,6 +41,23 @@ public final class SpreadsheetSelectHistoryTokenTest extends SpreadsheetNameHist
         );
     }
 
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public void testMenuWithCell() {
+        this.menuWithCellAndCheck();
+    }
+
+    @Test
+    public void testMenuWithColumn() {
+        this.menuWithColumnAndCheck();
+    }
+
+    @Test
+    public void testMenuWithRow() {
+        this.menuWithRowAndCheck();
+    }
+
     @Override
     SpreadsheetSelectHistoryToken createHistoryToken() {
         return SpreadsheetSelectHistoryToken.with(

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectionHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectionHistoryTokenTestCase.java
@@ -111,4 +111,21 @@ public abstract class SpreadsheetSelectionHistoryTokenTestCase<T extends Spreads
                         .selection(selection)
         );
     }
+
+    // menu(Selection)..................................................................................................
+
+    @Test
+    public void testMenuWithCell() {
+        this.menuWithCellAndCheck();
+    }
+
+    @Test
+    public void testMenuWithColumn() {
+        this.menuWithColumnAndCheck();
+    }
+
+    @Test
+    public void testMenuWithRow() {
+        this.menuWithRowAndCheck();
+    }
 }


### PR DESCRIPTION
- This will be used when a right mouse click happens on a cell/column/row within the viewport to select the appropriate selection and menu HistoryToken.