### PR TITLE
SpreadsheetViewportWidget window clear fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/SpreadsheetViewportCache.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/SpreadsheetViewportCache.java
@@ -94,19 +94,26 @@ final class SpreadsheetViewportCache implements SpreadsheetDeltaWatcher, Spreads
         final Map<SpreadsheetColumnReference, Length<?>> columnWidths = this.columnWidths;
         final Map<SpreadsheetRowReference, Length<?>> rowHeights = this.rowHeights;
 
-        final Set<SpreadsheetCellRange> windows = delta.window();
-        if (false == this.windows.equals(windows)) {
-            // no window clear caches
-            cells.clear();
+        final Set<SpreadsheetCellRange> previousWindow = this.windows;
+        Set<SpreadsheetCellRange> window = delta.window();
+        if(window.isEmpty()) {
+            window = previousWindow;
+        } else {
+            if (false == previousWindow.equals(window)) {
+                // no window clear caches
+                cells.clear();
 
-            cellToLabels.clear();
-            labelToNonLabel.clear();
+                cellToLabels.clear();
+                labelToNonLabel.clear();
 
-            columns.clear();
-            rows.clear();
+                columns.clear();
+                rows.clear();
 
-            columnWidths.clear();
-            rowHeights.clear();
+                columnWidths.clear();
+                rowHeights.clear();
+
+                this.windows = window;
+            }
         }
 
         for (final SpreadsheetCellReference cell : delta.deletedCells()) {
@@ -164,10 +171,8 @@ final class SpreadsheetViewportCache implements SpreadsheetDeltaWatcher, Spreads
                 delta.labels(),
                 cellToLabels,
                 labelToNonLabel,
-                windows
+                window
         );
-
-        this.windows = windows;
     }
 
     Optional<SpreadsheetCell> cell(final SpreadsheetCellReference cell) {

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/SpreadsheetViewportWidget.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/SpreadsheetViewportWidget.java
@@ -128,7 +128,6 @@ public final class SpreadsheetViewportWidget implements SpreadsheetDeltaWatcher,
         this.cache.onSpreadsheetDelta(delta, context);
         this.setViewportSelection(delta.viewportSelection());
 
-        this.windows = delta.window();
         this.updateTable();
     }
 
@@ -378,7 +377,7 @@ public final class SpreadsheetViewportWidget implements SpreadsheetDeltaWatcher,
         final Set<SpreadsheetRowReference> rows = Sets.sorted();
 
         // gather visible columns and rows.
-        for(final SpreadsheetCellRange window : this.windows) {
+        for(final SpreadsheetCellRange window : this.window()) {
             for(final SpreadsheetColumnReference column : window.columnRange()) {
                 if(false == cache.isColumnHidden(column)) {
                     columns.add(column);
@@ -681,9 +680,4 @@ public final class SpreadsheetViewportWidget implements SpreadsheetDeltaWatcher,
      * Cache that holds all the cells, labels etc displayed by this widget.
      */
     private SpreadsheetViewportCache cache = SpreadsheetViewportCache.empty();
-
-    /**
-     * The windows for this widget.
-     */
-    private Set<SpreadsheetCellRange> windows = Sets.empty();
 }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/SpreadsheetViewportCacheTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/SpreadsheetViewportCacheTest.java
@@ -694,19 +694,23 @@ public final class SpreadsheetViewportCacheTest implements ClassTesting<Spreadsh
                 CONTEXT
         );
 
+        this.checkWindow(
+                cache,
+                WINDOW
+        );
+
+        // A1_CELL and LABEL_MAPPINGA1A not lost
+
         this.checkCells(
                 cache,
+                A1_CELL,
                 A2_CELL
         );
 
         this.checkCellToLabels(
                 cache,
+                LABEL_MAPPINGA1A,
                 LABEL_MAPPINGB3
-        );
-
-        this.checkWindow(
-                cache,
-                ""
         );
     }
 


### PR DESCRIPTION
- window was always getting overwritten even when a SpreadsheetDelta response had no window, this resulted in PATCH of cell style which does not return a window to cause he viewport to have zero cells rendered and be blank.