### PR TITLE
SpreadsheetMetadataPropertyStyleSaveHistoryToken Optional value

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetHistoryToken.java
@@ -396,7 +396,7 @@ public abstract class SpreadsheetHistoryToken extends HistoryToken implements Sp
     public static <T> SpreadsheetMetadataPropertyStyleSaveHistoryToken<T> metadataPropertyStyleSave(final SpreadsheetId id,
                                                                                                     final SpreadsheetName name,
                                                                                                     final TextStylePropertyName<T> stylePropertyName,
-                                                                                                    final T stylePropertyValue) {
+                                                                                                    final Optional<T> stylePropertyValue) {
         return SpreadsheetMetadataPropertyStyleSaveHistoryToken.with(
                 id,
                 name,

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleHistoryToken.java
@@ -26,6 +26,7 @@ import walkingkooka.tree.text.TextStyle;
 import walkingkooka.tree.text.TextStylePropertyName;
 
 import java.util.Objects;
+import java.util.Optional;
 
 public abstract class SpreadsheetMetadataPropertyStyleHistoryToken<T> extends SpreadsheetMetadataPropertyHistoryToken<TextStyle> {
 
@@ -72,7 +73,11 @@ public abstract class SpreadsheetMetadataPropertyStyleHistoryToken<T> extends Sp
                 this.id(),
                 this.name(),
                 propertyName,
-                propertyName.parseValue(value)
+                Optional.ofNullable(
+                        value.isEmpty() ?
+                                null :
+                                propertyName.parseValue(value)
+                )
         );
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSaveHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSaveHistoryToken.java
@@ -27,12 +27,15 @@ import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.tree.text.TextStyle;
 import walkingkooka.tree.text.TextStylePropertyName;
 
+import java.util.Objects;
+import java.util.Optional;
+
 public final class SpreadsheetMetadataPropertyStyleSaveHistoryToken<T> extends SpreadsheetMetadataPropertyStyleHistoryToken<T> {
 
     static <T> SpreadsheetMetadataPropertyStyleSaveHistoryToken<T> with(final SpreadsheetId id,
                                                                         final SpreadsheetName name,
                                                                         final TextStylePropertyName<T> stylePropertyName,
-                                                                        final T stylePropertyValue) {
+                                                                        final Optional<T> stylePropertyValue) {
         return new SpreadsheetMetadataPropertyStyleSaveHistoryToken<>(
                 id,
                 name,
@@ -44,21 +47,21 @@ public final class SpreadsheetMetadataPropertyStyleSaveHistoryToken<T> extends S
     private SpreadsheetMetadataPropertyStyleSaveHistoryToken(final SpreadsheetId id,
                                                              final SpreadsheetName name,
                                                              final TextStylePropertyName<T> stylePropertyName,
-                                                             final T stylePropertyValue) {
+                                                             final Optional<T> stylePropertyValue) {
         super(
                 id,
                 name,
                 stylePropertyName
         );
 
-        this.stylePropertyValue = stylePropertyValue;
+        this.stylePropertyValue = Objects.requireNonNull(stylePropertyValue, "stylePropertyValue");
     }
 
-    public T stylePropertyValue() {
+    public Optional<T> stylePropertyValue() {
         return this.stylePropertyValue;
     }
 
-    private final T stylePropertyValue;
+    private final Optional<T> stylePropertyValue;
 
     @Override
     UrlFragment styleUrlFragment() {
@@ -93,9 +96,9 @@ public final class SpreadsheetMetadataPropertyStyleSaveHistoryToken<T> extends S
                         this.id(),
                         SpreadsheetMetadata.EMPTY.set(
                                 SpreadsheetMetadataPropertyName.STYLE,
-                                TextStyle.EMPTY.set(
+                                TextStyle.EMPTY.setOrRemove(
                                         this.stylePropertyName(),
-                                        this.stylePropertyValue()
+                                        this.stylePropertyValue().orElse(null)
                                 )
                         )
                 );

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTest.java
@@ -1446,6 +1446,19 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>, Parse
     }
 
     @Test
+    public void testParseSpreadsheetIdSpreadsheetNameMetadataStylePropertyNameSaveWithoutValue() {
+        this.parseStringAndCheck(
+                "/123/SpreadsheetName456/metadata/style/color/save/",
+                SpreadsheetHistoryToken.metadataPropertyStyleSave(
+                        ID,
+                        NAME,
+                        TextStylePropertyName.COLOR,
+                        Optional.empty()
+                )
+        );
+    }
+
+    @Test
     public void testParseSpreadsheetIdSpreadsheetNameMetadataStylePropertyNameSave() {
         this.parseStringAndCheck(
                 "/123/SpreadsheetName456/metadata/style/color/save/#123456",
@@ -1453,7 +1466,9 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>, Parse
                         ID,
                         NAME,
                         TextStylePropertyName.COLOR,
-                        Color.parse("#123456")
+                        Optional.of(
+                                Color.parse("#123456")
+                        )
                 )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySaveHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySaveHistoryTokenTest.java
@@ -27,6 +27,8 @@ import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.text.TextStylePropertyName;
 
+import java.util.Optional;
+
 public final class SpreadsheetMetadataPropertySaveHistoryTokenTest extends SpreadsheetMetadataPropertyHistoryTokenTestCase<SpreadsheetMetadataPropertySaveHistoryToken<ExpressionNumberKind>, ExpressionNumberKind> {
 
     @Test
@@ -100,14 +102,29 @@ public final class SpreadsheetMetadataPropertySaveHistoryTokenTest extends Sprea
     }
 
     @Test
-    public void testParseStyle() {
+    public void testParseStyleSaveWithoutValue() {
+        this.parseAndCheck(
+                "/123/SpreadsheetName456/metadata/style/color/save/",
+                SpreadsheetHistoryToken.metadataPropertyStyleSave(
+                        ID,
+                        NAME,
+                        TextStylePropertyName.COLOR,
+                        Optional.empty()
+                )
+        );
+    }
+
+    @Test
+    public void testParseStyleSaveValue() {
         this.parseAndCheck(
                 "/123/SpreadsheetName456/metadata/style/color/save/#123456",
                 SpreadsheetHistoryToken.metadataPropertyStyleSave(
                         ID,
                         NAME,
                         TextStylePropertyName.COLOR,
-                        Color.parse("#123456")
+                        Optional.of(
+                                Color.parse("#123456")
+                        )
                 )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSaveHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSaveHistoryTokenTest.java
@@ -28,11 +28,41 @@ import walkingkooka.tree.text.FontStyle;
 import walkingkooka.tree.text.TextStyle;
 import walkingkooka.tree.text.TextStylePropertyName;
 
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public final class SpreadsheetMetadataPropertyStyleSaveHistoryTokenTest extends SpreadsheetMetadataPropertyStyleHistoryTokenTestCase<SpreadsheetMetadataPropertyStyleSaveHistoryToken<Color>, Color> {
+
+    @Test
+    public void testWithNullValueFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> SpreadsheetMetadataPropertyStyleSaveHistoryToken.with(
+                        ID,
+                        NAME,
+                        STYLE_PROPERTY_NAME,
+                        null
+                )
+        );
+    }
 
     @Test
     public void testUrlFragmentColor() {
         this.urlFragmentAndCheck("/123/SpreadsheetName456/metadata/style/color/save/#123456");
+    }
+
+    @Test
+    public void testUrlFragmentFontFamilyWithoutValue() {
+        this.urlFragmentAndCheck(
+                SpreadsheetMetadataPropertyStyleSaveHistoryToken.with(
+                        ID,
+                        NAME,
+                        TextStylePropertyName.FONT_FAMILY,
+                        Optional.empty()
+                ),
+                "/123/SpreadsheetName456/metadata/style/font-family/save/"
+        );
     }
 
     @Test
@@ -42,7 +72,9 @@ public final class SpreadsheetMetadataPropertyStyleSaveHistoryTokenTest extends 
                         ID,
                         NAME,
                         TextStylePropertyName.FONT_FAMILY,
-                        FontFamily.with("TimesNewRoman")
+                        Optional.of(
+                                FontFamily.with("TimesNewRoman")
+                        )
                 ),
                 "/123/SpreadsheetName456/metadata/style/font-family/save/TimesNewRoman"
         );
@@ -55,7 +87,9 @@ public final class SpreadsheetMetadataPropertyStyleSaveHistoryTokenTest extends 
                         ID,
                         NAME,
                         TextStylePropertyName.FONT_STYLE,
-                        FontStyle.ITALIC
+                        Optional.of(
+                                FontStyle.ITALIC
+                        )
                 ),
                 "/123/SpreadsheetName456/metadata/style/font-style/save/ITALIC"
         );
@@ -69,7 +103,9 @@ public final class SpreadsheetMetadataPropertyStyleSaveHistoryTokenTest extends 
                         ID,
                         NAME,
                         TextStylePropertyName.COLOR,
-                        Color.parse("#123456")
+                        Optional.of(
+                                Color.parse("#123456")
+                        )
                 )
         );
     }
@@ -82,7 +118,9 @@ public final class SpreadsheetMetadataPropertyStyleSaveHistoryTokenTest extends 
                         ID,
                         NAME,
                         TextStylePropertyName.FONT_FAMILY,
-                        FontFamily.with("TimesNewRoman2")
+                        Optional.of(
+                                FontFamily.with("TimesNewRoman2")
+                        )
                 )
         );
     }
@@ -95,7 +133,9 @@ public final class SpreadsheetMetadataPropertyStyleSaveHistoryTokenTest extends 
                 id,
                 name,
                 STYLE_PROPERTY_NAME,
-                PROPERTY_VALUE
+                Optional.of(
+                        PROPERTY_VALUE
+                )
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/279
- SpreadsheetMetadataPropertyStyleSaveHistoryToken Optional value now nullable