### PR TITLE
SpreadsheetMetadataPropertySaveHistoryToken optional value

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetHistoryToken.java
@@ -368,7 +368,7 @@ public abstract class SpreadsheetHistoryToken extends HistoryToken implements Sp
     public static <T> SpreadsheetMetadataPropertySaveHistoryToken<T> metadataPropertySave(final SpreadsheetId id,
                                                                                           final SpreadsheetName name,
                                                                                           final SpreadsheetMetadataPropertyName<T> propertyName,
-                                                                                          final T propertyValue) {
+                                                                                          final Optional<T> propertyValue) {
         return SpreadsheetMetadataPropertySaveHistoryToken.with(
                 id,
                 name,

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySaveHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySaveHistoryToken.java
@@ -26,12 +26,15 @@ import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.tree.text.TextStylePropertyName;
 
+import java.util.Objects;
+import java.util.Optional;
+
 public final class SpreadsheetMetadataPropertySaveHistoryToken<T> extends SpreadsheetMetadataPropertyHistoryToken<T> {
 
     static <T> SpreadsheetMetadataPropertySaveHistoryToken<T> with(final SpreadsheetId id,
                                                                    final SpreadsheetName name,
                                                                    final SpreadsheetMetadataPropertyName<T> propertyName,
-                                                                   final T propertyValue) {
+                                                                   final Optional<T> propertyValue) {
         return new SpreadsheetMetadataPropertySaveHistoryToken<>(
                 id,
                 name,
@@ -43,21 +46,21 @@ public final class SpreadsheetMetadataPropertySaveHistoryToken<T> extends Spread
     private SpreadsheetMetadataPropertySaveHistoryToken(final SpreadsheetId id,
                                                         final SpreadsheetName name,
                                                         final SpreadsheetMetadataPropertyName<T> propertyName,
-                                                        final T propertyValue) {
+                                                        final Optional<T> propertyValue) {
         super(
                 id,
                 name,
                 propertyName
         );
 
-        this.propertyValue = propertyValue;
+        this.propertyValue = Objects.requireNonNull(propertyValue, "propertyValue");
     }
 
-    public T propertyValue() {
+    public Optional<T> propertyValue() {
         return this.propertyValue;
     }
 
-    private final T propertyValue;
+    private final Optional<T> propertyValue;
 
     @Override
     UrlFragment metadataPropertyUrlFragment() {
@@ -113,9 +116,9 @@ public final class SpreadsheetMetadataPropertySaveHistoryToken<T> extends Spread
         context.spreadsheetMetadataFetcher()
                 .patchMetadata(
                         this.id(),
-                        SpreadsheetMetadata.EMPTY.set(
+                        SpreadsheetMetadata.EMPTY.setOrRemove(
                                 this.propertyName(),
-                                this.propertyValue()
+                                this.propertyValue().orElse(null)
                         )
                 );
     }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySelectHistoryToken.java
@@ -25,6 +25,8 @@ import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.tree.text.TextStylePropertyName;
 
+import java.util.Optional;
+
 public final class SpreadsheetMetadataPropertySelectHistoryToken<T> extends SpreadsheetMetadataPropertyHistoryToken<T> {
 
     static <T> SpreadsheetMetadataPropertySelectHistoryToken<T> with(final SpreadsheetId id,
@@ -75,10 +77,14 @@ public final class SpreadsheetMetadataPropertySelectHistoryToken<T> extends Spre
         final SpreadsheetMetadataPropertyName<T> propertyName = this.propertyName();
 
         return SpreadsheetHistoryToken.metadataPropertySave(
-            this.id(),
+                this.id(),
                 this.name(),
                 propertyName,
-                propertyName.parseValue(value)
+                Optional.ofNullable(
+                        value.isEmpty() ?
+                                null :
+                                propertyName.parseValue(value)
+                )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTest.java
@@ -1410,6 +1410,19 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>, Parse
     }
 
     @Test
+    public void testParseSpreadsheetIdSpreadsheetNameMetadataPropertyNameSaveWithoutValue() {
+        this.parseStringAndCheck(
+                "/123/SpreadsheetName456/metadata/decimal-separator/save/",
+                SpreadsheetHistoryToken.metadataPropertySave(
+                        ID,
+                        NAME,
+                        SpreadsheetMetadataPropertyName.DECIMAL_SEPARATOR,
+                        Optional.empty()
+                )
+        );
+    }
+
+    @Test
     public void testParseSpreadsheetIdSpreadsheetNameMetadataPropertyNameSave() {
         this.parseStringAndCheck(
                 "/123/SpreadsheetName456/metadata/decimal-separator/save/.",
@@ -1417,7 +1430,9 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>, Parse
                         ID,
                         NAME,
                         SpreadsheetMetadataPropertyName.DECIMAL_SEPARATOR,
-                        '.'
+                        Optional.of(
+                                '.'
+                        )
                 )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySaveHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySaveHistoryTokenTest.java
@@ -29,11 +29,39 @@ import walkingkooka.tree.text.TextStylePropertyName;
 
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public final class SpreadsheetMetadataPropertySaveHistoryTokenTest extends SpreadsheetMetadataPropertyHistoryTokenTestCase<SpreadsheetMetadataPropertySaveHistoryToken<ExpressionNumberKind>, ExpressionNumberKind> {
+
+    @Test
+    public void testWithNullValueFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> SpreadsheetMetadataPropertySaveHistoryToken.with(
+                        ID,
+                        NAME,
+                        SpreadsheetMetadataPropertyName.LOCALE,
+                        null
+                )
+        );
+    }
 
     @Test
     public void testUrlFragmentExpressionNumberKind() {
         this.urlFragmentAndCheck("/123/SpreadsheetName456/metadata/expression-number-kind/save/BIG_DECIMAL");
+    }
+
+    @Test
+    public void testUrlFragmentDateFormatPatternNullValue() {
+        this.urlFragmentAndCheck(
+                SpreadsheetMetadataPropertySaveHistoryToken.with(
+                        ID,
+                        NAME,
+                        SpreadsheetMetadataPropertyName.DATE_FORMAT_PATTERN,
+                        Optional.empty()
+                ),
+                "/123/SpreadsheetName456/metadata/pattern/date-format/save/"
+        );
     }
 
     @Test
@@ -43,7 +71,9 @@ public final class SpreadsheetMetadataPropertySaveHistoryTokenTest extends Sprea
                         ID,
                         NAME,
                         SpreadsheetMetadataPropertyName.DATE_FORMAT_PATTERN,
-                        SpreadsheetPattern.parseDateFormatPattern("yymmdd")
+                        Optional.of(
+                                SpreadsheetPattern.parseDateFormatPattern("yymmdd")
+                        )
                 ),
                 "/123/SpreadsheetName456/metadata/pattern/date-format/save/yymmdd"
         );
@@ -56,7 +86,9 @@ public final class SpreadsheetMetadataPropertySaveHistoryTokenTest extends Sprea
                         ID,
                         NAME,
                         SpreadsheetMetadataPropertyName.DEFAULT_YEAR,
-                        99
+                        Optional.of(
+                                99
+                        )
                 ),
                 "/123/SpreadsheetName456/metadata/default-year/save/99"
         );
@@ -70,7 +102,9 @@ public final class SpreadsheetMetadataPropertySaveHistoryTokenTest extends Sprea
                         ID,
                         NAME,
                         SpreadsheetMetadataPropertyName.DATE_FORMAT_PATTERN,
-                        SpreadsheetPattern.parseDateFormatPattern("yymmdd")
+                        Optional.of(
+                                SpreadsheetPattern.parseDateFormatPattern("yymmdd")
+                        )
                 )
         );
     }
@@ -83,7 +117,9 @@ public final class SpreadsheetMetadataPropertySaveHistoryTokenTest extends Sprea
                         ID,
                         NAME,
                         SpreadsheetMetadataPropertyName.DEFAULT_YEAR,
-                        49
+                        Optional.of(
+                                49
+                        )
                 )
         );
     }
@@ -146,7 +182,9 @@ public final class SpreadsheetMetadataPropertySaveHistoryTokenTest extends Sprea
                 id,
                 name,
                 propertyName,
-                ExpressionNumberKind.BIG_DECIMAL
+                Optional.of(
+                        ExpressionNumberKind.BIG_DECIMAL
+                )
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/278
- SpreadsheetMetadataPropertySaveHistoryToken Optional value now nullable