### PR TITLE
SpreadsheetHistoryToken.setIdNameAndViewportSelection

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/SpreadsheetViewportWidget.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/SpreadsheetViewportWidget.java
@@ -567,7 +567,7 @@ public final class SpreadsheetViewportWidget implements SpreadsheetDeltaWatcher,
      * Creates an ANCHOR including an ID and TEXT in upper case of the given {@link SpreadsheetSelection}.
      */
     private HTMLAnchorElement link(final SpreadsheetSelection selection) {
-        final SpreadsheetNameHistoryToken token = this.nameHistoryToken.viewportSelection(
+        final SpreadsheetNameHistoryToken token = this.nameHistoryToken.viewportSelectionHistoryToken(
                 selection.setDefaultAnchor()
         );
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellClearHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellClearHistoryToken.java
@@ -52,16 +52,6 @@ public final class SpreadsheetCellClearHistoryToken extends SpreadsheetCellHisto
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetCellClearHistoryToken(
-                id,
-                name,
-                this.viewportSelection()
-        );
-    }
-
-    @Override
     SpreadsheetNameHistoryToken formulaHistoryToken() {
         return this;
     }
@@ -77,8 +67,8 @@ public final class SpreadsheetCellClearHistoryToken extends SpreadsheetCellHisto
     }
 
     @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         // POST cell clear
         this.deltaClearAndPushSelectionHistoryToken(context);
     }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellDeleteHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellDeleteHistoryToken.java
@@ -52,16 +52,6 @@ public final class SpreadsheetCellDeleteHistoryToken extends SpreadsheetCellHist
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetCellDeleteHistoryToken(
-                id,
-                name,
-                this.viewportSelection()
-        );
-    }
-
-    @Override
     SpreadsheetNameHistoryToken formulaHistoryToken() {
         return this;
     }
@@ -77,8 +67,8 @@ public final class SpreadsheetCellDeleteHistoryToken extends SpreadsheetCellHist
     }
 
     @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         context.spreadsheetDeltaFetcher()
                 .deleteDelta(
                         this.id(),

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormulaSaveHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormulaSaveHistoryToken.java
@@ -71,17 +71,6 @@ public final class SpreadsheetCellFormulaSaveHistoryToken extends SpreadsheetCel
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetCellFormulaSaveHistoryToken(
-                id,
-                name,
-                this.viewportSelection(),
-                this.formula()
-        );
-    }
-
-    @Override
     SpreadsheetNameHistoryToken save(final String value) {
         return this;
     }
@@ -96,8 +85,8 @@ public final class SpreadsheetCellFormulaSaveHistoryToken extends SpreadsheetCel
     }
 
     @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         // remove the save
         context.pushHistoryToken(
                 this.formulaHistoryToken()

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormulaSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormulaSelectHistoryToken.java
@@ -52,16 +52,6 @@ public final class SpreadsheetCellFormulaSelectHistoryToken extends SpreadsheetC
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetCellFormulaSelectHistoryToken(
-                id,
-                name,
-                this.viewportSelection()
-        );
-    }
-
-    @Override
     SpreadsheetNameHistoryToken save(final String formulaText) {
         return formulaSave(
                 this.id(),
@@ -77,8 +67,8 @@ public final class SpreadsheetCellFormulaSelectHistoryToken extends SpreadsheetC
     }
 
     @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         // enable formula text box and give focus
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFreezeHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFreezeHistoryToken.java
@@ -67,16 +67,6 @@ public final class SpreadsheetCellFreezeHistoryToken extends SpreadsheetCellHist
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetCellFreezeHistoryToken(
-                id,
-                name,
-                this.viewportSelection()
-        );
-    }
-
-    @Override
     SpreadsheetNameHistoryToken formulaHistoryToken() {
         return this;
     }
@@ -92,8 +82,8 @@ public final class SpreadsheetCellFreezeHistoryToken extends SpreadsheetCellHist
     }
 
     @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         final SpreadsheetSelection selection = this.viewportSelection()
                 .selection();
         this.patchMetadataAndPushSelectionHistoryToken(

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellHistoryToken.java
@@ -92,7 +92,7 @@ abstract public class SpreadsheetCellHistoryToken extends SpreadsheetViewportSel
                         .selection()
                         .testCell(selection.toCell()) ?
                 this :
-                this.viewportSelection(
+                this.viewportSelectionHistoryToken(
                         selection.setDefaultAnchor()
                 ).menu();
     }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellMenuHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellMenuHistoryToken.java
@@ -52,16 +52,6 @@ public final class SpreadsheetCellMenuHistoryToken extends SpreadsheetCellHistor
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetCellMenuHistoryToken(
-                id,
-                name,
-                this.viewportSelection()
-        );
-    }
-
-    @Override
     SpreadsheetNameHistoryToken formulaHistoryToken() {
         return this;
     }
@@ -77,8 +67,8 @@ public final class SpreadsheetCellMenuHistoryToken extends SpreadsheetCellHistor
     }
 
     @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         // show cell context menu
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternSaveHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternSaveHistoryToken.java
@@ -78,18 +78,6 @@ public final class SpreadsheetCellPatternSaveHistoryToken extends SpreadsheetCel
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetCellPatternSaveHistoryToken(
-                id,
-                name,
-                this.viewportSelection(),
-                this.patternKind(),
-                this.pattern()
-        );
-    }
-
-    @Override
     SpreadsheetNameHistoryToken pattern(final SpreadsheetPatternKind patternKind) {
         return cellPattern(
                 this.id(),
@@ -105,8 +93,8 @@ public final class SpreadsheetCellPatternSaveHistoryToken extends SpreadsheetCel
     }
 
     @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         final SpreadsheetPatternKind kind = this.patternKind();
 
         // clear the save from the history token.

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternSelectHistoryToken.java
@@ -58,17 +58,6 @@ public final class SpreadsheetCellPatternSelectHistoryToken extends SpreadsheetC
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetCellPatternSelectHistoryToken(
-                id,
-                name,
-                this.viewportSelection(),
-                this.patternKind()
-        );
-    }
-
-    @Override
     SpreadsheetNameHistoryToken pattern(final SpreadsheetPatternKind patternKind) {
         return this;
     }
@@ -91,8 +80,8 @@ public final class SpreadsheetCellPatternSelectHistoryToken extends SpreadsheetC
     }
 
     @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         // show cell pattern edit UI
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSelectHistoryToken.java
@@ -52,16 +52,6 @@ public final class SpreadsheetCellSelectHistoryToken extends SpreadsheetCellHist
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetCellSelectHistoryToken(
-                id,
-                name,
-                this.viewportSelection()
-        );
-    }
-
-    @Override
     SpreadsheetNameHistoryToken formulaHistoryToken() {
         return formula(
                 this.id(),
@@ -86,8 +76,8 @@ public final class SpreadsheetCellSelectHistoryToken extends SpreadsheetCellHist
     }
 
     @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         context.spreadsheetMetadataFetcher()
                 .patchViewportSelectionIfDifferent(
                         this.viewportSelection(),

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleSaveHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleSaveHistoryToken.java
@@ -73,25 +73,13 @@ final public class SpreadsheetCellStyleSaveHistoryToken<T> extends SpreadsheetCe
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetCellStyleSaveHistoryToken<>(
-                id,
-                name,
-                this.viewportSelection(),
-                this.propertyName(),
-                this.propertyValue()
-        );
-    }
-
-    @Override
     SpreadsheetNameHistoryToken save(final String value) {
         return this;
     }
 
     @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         final TextStylePropertyName<T> propertyName = this.propertyName();
 
         // clear the save from the history token.

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleSelectHistoryToken.java
@@ -58,17 +58,6 @@ final public class SpreadsheetCellStyleSelectHistoryToken<T> extends Spreadsheet
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetCellStyleSelectHistoryToken<>(
-                id,
-                name,
-                this.viewportSelection(),
-                this.propertyName()
-        );
-    }
-
-    @Override
     SpreadsheetNameHistoryToken save(final String value) {
         final TextStylePropertyName<T> propertyName = this.propertyName();
 
@@ -86,8 +75,8 @@ final public class SpreadsheetCellStyleSelectHistoryToken<T> extends Spreadsheet
     }
 
     @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         // show style controls like BOLD icon etc
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellUnfreezeHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellUnfreezeHistoryToken.java
@@ -67,16 +67,6 @@ public final class SpreadsheetCellUnfreezeHistoryToken extends SpreadsheetCellHi
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetCellUnfreezeHistoryToken(
-                id,
-                name,
-                this.viewportSelection()
-        );
-    }
-
-    @Override
     SpreadsheetNameHistoryToken formulaHistoryToken() {
         return this;
     }
@@ -92,8 +82,8 @@ public final class SpreadsheetCellUnfreezeHistoryToken extends SpreadsheetCellHi
     }
 
     @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         this.patchMetadataAndPushSelectionHistoryToken(
                 SpreadsheetMetadataPropertyName.FROZEN_COLUMNS,
                 null,

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnClearHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnClearHistoryToken.java
@@ -51,18 +51,8 @@ public class SpreadsheetColumnClearHistoryToken extends SpreadsheetColumnHistory
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetColumnClearHistoryToken(
-                id,
-                name,
-                this.viewportSelection()
-        );
-    }
-
-    @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         this.deltaClearAndPushSelectionHistoryToken(context);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnDeleteHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnDeleteHistoryToken.java
@@ -51,18 +51,8 @@ public class SpreadsheetColumnDeleteHistoryToken extends SpreadsheetColumnHistor
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetColumnDeleteHistoryToken(
-                id,
-                name,
-                this.viewportSelection()
-        );
-    }
-
-    @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         context.spreadsheetDeltaFetcher()
                 .deleteDelta(
                         this.id(),

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnFreezeHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnFreezeHistoryToken.java
@@ -59,18 +59,8 @@ public class SpreadsheetColumnFreezeHistoryToken extends SpreadsheetColumnHistor
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetColumnFreezeHistoryToken(
-                id,
-                name,
-                this.viewportSelection()
-        );
-    }
-
-    @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         this.patchMetadataAndPushSelectionHistoryToken(
                 SpreadsheetMetadataPropertyName.FROZEN_COLUMNS,
                 this.viewportSelection()

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnHistoryToken.java
@@ -97,7 +97,7 @@ abstract public class SpreadsheetColumnHistoryToken extends SpreadsheetViewportS
                         .selection()
                         .testColumn(selection.toColumn()) ?
                 this :
-                this.viewportSelection(
+                this.viewportSelectionHistoryToken(
                             selection.setDefaultAnchor()
                         ).menu();
     }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnMenuHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnMenuHistoryToken.java
@@ -51,18 +51,8 @@ public class SpreadsheetColumnMenuHistoryToken extends SpreadsheetColumnHistoryT
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetColumnMenuHistoryToken(
-                id,
-                name,
-                this.viewportSelection()
-        );
-    }
-
-    @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         // show column context menu
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnSelectHistoryToken.java
@@ -51,18 +51,8 @@ public class SpreadsheetColumnSelectHistoryToken extends SpreadsheetColumnHistor
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetColumnSelectHistoryToken(
-                id,
-                name,
-                this.viewportSelection()
-        );
-    }
-
-    @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         context.spreadsheetMetadataFetcher()
                 .patchViewportSelectionIfDifferent(
                         this.viewportSelection(),

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnUnfreezeHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnUnfreezeHistoryToken.java
@@ -59,18 +59,8 @@ public class SpreadsheetColumnUnfreezeHistoryToken extends SpreadsheetColumnHist
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetColumnUnfreezeHistoryToken(
-                id,
-                name,
-                this.viewportSelection()
-        );
-    }
-
-    @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         this.patchMetadataAndPushSelectionHistoryToken(
                 SpreadsheetMetadataPropertyName.FROZEN_COLUMNS,
                 null,

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCreateHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCreateHistoryToken.java
@@ -22,6 +22,7 @@ import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.dominokit.AppContext;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
+import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
 import walkingkooka.text.cursor.TextCursor;
 
 import java.util.Optional;
@@ -55,8 +56,10 @@ public final class SpreadsheetCreateHistoryToken extends SpreadsheetHistoryToken
     }
 
     @Override
-    public SpreadsheetHistoryToken setIdAndName0(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
+    SpreadsheetHistoryToken setIdNameViewportSelection0(final SpreadsheetId id,
+                                                        final SpreadsheetName name,
+                                                        final SpreadsheetViewportSelection viewportSelection) {
+        // shouldnt happen...
         return spreadsheetLoad(id);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetHistoryToken.java
@@ -560,17 +560,26 @@ public abstract class SpreadsheetHistoryToken extends HistoryToken implements Sp
         return SAVE.append(urlFragment);
     }
 
-    public final SpreadsheetHistoryToken setIdAndName(final SpreadsheetId id,
-                                                      final SpreadsheetName name) {
+    public final SpreadsheetHistoryToken setIdNameViewportSelection(final SpreadsheetId id,
+                                                                    final SpreadsheetName name,
+                                                                    final Optional<SpreadsheetViewportSelection> viewportSelection) {
         Objects.requireNonNull(id, "id");
         Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(viewportSelection, "viewportSelection");
 
-        return this.setIdAndName0(
-                id,
-                name
-        );
+        return viewportSelection.isPresent() ?
+                this.setIdNameViewportSelection0(
+                        id,
+                        name,
+                        viewportSelection.get()
+                ) :
+                spreadsheetSelect(
+                        id,
+                        name
+                );
     }
 
-    abstract SpreadsheetHistoryToken setIdAndName0(final SpreadsheetId id,
-                                                   final SpreadsheetName name);
+    abstract SpreadsheetHistoryToken setIdNameViewportSelection0(final SpreadsheetId id,
+                                                                 final SpreadsheetName name,
+                                                                 final SpreadsheetViewportSelection viewportSelection);
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingDeleteHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingDeleteHistoryToken.java
@@ -60,16 +60,6 @@ public final class SpreadsheetLabelMappingDeleteHistoryToken extends Spreadsheet
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetLabelMappingDeleteHistoryToken(
-                id,
-                name,
-                this.labelName
-        );
-    }
-
-    @Override
     SpreadsheetNameHistoryToken delete() {
         return this;
     }
@@ -80,8 +70,8 @@ public final class SpreadsheetLabelMappingDeleteHistoryToken extends Spreadsheet
     }
 
     @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         // DELETE label mapping
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingHistoryToken.java
@@ -23,6 +23,7 @@ import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
 import walkingkooka.tree.text.TextStylePropertyName;
 
 public abstract class SpreadsheetLabelMappingHistoryToken extends SpreadsheetSelectionHistoryToken {
@@ -41,6 +42,17 @@ public abstract class SpreadsheetLabelMappingHistoryToken extends SpreadsheetSel
     @Override final UrlFragment selectionUrlFragment() {
         return LABEL.append(UrlFragment.with(this.labelName().value()))
                 .append(this.labelUrlFragment());
+    }
+
+    @Override
+    final SpreadsheetHistoryToken setIdNameViewportSelection0(final SpreadsheetId id,
+                                                              final SpreadsheetName name,
+                                                              final SpreadsheetViewportSelection viewportSelection) {
+        return this.viewportSelectionHistoryToken(
+                id,
+                name,
+                viewportSelection
+        );
     }
 
     abstract SpreadsheetLabelName labelName();
@@ -68,7 +80,7 @@ public abstract class SpreadsheetLabelMappingHistoryToken extends SpreadsheetSel
     }
 
     @Override final SpreadsheetNameHistoryToken menu0(final SpreadsheetSelection selection) {
-        return this.viewportSelection(
+        return this.viewportSelectionHistoryToken(
                 selection.setDefaultAnchor()
         ).menu();
     }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingSaveHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingSaveHistoryToken.java
@@ -63,16 +63,6 @@ public final class SpreadsheetLabelMappingSaveHistoryToken extends SpreadsheetLa
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetLabelMappingSaveHistoryToken(
-                id,
-                name,
-                this.mapping
-        );
-    }
-
-    @Override
     SpreadsheetNameHistoryToken delete() {
         return this;
     }
@@ -83,8 +73,8 @@ public final class SpreadsheetLabelMappingSaveHistoryToken extends SpreadsheetLa
     }
 
     @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         // POST label mapping
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingSelectHistoryToken.java
@@ -61,16 +61,6 @@ public final class SpreadsheetLabelMappingSelectHistoryToken extends Spreadsheet
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetLabelMappingSelectHistoryToken(
-                id,
-                name,
-                this.labelName()
-        );
-    }
-
-    @Override
     SpreadsheetNameHistoryToken delete() {
         return labelMappingDelete(
                 this.id(),
@@ -91,8 +81,8 @@ public final class SpreadsheetLabelMappingSelectHistoryToken extends Spreadsheet
     }
 
     @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         // show label mapping UI
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLoadHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLoadHistoryToken.java
@@ -23,6 +23,7 @@ import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.dominokit.AppContext;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
+import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
 import walkingkooka.text.cursor.TextCursor;
 
 public final class SpreadsheetLoadHistoryToken extends SpreadsheetIdHistoryToken {
@@ -52,8 +53,9 @@ public final class SpreadsheetLoadHistoryToken extends SpreadsheetIdHistoryToken
     }
 
     @Override
-    SpreadsheetHistoryToken setIdAndName0(final SpreadsheetId id,
-                                          final SpreadsheetName name) {
+    SpreadsheetHistoryToken setIdNameViewportSelection0(final SpreadsheetId id,
+                                                        final SpreadsheetName name,
+                                                        final SpreadsheetViewportSelection viewportSelection) {
         return new SpreadsheetLoadHistoryToken(id); // dont care about the name, when loading a new id
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataHistoryToken.java
@@ -22,6 +22,7 @@ import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
 import walkingkooka.text.cursor.TextCursor;
 
 public abstract class SpreadsheetMetadataHistoryToken extends SpreadsheetNameHistoryToken {
@@ -70,6 +71,17 @@ public abstract class SpreadsheetMetadataHistoryToken extends SpreadsheetNameHis
     }
 
     @Override
+    final SpreadsheetHistoryToken setIdNameViewportSelection0(final SpreadsheetId id,
+                                                              final SpreadsheetName name,
+                                                              final SpreadsheetViewportSelection viewportSelection) {
+        return this.viewportSelectionHistoryToken(
+                id,
+                name,
+                viewportSelection
+        );
+    }
+
+    @Override
     final SpreadsheetNameHistoryToken clear() {
         return this;
     }
@@ -96,7 +108,7 @@ public abstract class SpreadsheetMetadataHistoryToken extends SpreadsheetNameHis
 
     @Override
     SpreadsheetNameHistoryToken menu0(final SpreadsheetSelection selection) {
-        return this.viewportSelection(
+        return this.viewportSelectionHistoryToken(
                 selection.setDefaultAnchor()
         ).menu();
     }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySaveHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySaveHistoryToken.java
@@ -90,17 +90,6 @@ public final class SpreadsheetMetadataPropertySaveHistoryToken<T> extends Spread
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetMetadataPropertySaveHistoryToken<>(
-                id,
-                name,
-                this.propertyName(),
-                this.propertyValue()
-        );
-    }
-
-    @Override
     SpreadsheetNameHistoryToken save(final String value) {
         return this;
     }
@@ -111,8 +100,8 @@ public final class SpreadsheetMetadataPropertySaveHistoryToken<T> extends Spread
     }
 
     @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         context.spreadsheetMetadataFetcher()
                 .patchMetadata(
                         this.id(),

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySelectHistoryToken.java
@@ -98,18 +98,8 @@ public final class SpreadsheetMetadataPropertySelectHistoryToken<T> extends Spre
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetMetadataPropertySelectHistoryToken<>(
-                id,
-                name,
-                this.propertyName()
-        );
-    }
-
-    @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         // show metadata edit UI
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSaveHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSaveHistoryToken.java
@@ -77,19 +77,8 @@ public final class SpreadsheetMetadataPropertyStyleSaveHistoryToken<T> extends S
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetMetadataPropertyStyleSaveHistoryToken<>(
-                id,
-                name,
-                this.stylePropertyName(),
-                this.stylePropertyValue()
-        );
-    }
-
-    @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         // PATCH metadata with style property+value
         context.spreadsheetMetadataFetcher()
                 .patchMetadata(

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSelectHistoryToken.java
@@ -75,18 +75,8 @@ public final class SpreadsheetMetadataPropertyStyleSelectHistoryToken<T> extends
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetMetadataPropertyStyleSelectHistoryToken<>(
-                id,
-                name,
-                this.stylePropertyName()
-        );
-    }
-
-    @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         // show metadata style UI
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataSelectHistoryToken.java
@@ -47,15 +47,6 @@ public final class SpreadsheetMetadataSelectHistoryToken extends SpreadsheetMeta
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetMetadataSelectHistoryToken(
-                id,
-                name
-        );
-    }
-
-    @Override
     SpreadsheetNameHistoryToken save(final String value) {
         return this;
     }
@@ -66,8 +57,8 @@ public final class SpreadsheetMetadataSelectHistoryToken extends SpreadsheetMeta
     }
 
     @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         // show metadata UI
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowClearHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowClearHistoryToken.java
@@ -51,18 +51,8 @@ public class SpreadsheetRowClearHistoryToken extends SpreadsheetRowHistoryToken 
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetRowClearHistoryToken(
-                id,
-                name,
-                this.viewportSelection()
-        );
-    }
-
-    @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         this.deltaClearAndPushSelectionHistoryToken(context);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowDeleteHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowDeleteHistoryToken.java
@@ -51,18 +51,8 @@ public class SpreadsheetRowDeleteHistoryToken extends SpreadsheetRowHistoryToken
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetRowDeleteHistoryToken(
-                id,
-                name,
-                this.viewportSelection()
-        );
-    }
-
-    @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         context.spreadsheetDeltaFetcher()
                 .deleteDelta(
                         this.id(),

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowFreezeHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowFreezeHistoryToken.java
@@ -59,18 +59,8 @@ public class SpreadsheetRowFreezeHistoryToken extends SpreadsheetRowHistoryToken
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetRowFreezeHistoryToken(
-                id,
-                name,
-                this.viewportSelection()
-        );
-    }
-
-    @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         this.patchMetadataAndPushSelectionHistoryToken(
                 SpreadsheetMetadataPropertyName.FROZEN_ROWS,
                 this.viewportSelection()

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowHistoryToken.java
@@ -97,7 +97,7 @@ abstract public class SpreadsheetRowHistoryToken extends SpreadsheetViewportSele
                         .selection()
                         .testRow(selection.toRow()) ?
                 this :
-                this.viewportSelection(
+                this.viewportSelectionHistoryToken(
                         selection.setDefaultAnchor()
                 ).menu();
     }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowMenuHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowMenuHistoryToken.java
@@ -51,19 +51,8 @@ public class SpreadsheetRowMenuHistoryToken extends SpreadsheetRowHistoryToken {
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetRowMenuHistoryToken(
-                id,
-                name,
-                this.viewportSelection()
-        );
-    }
-
-
-    @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         // open row menu here
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowSelectHistoryToken.java
@@ -51,18 +51,8 @@ public class SpreadsheetRowSelectHistoryToken extends SpreadsheetRowHistoryToken
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetRowSelectHistoryToken(
-                id,
-                name,
-                this.viewportSelection()
-        );
-    }
-
-    @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         context.spreadsheetMetadataFetcher()
                 .patchViewportSelectionIfDifferent(
                         this.viewportSelection(),

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowUnfreezeHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowUnfreezeHistoryToken.java
@@ -59,18 +59,8 @@ public class SpreadsheetRowUnfreezeHistoryToken extends SpreadsheetRowHistoryTok
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetRowUnfreezeHistoryToken(
-                id,
-                name,
-                this.viewportSelection()
-        );
-    }
-
-    @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
         this.patchMetadataAndPushSelectionHistoryToken(
                 SpreadsheetMetadataPropertyName.FROZEN_ROWS,
                 null,

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectHistoryToken.java
@@ -230,11 +230,13 @@ public final class SpreadsheetSelectHistoryToken extends SpreadsheetNameHistoryT
     }
 
     @Override
-    SpreadsheetHistoryToken setDifferentIdOrName(final SpreadsheetId id,
-                                                 final SpreadsheetName name) {
-        return new SpreadsheetSelectHistoryToken(
+    SpreadsheetHistoryToken setIdNameViewportSelection0(final SpreadsheetId id,
+                                                        final SpreadsheetName name,
+                                                        final SpreadsheetViewportSelection viewportSelection) {
+        return this.viewportSelectionHistoryToken(
                 id,
-                name
+                name,
+                viewportSelection
         );
     }
 
@@ -265,7 +267,7 @@ public final class SpreadsheetSelectHistoryToken extends SpreadsheetNameHistoryT
 
     @Override
     SpreadsheetNameHistoryToken menu0(final SpreadsheetSelection selection) {
-        return this.viewportSelection(
+        return this.viewportSelectionHistoryToken(
                 selection.setDefaultAnchor()
         ).menu();
     }
@@ -301,8 +303,11 @@ public final class SpreadsheetSelectHistoryToken extends SpreadsheetNameHistoryT
     }
 
     @Override
-    void onHashChange0(final HistoryToken previous,
-                       final AppContext context) {
-        // do nothing.
+    public void onHashChange(final HistoryToken previous,
+                             final AppContext context) {
+        context.spreadsheetMetadataFetcher()
+                .loadSpreadsheetMetadata(
+                        this.id()
+                );
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetViewportSelectionHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetViewportSelectionHistoryToken.java
@@ -57,6 +57,21 @@ public abstract class SpreadsheetViewportSelectionHistoryToken extends Spreadshe
 
     abstract UrlFragment selectionViewportUrlFragment();
 
+    @Override
+    final SpreadsheetHistoryToken setIdNameViewportSelection0(final SpreadsheetId id,
+                                                              final SpreadsheetName name,
+                                                              final SpreadsheetViewportSelection viewportSelection) {
+        return this.id().equals(id) &&
+                this.name().equals(name) &&
+                this.viewportSelection().equals(viewportSelection) ?
+                this :
+                this.viewportSelectionHistoryToken(
+                        id,
+                        name,
+                        viewportSelection
+                );
+    }
+
     /**
      * Factory that returns a {@link SpreadsheetViewportSelectionHistoryToken} without any action and just the
      * {@link SpreadsheetViewportSelection}

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCreateHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCreateHistoryTokenTest.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.dominokit.history;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.SpreadsheetId;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
 public final class SpreadsheetCreateHistoryTokenTest extends SpreadsheetHistoryTokenTestCase<SpreadsheetCreateHistoryToken> {
 
@@ -31,9 +32,10 @@ public final class SpreadsheetCreateHistoryTokenTest extends SpreadsheetHistoryT
     public void testSetId() {
         final SpreadsheetId differentId = SpreadsheetId.with(9999);
 
-        this.setIdAndNameAndCheck(
+        this.setIdNameViewportSelectionAndCheck(
                 differentId,
                 NAME,
+                SpreadsheetSelection.A1.setDefaultAnchor(),
                 SpreadsheetHistoryToken.spreadsheetLoad(
                         differentId
                 )

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetHistoryTokenTestCase.java
@@ -21,6 +21,10 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.net.UrlFragment;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
+
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -60,50 +64,100 @@ public abstract class SpreadsheetHistoryTokenTestCase<T extends SpreadsheetHisto
         );
     }
 
-    // setIdAndName.....................................................................................................
+    // setIdNameViewportSelection.......................................................................................
 
     @Test
-    public final void testSetIdAndNameNullIdFails() {
+    public final void testSetIdNameViewportSelectionNullIdFails() {
         assertThrows(
                 NullPointerException.class,
-                () -> this.createHistoryToken().setIdAndName(
+                () -> this.createHistoryToken().setIdNameViewportSelection(
                         null,
-                        NAME
+                        NAME,
+                        Optional.of(
+                                SpreadsheetSelection.A1.setDefaultAnchor()
+                        )
                 )
         );
     }
 
     @Test
-    public final void testSetIdAndNameNullNameFails() {
+    public final void testSetIdNameViewportSelectionNullNameFails() {
         assertThrows(
                 NullPointerException.class,
-                () -> this.createHistoryToken().setIdAndName(
+                () -> this.createHistoryToken().setIdNameViewportSelection(
                         ID,
+                        null,
+                        Optional.of(
+                                SpreadsheetSelection.A1.setDefaultAnchor()
+                        )
+                )
+        );
+    }
+
+    @Test
+    public final void testSetIdNameViewportSelectionNullViewportSelectionFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> this.createHistoryToken().setIdNameViewportSelection(
+                        ID,
+                        NAME,
                         null
                 )
         );
     }
 
-    final void setIdAndNameAndCheck(final SpreadsheetId id,
-                                    final SpreadsheetName name,
-                                    final SpreadsheetHistoryToken expected) {
-        this.setIdAndNameAndCheck(
-                this.createHistoryToken(),
+    final void setIdNameViewportSelectionAndCheck(final SpreadsheetId id,
+                                                  final SpreadsheetName name,
+                                                  final SpreadsheetViewportSelection viewportSelection,
+                                                  final SpreadsheetHistoryToken expected) {
+        this.setIdNameViewportSelectionAndCheck(
                 id,
                 name,
+                Optional.of(viewportSelection),
                 expected
         );
     }
 
-    final void setIdAndNameAndCheck(final SpreadsheetHistoryToken token,
-                                    final SpreadsheetId id,
-                                    final SpreadsheetName name,
-                                    final SpreadsheetHistoryToken expected) {
+    final void setIdNameViewportSelectionAndCheck(final SpreadsheetId id,
+                                                  final SpreadsheetName name,
+                                                  final Optional<SpreadsheetViewportSelection> viewportSelection,
+                                                  final SpreadsheetHistoryToken expected) {
+        this.setIdNameViewportSelectionAndCheck(
+                this.createHistoryToken(),
+                id,
+                name,
+                viewportSelection,
+                expected
+        );
+    }
+
+    final void setIdNameViewportSelectionAndCheck(final SpreadsheetHistoryToken token,
+                                                  final SpreadsheetId id,
+                                                  final SpreadsheetName name,
+                                                  final SpreadsheetViewportSelection viewportSelection,
+                                                  final SpreadsheetHistoryToken expected) {
+        this.setIdNameViewportSelectionAndCheck(
+                token,
+                id,
+                name,
+                Optional.of(
+                        viewportSelection
+                ),
+                expected
+        );
+    }
+
+    final void setIdNameViewportSelectionAndCheck(final SpreadsheetHistoryToken token,
+                                                  final SpreadsheetId id,
+                                                  final SpreadsheetName name,
+                                                  final Optional<SpreadsheetViewportSelection> viewportSelection,
+                                                  final SpreadsheetHistoryToken expected) {
         this.checkEquals(
                 expected,
-                token.setIdAndName(
+                token.setIdNameViewportSelection(
                         id,
-                        name
+                        name,
+                        viewportSelection
                 ),
                 () -> token + " setIdAndName " + id + ", " + name
         );

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLoadHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLoadHistoryTokenTest.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.dominokit.history;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.SpreadsheetId;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
 public final class SpreadsheetLoadHistoryTokenTest extends SpreadsheetIdHistoryTokenTestCase<SpreadsheetLoadHistoryToken> {
 
@@ -31,9 +32,10 @@ public final class SpreadsheetLoadHistoryTokenTest extends SpreadsheetIdHistoryT
     public void testSetIdDifferent() {
         final SpreadsheetId differentId = SpreadsheetId.with(9999);
 
-        this.setIdAndNameAndCheck(
+        this.setIdNameViewportSelectionAndCheck(
                 differentId,
                 NAME,
+                SpreadsheetSelection.ALL_CELLS.setDefaultAnchor(),
                 SpreadsheetHistoryToken.spreadsheetLoad(
                         differentId
                 )

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataHistoryTokenTestCase.java
@@ -20,11 +20,30 @@ package walkingkooka.spreadsheet.dominokit.history;
 import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
 
 public abstract class SpreadsheetMetadataHistoryTokenTestCase<T extends SpreadsheetMetadataHistoryToken> extends SpreadsheetNameHistoryTokenTestCase<T> {
 
     SpreadsheetMetadataHistoryTokenTestCase() {
         super();
+    }
+
+    @Test
+    public final void testSetIdNameViewportSelectionWithViewportSelection() {
+        final SpreadsheetViewportSelection viewportSelection = SpreadsheetSelection.parseCell("Z99")
+                .setDefaultAnchor();
+
+        this.setIdNameViewportSelectionAndCheck(
+                ID,
+                NAME,
+                viewportSelection,
+                SpreadsheetHistoryToken.cell(
+                        ID,
+                        NAME,
+                        viewportSelection
+                )
+        );
     }
 
     // menu(Selection)..................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNameHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNameHistoryTokenTestCase.java
@@ -24,6 +24,9 @@ import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetRowReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
+
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -34,64 +37,82 @@ public abstract class SpreadsheetNameHistoryTokenTestCase<T extends SpreadsheetN
     }
 
     @Test
-    public void testSetIdAndNameDifferentId() {
+    public final void testSetIdNameViewportSelectionWithDifferentId() {
         final T token = this.createHistoryToken();
 
         final SpreadsheetId differentId = SpreadsheetId.with(999);
+        final SpreadsheetViewportSelection viewportSelection = SpreadsheetSelection.A1.setDefaultAnchor();
 
-        final SpreadsheetNameHistoryToken different = (SpreadsheetNameHistoryToken) token.setIdAndName(
+        this.checkNotEquals(
                 differentId,
-                NAME
-        );
-
-        this.checkEquals(
-                differentId,
-                different.id(),
+                token.id(),
                 "id"
         );
 
         this.checkEquals(
                 NAME,
-                different.name(),
+                token.name(),
                 "name"
         );
 
-        this.setIdAndNameAndCheck(
-                different,
-                ID,
+        this.setIdNameViewportSelectionAndCheck(
+                differentId,
                 NAME,
-                token
+                Optional.of(viewportSelection),
+                SpreadsheetHistoryToken.cell(
+                        differentId,
+                        NAME,
+                        viewportSelection
+                )
         );
     }
 
     @Test
-    public void testSetIdAndNameDifferentName() {
+    public final void testSetIdNameViewportSelectionWithDifferentName() {
         final T token = this.createHistoryToken();
 
         final SpreadsheetName differentName = SpreadsheetName.with("different");
-
-        final SpreadsheetNameHistoryToken different = (SpreadsheetNameHistoryToken) token.setIdAndName(
-                ID,
-                differentName
-        );
+        final SpreadsheetViewportSelection viewportSelection = SpreadsheetSelection.A1.setDefaultAnchor();
 
         this.checkEquals(
                 ID,
-                different.id(),
+                token.id(),
                 "id"
         );
 
-        this.checkEquals(
+        this.checkNotEquals(
                 differentName,
-                different.name(),
+                token.name(),
                 "name"
         );
 
-        this.setIdAndNameAndCheck(
-                different,
+        this.setIdNameViewportSelectionAndCheck(
+                token,
+                ID,
+                differentName,
+                viewportSelection,
+                SpreadsheetHistoryToken.cell(
+                        ID,
+                        differentName,
+                        viewportSelection
+                )
+        );
+    }
+
+    @Test
+    public final void testSetIdNameViewportSelectionWithCell() {
+        final SpreadsheetViewportSelection viewportSelection = SpreadsheetSelection.parseCell("Z99")
+                .setDefaultAnchor();
+
+        this.setIdNameViewportSelectionAndCheck(
                 ID,
                 NAME,
-                token
+                viewportSelection,
+                SpreadsheetHistoryToken.cell(
+                        ID,
+                        NAME,
+                        viewportSelection
+                )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectHistoryTokenTest.java
@@ -19,6 +19,8 @@ package walkingkooka.spreadsheet.dominokit.history;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.SpreadsheetId;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
 
 public final class SpreadsheetSelectHistoryTokenTest extends SpreadsheetNameHistoryTokenTestCase<SpreadsheetSelectHistoryToken> {
 
@@ -28,15 +30,18 @@ public final class SpreadsheetSelectHistoryTokenTest extends SpreadsheetNameHist
     }
 
     @Test
-    public void testSetIdDifferentId() {
+    public void testSetIdNameViewportSelectionDifferentId() {
         final SpreadsheetId differentId = SpreadsheetId.with(9999);
+        final SpreadsheetViewportSelection viewportSelection = SpreadsheetSelection.ALL_CELLS.setDefaultAnchor();
 
-        this.setIdAndNameAndCheck(
+        this.setIdNameViewportSelectionAndCheck(
                 differentId,
                 NAME,
-                SpreadsheetHistoryToken.spreadsheetSelect(
+                viewportSelection,
+                SpreadsheetHistoryToken.cell(
                         differentId,
-                        NAME
+                        NAME,
+                        viewportSelection
                 )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectionHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectionHistoryTokenTestCase.java
@@ -56,7 +56,7 @@ public abstract class SpreadsheetSelectionHistoryTokenTestCase<T extends Spreads
                         selection.setDefaultAnchor()
                 ),
                 this.createHistoryToken()
-                        .viewportSelection(
+                        .viewportSelectionHistoryToken(
                                 selection.setDefaultAnchor()
                         )
         );
@@ -84,7 +84,7 @@ public abstract class SpreadsheetSelectionHistoryTokenTestCase<T extends Spreads
                         selection.setDefaultAnchor()
                 ),
                 this.createHistoryToken()
-                        .viewportSelection(
+                        .viewportSelectionHistoryToken(
                                 selection.setDefaultAnchor()
                         )
         );
@@ -112,7 +112,7 @@ public abstract class SpreadsheetSelectionHistoryTokenTestCase<T extends Spreads
                         selection.setDefaultAnchor()
                 ),
                 this.createHistoryToken()
-                        .viewportSelection(
+                        .viewportSelectionHistoryToken(
                                 selection.setDefaultAnchor()
                         )
         );

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetViewportSelectionHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetViewportSelectionHistoryTokenTestCase.java
@@ -17,16 +17,35 @@
 
 package walkingkooka.spreadsheet.dominokit.history;
 
+import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
 
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public abstract class SpreadsheetViewportSelectionHistoryTokenTestCase<T extends SpreadsheetViewportSelectionHistoryToken> extends SpreadsheetSelectionHistoryTokenTestCase<T> {
 
     SpreadsheetViewportSelectionHistoryTokenTestCase() {
         super();
+    }
+
+    @Test
+    public final void testSetIdNameViewportSameViewportSelection() {
+        final T token = this.createHistoryToken();
+        assertSame(
+                token,
+                token.setIdNameViewportSelection(
+                        token.id(),
+                        token.name(),
+                        Optional.of(
+                                token.viewportSelection()
+                        )
+                )
+        );
     }
 
     final void createHistoryTokenFails(final SpreadsheetViewportSelection viewportSelection,


### PR DESCRIPTION
- Returned SpreadsheetViewportSelection *STILL* does not update browser history token in hash.