### PR TITLE
SpreadsheetViewportWidget.loadViewportCells clear cache fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/SpreadsheetViewportCache.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/SpreadsheetViewportCache.java
@@ -62,6 +62,24 @@ final class SpreadsheetViewportCache implements SpreadsheetDeltaWatcher, Spreads
     }
 
     /**
+     * Clearing all caches.
+     */
+    public void clear() {
+        this.cells.clear();
+
+        this.cellToLabels.clear();
+        this.labelToNonLabel.clear();
+
+        this.columns.clear();
+        this.rows.clear();
+
+        this.columnWidths.clear();
+        this.rowHeights.clear();
+
+        this.windows = Sets.empty();
+    }
+
+    /**
      * Captures the default width and height which will be used when rendering
      */
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/SpreadsheetViewportWidget.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/SpreadsheetViewportWidget.java
@@ -198,6 +198,8 @@ public final class SpreadsheetViewportWidget implements SpreadsheetDeltaWatcher,
      * Loads all the cells to fill the viewport. Assumes that a metadata with id is present.
      */
     private void loadViewportCells() {
+        this.cache.clear(); // equivalent to clearing all cached data.
+
         this.reload = false;
 
         final SpreadsheetMetadata metadata = this.metadata;


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/307
- loading cells for viewport should clear SpreadsheetViewportWidget cache