### PR TITLE
SpreadsheetNameHistoryToken.onHashChange/onSpreadsheetMetadata redraw…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSelectHistoryToken.java
@@ -88,11 +88,6 @@ public final class SpreadsheetCellSelectHistoryToken extends SpreadsheetCellHist
     @Override
     public void onHashChange(final HistoryToken previous,
                              final AppContext context) {
-        context.spreadsheetMetadataFetcher()
-                .patchViewportSelectionIfDifferent(
-                        this.viewportSelection(),
-                        this.id(),
-                        previous
-                );
+        // nop
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnSelectHistoryToken.java
@@ -63,11 +63,6 @@ public class SpreadsheetColumnSelectHistoryToken extends SpreadsheetColumnHistor
     @Override
     public void onHashChange(final HistoryToken previous,
                              final AppContext context) {
-        context.spreadsheetMetadataFetcher()
-                .patchViewportSelectionIfDifferent(
-                        this.viewportSelection(),
-                        this.id(),
-                        previous
-                );
+        // nop
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCreateHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCreateHistoryToken.java
@@ -21,11 +21,8 @@ import walkingkooka.net.UrlFragment;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.dominokit.AppContext;
-import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
 import walkingkooka.text.cursor.TextCursor;
-
-import java.util.Optional;
 
 /**
  * A token that represents a spreadsheet create action.
@@ -77,24 +74,5 @@ public final class SpreadsheetCreateHistoryToken extends SpreadsheetHistoryToken
                              final AppContext context) {
         context.spreadsheetMetadataFetcher()
                 .createSpreadsheetMetadata();
-    }
-
-    /**
-     * When the spreadsheet is created and a new {@link SpreadsheetMetadata} is returned update the history token.
-     */
-    @Override
-    public void onSpreadsheetMetadata(final SpreadsheetMetadata metadata,
-                                      final AppContext context) {
-        final Optional<SpreadsheetId> id = metadata.id();
-        final Optional<SpreadsheetName> name = metadata.name();
-
-        if (id.isPresent() && name.isPresent()) {
-            context.pushHistoryToken(
-                    spreadsheetSelect(
-                            id.get(),
-                            name.get()
-                    )
-            );
-        }
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetHistoryToken.java
@@ -19,14 +19,13 @@ package walkingkooka.spreadsheet.dominokit.history;
 
 import walkingkooka.net.HasUrlFragment;
 import walkingkooka.net.UrlFragment;
-import walkingkooka.spreadsheet.dominokit.SpreadsheetMetadataWatcher;
 
 import java.util.Optional;
 
 /**
  * Instances represent a token within a history hash.
  */
-public abstract class SpreadsheetHistoryToken extends HistoryToken implements SpreadsheetMetadataWatcher {
+public abstract class SpreadsheetHistoryToken extends HistoryToken {
 
     final static UrlFragment CLEAR = UrlFragment.SLASH.append(UrlFragment.with("clear"));
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLoadHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLoadHistoryToken.java
@@ -21,8 +21,6 @@ import walkingkooka.net.UrlFragment;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.dominokit.AppContext;
-import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
-import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
 import walkingkooka.text.cursor.TextCursor;
 
@@ -73,19 +71,5 @@ public final class SpreadsheetLoadHistoryToken extends SpreadsheetIdHistoryToken
                              final AppContext context) {
         context.spreadsheetMetadataFetcher()
                 .loadSpreadsheetMetadata(this.id());
-    }
-
-    /**
-     * When the spreadsheet is loaded and a new {@link SpreadsheetMetadata} is returned update the history token.
-     */
-    @Override
-    public void onSpreadsheetMetadata(final SpreadsheetMetadata metadata,
-                                      final AppContext context) {
-        context.pushHistoryToken(
-                spreadsheetSelect(
-                        metadata.getOrFail(SpreadsheetMetadataPropertyName.SPREADSHEET_ID),
-                        metadata.getOrFail(SpreadsheetMetadataPropertyName.SPREADSHEET_NAME)
-                )
-        );
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNameHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNameHistoryToken.java
@@ -20,10 +20,7 @@ package walkingkooka.spreadsheet.dominokit.history;
 import walkingkooka.net.UrlFragment;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
-import walkingkooka.spreadsheet.dominokit.AppContext;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
-import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
-import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
@@ -202,46 +199,5 @@ public abstract class SpreadsheetNameHistoryToken extends SpreadsheetIdHistoryTo
             );
         }
         return result;
-    }
-
-    /**
-     * The new metadata might have a different id or name, update the history token.
-     */
-    @Override
-    public void onSpreadsheetMetadata(final SpreadsheetMetadata metadata,
-                                      final AppContext context) {
-        this.pushHistoryTokenIdNameViewportSelection(
-                metadata.id(),
-                metadata.name(),
-                metadata.get(SpreadsheetMetadataPropertyName.SELECTION),
-                context
-        );
-    }
-
-    private void pushHistoryTokenIdNameViewportSelection(final Optional<SpreadsheetId> id,
-                                                         final Optional<SpreadsheetName> name,
-                                                         final Optional<SpreadsheetViewportSelection> viewportSelection,
-                                                         final AppContext context) {
-        if (id.isPresent() && name.isPresent()) {
-            this.pushHistoryTokenIdNameViewportSelection(
-                    id.get(),
-                    name.get(),
-                    viewportSelection,
-                    context
-            );
-        }
-    }
-
-    private void pushHistoryTokenIdNameViewportSelection(final SpreadsheetId id,
-                                                         final SpreadsheetName name,
-                                                         final Optional<SpreadsheetViewportSelection> viewportSelection,
-                                                         final AppContext context) {
-        context.pushHistoryToken(
-                this.idNameViewportSelection(
-                        id,
-                        name,
-                        viewportSelection
-                )
-        );
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowSelectHistoryToken.java
@@ -63,11 +63,6 @@ public class SpreadsheetRowSelectHistoryToken extends SpreadsheetRowHistoryToken
     @Override
     public void onHashChange(final HistoryToken previous,
                              final AppContext context) {
-        context.spreadsheetMetadataFetcher()
-                .patchViewportSelectionIfDifferent(
-                        this.viewportSelection(),
-                        this.id(),
-                        previous
-                );
+        // nop
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectHistoryToken.java
@@ -313,12 +313,24 @@ public final class SpreadsheetSelectHistoryToken extends SpreadsheetNameHistoryT
         return this;
     }
 
+    /**
+     * If the {@link SpreadsheetId} has changed, load the new id.
+     */
     @Override
     public void onHashChange(final HistoryToken previous,
                              final AppContext context) {
-        context.spreadsheetMetadataFetcher()
-                .loadSpreadsheetMetadata(
-                        this.id()
-                );
+        boolean load = true;
+        final SpreadsheetId id = this.id();
+        if (previous instanceof SpreadsheetIdHistoryToken) {
+            final SpreadsheetIdHistoryToken spreadsheetIdHistoryToken = (SpreadsheetIdHistoryToken) previous;
+            load = false == id.equals(spreadsheetIdHistoryToken.id());
+        }
+
+        if (load) {
+            context.spreadsheetMetadataFetcher()
+                    .loadSpreadsheetMetadata(
+                            id
+                    );
+        }
     }
 }


### PR DESCRIPTION
…/pushHistory/patchMetadata

- SpreadsheetCellSelectHistoryToken/SpreadsheetColumnSelectHistoryToken/SpreadsheetRowSelectHistoryToken no longer "PATCH" SpreadsheetMetadata, which also meant that a cell/menu history token didnt actually PATCH metadata.
- App now implements SpreadsheetDeltaWatcher & SpreadsheetMetadataWatcher.
- App.onSpreadsheetDelta & onSpreadsheetMetadata now PATCH SpreadsheetMetadata.SELECTION on viewportSelection changes.
- HistoryToken unimplements SpreadsheetMetadataWatcher
- SpreadsheetViewportWidget now only updates selection from a HistoryWatcher event.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/320
- loading SpreadsheetMetadata should ignore selection returned if a selection is already active in history token.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/266
- Returned SpreadsheetViewportSelection in SpreadsheetDelta's are ignored.