### PR TITLE
SpreadsheetNameHistoryToken factory methods return type HistoryToken

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/App.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/App.java
@@ -165,7 +165,7 @@ public class App implements EntryPoint, AppContext, HistoryWatcher, SpreadsheetM
 
         // if a selection is already present copy from the metadata
         if (historyToken instanceof SpreadsheetSelectionHistoryToken) {
-            final HistoryToken withViewportSelection = historyToken.viewportSelectionHistoryToken(
+            final HistoryToken withViewportSelection = historyToken.setViewportSelection(
                     delta.viewportSelection()
             );
 
@@ -197,7 +197,7 @@ public class App implements EntryPoint, AppContext, HistoryWatcher, SpreadsheetM
 
             // if a selection is already present copy from the metadata
             if (tokenWithIdAndName instanceof SpreadsheetSelectionHistoryToken) {
-                tokenWithIdAndName = tokenWithIdAndName.viewportSelectionHistoryToken(
+                tokenWithIdAndName = tokenWithIdAndName.setViewportSelection(
                         metadata.get(SpreadsheetMetadataPropertyName.SELECTION)
                 );
             }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/SpreadsheetViewportWidget.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/SpreadsheetViewportWidget.java
@@ -39,7 +39,6 @@ import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
 import walkingkooka.spreadsheet.dominokit.history.HistoryWatcher;
-import walkingkooka.spreadsheet.dominokit.history.SpreadsheetNameHistoryToken;
 import walkingkooka.spreadsheet.engine.SpreadsheetDelta;
 import walkingkooka.spreadsheet.engine.SpreadsheetEngineEvaluation;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
@@ -201,7 +200,7 @@ public final class SpreadsheetViewportWidget implements SpreadsheetDeltaWatcher,
                 // clear any selection
                 context.pushHistoryToken(
                         context.historyToken()
-                                .viewportSelectionHistoryToken(
+                                .setViewportSelection(
                                         Optional.empty()
                                 )
                 );
@@ -689,7 +688,7 @@ public final class SpreadsheetViewportWidget implements SpreadsheetDeltaWatcher,
      * Creates an ANCHOR including an ID and TEXT in upper case of the given {@link SpreadsheetSelection}.
      */
     private HTMLAnchorElement link(final SpreadsheetSelection selection) {
-        final SpreadsheetNameHistoryToken token = this.historyToken.viewportSelectionHistoryToken(
+        final HistoryToken token = this.historyToken.setViewportSelection(
                 Optional.of(
                         selection.setDefaultAnchor()
                 )

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenSelectionSpreadsheetSelectionVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenSelectionSpreadsheetSelectionVisitor.java
@@ -36,8 +36,8 @@ import java.util.function.Function;
  */
 final class HistoryTokenSelectionSpreadsheetSelectionVisitor extends SpreadsheetSelectionVisitor {
 
-    static SpreadsheetNameHistoryToken selectionToken(final SpreadsheetNameHistoryToken token,
-                                                      final SpreadsheetViewportSelection viewportSelection) {
+    static HistoryToken selectionToken(final SpreadsheetNameHistoryToken token,
+                                       final SpreadsheetViewportSelection viewportSelection) {
         final HistoryTokenSelectionSpreadsheetSelectionVisitor visitor = new HistoryTokenSelectionSpreadsheetSelectionVisitor(
                 token,
                 viewportSelection.anchor()
@@ -112,13 +112,13 @@ final class HistoryTokenSelectionSpreadsheetSelectionVisitor extends Spreadsheet
     private final SpreadsheetNameHistoryToken token;
 
     private void setSelectionToken(final SpreadsheetSelection selection,
-                                   final Function<SpreadsheetViewportSelection, SpreadsheetNameHistoryToken> factory) {
+                                   final Function<SpreadsheetViewportSelection, HistoryToken> factory) {
         this.selectionToken = factory.apply(
                 selection.setAnchor(this.anchor)
         );
     }
 
-    private SpreadsheetNameHistoryToken selectionToken;
+    private HistoryToken selectionToken;
 
     private final SpreadsheetViewportSelectionAnchor anchor;
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellClearHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellClearHistoryToken.java
@@ -67,12 +67,12 @@ public final class SpreadsheetCellClearHistoryToken extends SpreadsheetCellHisto
     }
 
     @Override
-    SpreadsheetNameHistoryToken pattern(final SpreadsheetPatternKind patternKind) {
+    HistoryToken pattern(final SpreadsheetPatternKind patternKind) {
         return this;
     }
 
     @Override
-    SpreadsheetNameHistoryToken save(final String value) {
+    HistoryToken save(final String value) {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellDeleteHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellDeleteHistoryToken.java
@@ -67,12 +67,12 @@ public final class SpreadsheetCellDeleteHistoryToken extends SpreadsheetCellHist
     }
 
     @Override
-    SpreadsheetNameHistoryToken pattern(final SpreadsheetPatternKind patternKind) {
+    HistoryToken pattern(final SpreadsheetPatternKind patternKind) {
         return this;
     }
 
     @Override
-    SpreadsheetNameHistoryToken save(final String value) {
+    HistoryToken save(final String value) {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormulaHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormulaHistoryToken.java
@@ -46,7 +46,7 @@ abstract public class SpreadsheetCellFormulaHistoryToken extends SpreadsheetCell
     abstract UrlFragment formulaUrlFragment();
 
     @Override
-    SpreadsheetNameHistoryToken pattern(final SpreadsheetPatternKind patternKind) {
+    HistoryToken pattern(final SpreadsheetPatternKind patternKind) {
         return this; // ignore extra pattern
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormulaSaveHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormulaSaveHistoryToken.java
@@ -71,7 +71,7 @@ public final class SpreadsheetCellFormulaSaveHistoryToken extends SpreadsheetCel
     }
 
     @Override
-    SpreadsheetNameHistoryToken save(final String value) {
+    HistoryToken save(final String value) {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormulaSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormulaSelectHistoryToken.java
@@ -52,7 +52,7 @@ public final class SpreadsheetCellFormulaSelectHistoryToken extends SpreadsheetC
     }
 
     @Override
-    SpreadsheetNameHistoryToken save(final String formulaText) {
+    HistoryToken save(final String formulaText) {
         return formulaSave(
                 this.id(),
                 this.name(),

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFreezeHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFreezeHistoryToken.java
@@ -82,12 +82,12 @@ public final class SpreadsheetCellFreezeHistoryToken extends SpreadsheetCellHist
     }
 
     @Override
-    SpreadsheetNameHistoryToken pattern(final SpreadsheetPatternKind patternKind) {
+    HistoryToken pattern(final SpreadsheetPatternKind patternKind) {
         return this;
     }
 
     @Override
-    SpreadsheetNameHistoryToken save(final String value) {
+    HistoryToken save(final String value) {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellHistoryToken.java
@@ -24,8 +24,6 @@ import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
 import walkingkooka.tree.text.TextStylePropertyName;
 
-import java.util.Optional;
-
 abstract public class SpreadsheetCellHistoryToken extends SpreadsheetViewportSelectionHistoryToken {
 
     SpreadsheetCellHistoryToken(final SpreadsheetId id,
@@ -43,15 +41,14 @@ abstract public class SpreadsheetCellHistoryToken extends SpreadsheetViewportSel
         }
     }
 
-    @Override
-    final UrlFragment selectionViewportUrlFragment() {
+    @Override final UrlFragment selectionViewportUrlFragment() {
         return this.cellUrlFragment();
     }
 
     abstract UrlFragment cellUrlFragment();
 
-    @Override
-    final SpreadsheetNameHistoryToken clear() {
+    @Override //
+    final HistoryToken clear() {
         return cellClear(
                 this.id(),
                 this.name(),
@@ -59,8 +56,8 @@ abstract public class SpreadsheetCellHistoryToken extends SpreadsheetViewportSel
         );
     }
 
-    @Override
-    final SpreadsheetNameHistoryToken delete() {
+    @Override //
+    final HistoryToken delete() {
         return cellDelete(
                 this.id(),
                 this.name(),
@@ -68,8 +65,8 @@ abstract public class SpreadsheetCellHistoryToken extends SpreadsheetViewportSel
         );
     }
 
-    @Override
-    final SpreadsheetNameHistoryToken freeze() {
+    @Override //
+    final HistoryToken freeze() {
         return cellFreeze(
                 this.id(),
                 this.name(),
@@ -77,8 +74,8 @@ abstract public class SpreadsheetCellHistoryToken extends SpreadsheetViewportSel
         );
     }
 
-    @Override
-    final SpreadsheetNameHistoryToken menu() {
+    @Override //
+    final HistoryToken menu() {
         return cellMenu(
                 this.id(),
                 this.name(),
@@ -86,32 +83,20 @@ abstract public class SpreadsheetCellHistoryToken extends SpreadsheetViewportSel
         );
     }
 
-    @Override
-    final SpreadsheetNameHistoryToken menu0(final SpreadsheetSelection selection) {
-        return (false == this instanceof SpreadsheetCellFormulaHistoryToken) &&
-                selection.isCellReference() &&
-                this.viewportSelection()
+    @Override //
+    final SpreadsheetViewportSelection menuHistoryTokenSpreadsheetViewportSelection(final SpreadsheetSelection selection) {
+        final SpreadsheetViewportSelection viewportSelection = this.viewportSelection();
+
+        return selection.isCellReference() &&
+                viewportSelection
                         .selection()
                         .testCell(selection.toCell()) ?
-                this :
-                this.viewportSelectionHistoryToken(
-                        Optional.of(
-                                selection.setDefaultAnchor()
-                        )
-                ).menu();
+                viewportSelection :
+                selection.setDefaultAnchor();
     }
 
-    @Override
-    public final SpreadsheetViewportSelectionHistoryToken viewportSelectionHistoryToken() {
-        return cell(
-                this.id(),
-                this.name(),
-                this.viewportSelection()
-        );
-    }
-
-    @Override
-    final SpreadsheetNameHistoryToken style(final TextStylePropertyName<?> propertyName) {
+    @Override //
+    final HistoryToken style(final TextStylePropertyName<?> propertyName) {
         return cellStyle(
                 this.id(),
                 this.name(),
@@ -120,9 +105,18 @@ abstract public class SpreadsheetCellHistoryToken extends SpreadsheetViewportSel
         );
     }
 
-    @Override
-    final SpreadsheetNameHistoryToken unfreeze() {
+    @Override //
+    final HistoryToken unfreeze() {
         return cellUnfreeze(
+                this.id(),
+                this.name(),
+                this.viewportSelection()
+        );
+    }
+
+    @Override
+    public final HistoryToken viewportSelectionHistoryToken() {
+        return cell(
                 this.id(),
                 this.name(),
                 this.viewportSelection()

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellMenuHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellMenuHistoryToken.java
@@ -67,12 +67,12 @@ public final class SpreadsheetCellMenuHistoryToken extends SpreadsheetCellHistor
     }
 
     @Override
-    SpreadsheetNameHistoryToken pattern(final SpreadsheetPatternKind patternKind) {
+    HistoryToken pattern(final SpreadsheetPatternKind patternKind) {
         return this;
     }
 
     @Override
-    SpreadsheetNameHistoryToken save(final String value) {
+    HistoryToken save(final String value) {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternSaveHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternSaveHistoryToken.java
@@ -90,7 +90,7 @@ public final class SpreadsheetCellPatternSaveHistoryToken extends SpreadsheetCel
     }
 
     @Override
-    SpreadsheetNameHistoryToken pattern(final SpreadsheetPatternKind patternKind) {
+    HistoryToken pattern(final SpreadsheetPatternKind patternKind) {
         return cellPattern(
                 this.id(),
                 this.name(),
@@ -100,7 +100,7 @@ public final class SpreadsheetCellPatternSaveHistoryToken extends SpreadsheetCel
     }
 
     @Override
-    SpreadsheetNameHistoryToken save(final String value) {
+    HistoryToken save(final String value) {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternSelectHistoryToken.java
@@ -69,12 +69,12 @@ public final class SpreadsheetCellPatternSelectHistoryToken extends SpreadsheetC
     }
 
     @Override
-    SpreadsheetNameHistoryToken pattern(final SpreadsheetPatternKind patternKind) {
+    HistoryToken pattern(final SpreadsheetPatternKind patternKind) {
         return this;
     }
 
     @Override
-    SpreadsheetNameHistoryToken save(final String pattern) {
+    HistoryToken save(final String pattern) {
         final SpreadsheetPatternKind patternKind = this.patternKind();
 
         return cellPatternSave(

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSelectHistoryToken.java
@@ -71,7 +71,7 @@ public final class SpreadsheetCellSelectHistoryToken extends SpreadsheetCellHist
     }
 
     @Override
-    SpreadsheetNameHistoryToken pattern(final SpreadsheetPatternKind patternKind) {
+    HistoryToken pattern(final SpreadsheetPatternKind patternKind) {
         return cellPattern(
                 this.id(),
                 this.name(),
@@ -81,7 +81,7 @@ public final class SpreadsheetCellSelectHistoryToken extends SpreadsheetCellHist
     }
 
     @Override
-    SpreadsheetNameHistoryToken save(final String value) {
+    HistoryToken save(final String value) {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleHistoryToken.java
@@ -60,8 +60,7 @@ abstract public class SpreadsheetCellStyleHistoryToken<T> extends SpreadsheetCel
         return this;
     }
 
-    @Override
-    final SpreadsheetNameHistoryToken pattern(final SpreadsheetPatternKind patternKind) {
+    @Override final HistoryToken pattern(final SpreadsheetPatternKind patternKind) {
         return this;
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleSaveHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleSaveHistoryToken.java
@@ -85,7 +85,7 @@ final public class SpreadsheetCellStyleSaveHistoryToken<T> extends SpreadsheetCe
     }
 
     @Override
-    SpreadsheetNameHistoryToken save(final String value) {
+    HistoryToken save(final String value) {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleSelectHistoryToken.java
@@ -69,7 +69,7 @@ final public class SpreadsheetCellStyleSelectHistoryToken<T> extends Spreadsheet
     }
 
     @Override
-    SpreadsheetNameHistoryToken save(final String value) {
+    HistoryToken save(final String value) {
         final TextStylePropertyName<T> propertyName = this.propertyName();
 
         return cellStyleSave(

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellUnfreezeHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellUnfreezeHistoryToken.java
@@ -82,12 +82,12 @@ public final class SpreadsheetCellUnfreezeHistoryToken extends SpreadsheetCellHi
     }
 
     @Override
-    SpreadsheetNameHistoryToken pattern(final SpreadsheetPatternKind patternKind) {
+    HistoryToken pattern(final SpreadsheetPatternKind patternKind) {
         return this;
     }
 
     @Override
-    SpreadsheetNameHistoryToken save(final String value) {
+    HistoryToken save(final String value) {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnHistoryToken.java
@@ -25,8 +25,6 @@ import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
 import walkingkooka.tree.text.TextStylePropertyName;
 
-import java.util.Optional;
-
 abstract public class SpreadsheetColumnHistoryToken extends SpreadsheetViewportSelectionHistoryToken {
 
     SpreadsheetColumnHistoryToken(final SpreadsheetId id,
@@ -44,15 +42,15 @@ abstract public class SpreadsheetColumnHistoryToken extends SpreadsheetViewportS
         }
     }
 
-    @Override
+    @Override //
     final UrlFragment selectionViewportUrlFragment() {
         return this.columnUrlFragment();
     }
 
     abstract UrlFragment columnUrlFragment();
 
-    @Override
-    final SpreadsheetNameHistoryToken clear() {
+    @Override //
+    final HistoryToken clear() {
         return columnClear(
                 this.id(),
                 this.name(),
@@ -60,8 +58,8 @@ abstract public class SpreadsheetColumnHistoryToken extends SpreadsheetViewportS
         );
     }
 
-    @Override
-    final SpreadsheetNameHistoryToken delete() {
+    @Override //
+    final HistoryToken delete() {
         return columnDelete(
                 this.id(),
                 this.name(),
@@ -69,13 +67,13 @@ abstract public class SpreadsheetColumnHistoryToken extends SpreadsheetViewportS
         );
     }
 
-    @Override
+    @Override //
     final SpreadsheetNameHistoryToken formulaHistoryToken() {
         return this;
     }
 
-    @Override
-    final SpreadsheetNameHistoryToken freeze() {
+    @Override //
+    final HistoryToken freeze() {
         return columnFreeze(
                 this.id(),
                 this.name(),
@@ -83,8 +81,8 @@ abstract public class SpreadsheetColumnHistoryToken extends SpreadsheetViewportS
         );
     }
 
-    @Override
-    final SpreadsheetNameHistoryToken menu() {
+    @Override //
+    final HistoryToken menu() {
         return columnMenu(
                 this.id(),
                 this.name(),
@@ -92,33 +90,36 @@ abstract public class SpreadsheetColumnHistoryToken extends SpreadsheetViewportS
         );
     }
 
-    @Override
-    final SpreadsheetNameHistoryToken menu0(final SpreadsheetSelection selection) {
+    @Override //
+    final SpreadsheetViewportSelection menuHistoryTokenSpreadsheetViewportSelection(final SpreadsheetSelection selection) {
+        final SpreadsheetViewportSelection viewportSelection = this.viewportSelection();
+
         return selection.isColumnReference() &&
-                this.viewportSelection()
+                viewportSelection
                         .selection()
                         .testColumn(selection.toColumn()) ?
-                this :
-                this.viewportSelectionHistoryToken(
-                        Optional.of(
-                                selection.setDefaultAnchor()
-                        )
-                ).menu();
+                viewportSelection :
+                selection.setDefaultAnchor();
     }
 
-    @Override
-    SpreadsheetNameHistoryToken pattern(final SpreadsheetPatternKind patternKind) {
+    @Override //
+    HistoryToken pattern(final SpreadsheetPatternKind patternKind) {
         return this; // TODO
     }
 
-    @Override
-    SpreadsheetNameHistoryToken save(final String value) {
+    @Override //
+    HistoryToken save(final String value) {
         return this;
     }
 
-    @Override
-    public final SpreadsheetViewportSelectionHistoryToken viewportSelectionHistoryToken() {
-        return column(
+    @Override //
+    final HistoryToken style(final TextStylePropertyName<?> propertyName) {
+        return this; // column/A/style not currently supported
+    }
+
+    @Override //
+    final HistoryToken unfreeze() {
+        return columnUnfreeze(
                 this.id(),
                 this.name(),
                 this.viewportSelection()
@@ -126,13 +127,8 @@ abstract public class SpreadsheetColumnHistoryToken extends SpreadsheetViewportS
     }
 
     @Override
-    final SpreadsheetNameHistoryToken style(final TextStylePropertyName<?> propertyName) {
-        return this; // column/A/style not currently supported
-    }
-
-    @Override
-    final SpreadsheetNameHistoryToken unfreeze() {
-        return columnUnfreeze(
+    public final HistoryToken viewportSelectionHistoryToken() {
+        return column(
                 this.id(),
                 this.name(),
                 this.viewportSelection()

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingDeleteHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingDeleteHistoryToken.java
@@ -71,12 +71,12 @@ public final class SpreadsheetLabelMappingDeleteHistoryToken extends Spreadsheet
     }
 
     @Override
-    SpreadsheetNameHistoryToken delete() {
+    HistoryToken delete() {
         return this;
     }
 
     @Override
-    SpreadsheetNameHistoryToken save(final String value) {
+    HistoryToken save(final String value) {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingHistoryToken.java
@@ -23,9 +23,8 @@ import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
 import walkingkooka.tree.text.TextStylePropertyName;
-
-import java.util.Optional;
 
 public abstract class SpreadsheetLabelMappingHistoryToken extends SpreadsheetSelectionHistoryToken {
 
@@ -49,46 +48,43 @@ public abstract class SpreadsheetLabelMappingHistoryToken extends SpreadsheetSel
 
     abstract UrlFragment labelUrlFragment();
 
-    @Override
-    final SpreadsheetNameHistoryToken clear() {
+    @Override //
+    final HistoryToken clear() {
         return this;
     }
 
-    @Override
+    @Override //
     final SpreadsheetNameHistoryToken formulaHistoryToken() {
         return this;
     }
 
-    @Override
-    final SpreadsheetNameHistoryToken freeze() {
+    @Override //
+    final HistoryToken freeze() {
         return this;
     }
 
-    @Override
-    final SpreadsheetNameHistoryToken menu() {
+    @Override //
+    final HistoryToken menu() {
         return this;
     }
 
-    @Override final SpreadsheetNameHistoryToken menu0(final SpreadsheetSelection selection) {
-        return this.viewportSelectionHistoryToken(
-                Optional.of(
-                        selection.setDefaultAnchor()
-                )
-        ).menu();
+    @Override //
+    final SpreadsheetViewportSelection menuHistoryTokenSpreadsheetViewportSelection(final SpreadsheetSelection selection) {
+        return selection.setDefaultAnchor();
     }
 
-    @Override
-    SpreadsheetNameHistoryToken pattern(final SpreadsheetPatternKind patternKind) {
+    @Override //
+    HistoryToken pattern(final SpreadsheetPatternKind patternKind) {
         return this;
     }
 
-    @Override
-    final SpreadsheetNameHistoryToken style(final TextStylePropertyName<?> propertyName) {
+    @Override //
+    final HistoryToken style(final TextStylePropertyName<?> propertyName) {
         return this;
     }
 
-    @Override
-    final SpreadsheetNameHistoryToken unfreeze() {
+    @Override//
+    final HistoryToken unfreeze() {
         return this;
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingSaveHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingSaveHistoryToken.java
@@ -74,12 +74,12 @@ public final class SpreadsheetLabelMappingSaveHistoryToken extends SpreadsheetLa
     }
 
     @Override
-    SpreadsheetNameHistoryToken delete() {
+    HistoryToken delete() {
         return this;
     }
 
     @Override
-    SpreadsheetNameHistoryToken save(final String value) {
+    HistoryToken save(final String value) {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingSelectHistoryToken.java
@@ -72,7 +72,7 @@ public final class SpreadsheetLabelMappingSelectHistoryToken extends Spreadsheet
     }
 
     @Override
-    SpreadsheetNameHistoryToken delete() {
+    HistoryToken delete() {
         return labelMappingDelete(
                 this.id(),
                 this.name(),
@@ -81,7 +81,7 @@ public final class SpreadsheetLabelMappingSelectHistoryToken extends Spreadsheet
     }
 
     @Override
-    SpreadsheetNameHistoryToken save(final String value) {
+    HistoryToken save(final String value) {
         return labelMappingSave(
                 this.id(),
                 this.name(),

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataHistoryToken.java
@@ -22,9 +22,8 @@ import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
 import walkingkooka.text.cursor.TextCursor;
-
-import java.util.Optional;
 
 public abstract class SpreadsheetMetadataHistoryToken extends SpreadsheetNameHistoryToken {
 
@@ -71,46 +70,43 @@ public abstract class SpreadsheetMetadataHistoryToken extends SpreadsheetNameHis
         return result;
     }
 
-    @Override final SpreadsheetNameHistoryToken clear() {
+    @Override //
+    final HistoryToken clear() {
         return this;
     }
 
-    @Override
-    final SpreadsheetNameHistoryToken delete() {
+    @Override //
+    final HistoryToken delete() {
         return this;
     }
 
-    @Override
+    @Override //
     final SpreadsheetNameHistoryToken formulaHistoryToken() {
         return this;
     }
 
-    @Override
-    final SpreadsheetNameHistoryToken freeze() {
+    @Override //
+    final HistoryToken freeze() {
         return this;
     }
 
-    @Override
-    final SpreadsheetNameHistoryToken menu() {
+    @Override //
+    final HistoryToken menu() {
         return this;
     }
 
-    @Override
-    SpreadsheetNameHistoryToken menu0(final SpreadsheetSelection selection) {
-        return this.viewportSelectionHistoryToken(
-                Optional.of(
-                        selection.setDefaultAnchor()
-                )
-        ).menu();
+    @Override //
+    final SpreadsheetViewportSelection menuHistoryTokenSpreadsheetViewportSelection(final SpreadsheetSelection selection) {
+        return selection.setDefaultAnchor();
     }
 
-    @Override
-    final SpreadsheetNameHistoryToken pattern(final SpreadsheetPatternKind patternKind) {
+    @Override //
+    final HistoryToken pattern(final SpreadsheetPatternKind patternKind) {
         return this;
     }
 
-    @Override
-    final SpreadsheetNameHistoryToken unfreeze() {
+    @Override //
+    final HistoryToken unfreeze() {
         return this;
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySaveHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySaveHistoryToken.java
@@ -102,12 +102,12 @@ public final class SpreadsheetMetadataPropertySaveHistoryToken<T> extends Spread
     }
 
     @Override
-    SpreadsheetNameHistoryToken save(final String value) {
+    HistoryToken save(final String value) {
         return this;
     }
 
     @Override
-    SpreadsheetNameHistoryToken style(final TextStylePropertyName<?> propertyName) {
+    HistoryToken style(final TextStylePropertyName<?> propertyName) {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySelectHistoryToken.java
@@ -84,7 +84,7 @@ public final class SpreadsheetMetadataPropertySelectHistoryToken<T> extends Spre
     }
 
     @Override
-    SpreadsheetNameHistoryToken save(final String value) {
+    HistoryToken save(final String value) {
         final SpreadsheetMetadataPropertyName<T> propertyName = this.propertyName();
 
         return HistoryToken.metadataPropertySave(
@@ -100,7 +100,7 @@ public final class SpreadsheetMetadataPropertySelectHistoryToken<T> extends Spre
     }
 
     @Override
-    SpreadsheetNameHistoryToken style(final TextStylePropertyName<?> propertyName) {
+    HistoryToken style(final TextStylePropertyName<?> propertyName) {
         return HistoryToken.metadataPropertyStyle(
                 this.id(),
                 this.name(),

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleHistoryToken.java
@@ -66,7 +66,7 @@ public abstract class SpreadsheetMetadataPropertyStyleHistoryToken<T> extends Sp
     }
 
     @Override
-    SpreadsheetNameHistoryToken save(final String value) {
+    HistoryToken save(final String value) {
         final TextStylePropertyName<T> propertyName = this.stylePropertyName();
 
         return HistoryToken.metadataPropertyStyleSave(
@@ -82,7 +82,7 @@ public abstract class SpreadsheetMetadataPropertyStyleHistoryToken<T> extends Sp
     }
 
     @Override
-    SpreadsheetNameHistoryToken style(final TextStylePropertyName<?> propertyName) {
+    HistoryToken style(final TextStylePropertyName<?> propertyName) {
         return this;
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataSelectHistoryToken.java
@@ -57,12 +57,12 @@ public final class SpreadsheetMetadataSelectHistoryToken extends SpreadsheetMeta
     }
 
     @Override
-    SpreadsheetNameHistoryToken save(final String value) {
+    HistoryToken save(final String value) {
         return this;
     }
 
     @Override
-    SpreadsheetNameHistoryToken style(final TextStylePropertyName<?> propertyName) {
+    HistoryToken style(final TextStylePropertyName<?> propertyName) {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNameHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNameHistoryToken.java
@@ -57,7 +57,7 @@ public abstract class SpreadsheetNameHistoryToken extends SpreadsheetIdHistoryTo
 
     abstract UrlFragment spreadsheetUrlFragment();
 
-    final SpreadsheetNameHistoryToken cell(final SpreadsheetViewportSelection viewportSelection) {
+    final HistoryToken cell(final SpreadsheetViewportSelection viewportSelection) {
         return cell(
                 this.id(),
                 this.name(),
@@ -65,7 +65,7 @@ public abstract class SpreadsheetNameHistoryToken extends SpreadsheetIdHistoryTo
         );
     }
 
-    final SpreadsheetNameHistoryToken column(final SpreadsheetViewportSelection viewportSelection) {
+    final HistoryToken column(final SpreadsheetViewportSelection viewportSelection) {
         return column(
                 this.id(),
                 this.name(),
@@ -73,7 +73,7 @@ public abstract class SpreadsheetNameHistoryToken extends SpreadsheetIdHistoryTo
         );
     }
 
-    final SpreadsheetNameHistoryToken labelMapping(final SpreadsheetLabelName labelName) {
+    final HistoryToken labelMapping(final SpreadsheetLabelName labelName) {
         return labelMapping(
                 this.id(),
                 this.name(),
@@ -81,7 +81,7 @@ public abstract class SpreadsheetNameHistoryToken extends SpreadsheetIdHistoryTo
         );
     }
 
-    final SpreadsheetNameHistoryToken row(final SpreadsheetViewportSelection viewportSelection) {
+    final HistoryToken row(final SpreadsheetViewportSelection viewportSelection) {
         return row(
                 this.id(),
                 this.name(),
@@ -92,12 +92,12 @@ public abstract class SpreadsheetNameHistoryToken extends SpreadsheetIdHistoryTo
     /**
      * Creates a clear {@link SpreadsheetNameHistoryToken}.
      */
-    abstract SpreadsheetNameHistoryToken clear();
+    abstract HistoryToken clear();
 
     /**
      * Creates a delete {@link SpreadsheetNameHistoryToken}.
      */
-    abstract SpreadsheetNameHistoryToken delete();
+    abstract HistoryToken delete();
 
     /**
      * Creates a formula {@link SpreadsheetNameHistoryToken}.
@@ -107,47 +107,80 @@ public abstract class SpreadsheetNameHistoryToken extends SpreadsheetIdHistoryTo
     /**
      * Creates a freeze {@link SpreadsheetNameHistoryToken}.
      */
-    abstract SpreadsheetNameHistoryToken freeze();
+    abstract HistoryToken freeze();
 
     /**
      * Creates a menu {@link SpreadsheetNameHistoryToken}.
      */
-    abstract SpreadsheetNameHistoryToken menu();
+    abstract HistoryToken menu();
 
     /**
      * Creates a menu {@link SpreadsheetNameHistoryToken} for the given {@link SpreadsheetSelection}.
      */
-    final SpreadsheetNameHistoryToken menu(final SpreadsheetSelection selection) {
+    final HistoryToken menu(final SpreadsheetSelection selection) {
         Objects.requireNonNull(selection, "selection");
 
-        if(false == (selection.isCellReference() || selection.isColumnReference() || selection.isRowReference())) {
+        if (selection.isCellRange() || selection.isColumnReferenceRange() || selection.isRowReferenceRange()) {
             throw new IllegalArgumentException("Expected cell, column or row but got " + selection);
         }
 
-        return this.menu0(selection);
+        HistoryToken token;
+
+        final SpreadsheetId id = this.id();
+        final SpreadsheetName name = this.name();
+        final SpreadsheetViewportSelection menuViewportSelection = this.menuHistoryTokenSpreadsheetViewportSelection(selection);
+        final SpreadsheetSelection menuSelection = menuViewportSelection.selection();
+
+        if (menuSelection.isCellReference() || menuSelection.isCellRange() || menuSelection.isLabelName()) {
+            token = cellMenu(
+                    id,
+                    name,
+                    this.menuHistoryTokenSpreadsheetViewportSelection(selection)
+            );
+        } else {
+            if (menuSelection.isColumnReference() || menuSelection.isColumnReferenceRange()) {
+                token = columnMenu(
+                        id,
+                        name,
+                        menuViewportSelection
+                );
+            } else {
+                if (menuSelection.isRowReference() || menuSelection.isRowReferenceRange()) {
+                    token = rowMenu(
+                            id,
+                            name,
+                            menuViewportSelection
+                    );
+                } else {
+                    throw new IllegalArgumentException("Expected cell, column or row but got " + menuSelection);
+                }
+            }
+        }
+
+        return token;
     }
 
-    abstract SpreadsheetNameHistoryToken menu0(final SpreadsheetSelection selection);
+    abstract SpreadsheetViewportSelection menuHistoryTokenSpreadsheetViewportSelection(final SpreadsheetSelection selection);
 
     /**
      * Factory that creates a {@link SpreadsheetNameHistoryToken} with the given {@link SpreadsheetPatternKind}.
      */
-    abstract SpreadsheetNameHistoryToken pattern(final SpreadsheetPatternKind patternKind);
+    abstract HistoryToken pattern(final SpreadsheetPatternKind patternKind);
 
     /**
      * Creates a save {@link HistoryToken} after attempting to parse the value.
      */
-    abstract SpreadsheetNameHistoryToken save(final String value);
+    abstract HistoryToken save(final String value);
 
     /**
      * Factory that creates a {@link SpreadsheetNameHistoryToken} with the given {@link TextStylePropertyName} property name.
      */
-    abstract SpreadsheetNameHistoryToken style(final TextStylePropertyName<?> propertyName);
+    abstract HistoryToken style(final TextStylePropertyName<?> propertyName);
 
     /**
      * Creates a unfreeze {@link SpreadsheetNameHistoryToken}.
      */
-    abstract SpreadsheetNameHistoryToken unfreeze();
+    abstract HistoryToken unfreeze();
 
     final HistoryToken parsePattern(final TextCursor cursor) {
         HistoryToken result = this;
@@ -163,7 +196,7 @@ public abstract class SpreadsheetNameHistoryToken extends SpreadsheetIdHistoryTo
         return result;
     }
 
-    final SpreadsheetNameHistoryToken parseSave(final TextCursor cursor) {
+    final HistoryToken parseSave(final TextCursor cursor) {
         return this.save(
                 parseAll(cursor)
         );

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowHistoryToken.java
@@ -25,8 +25,6 @@ import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
 import walkingkooka.tree.text.TextStylePropertyName;
 
-import java.util.Optional;
-
 abstract public class SpreadsheetRowHistoryToken extends SpreadsheetViewportSelectionHistoryToken {
 
     SpreadsheetRowHistoryToken(final SpreadsheetId id,
@@ -44,15 +42,14 @@ abstract public class SpreadsheetRowHistoryToken extends SpreadsheetViewportSele
         }
     }
 
-    @Override
-    final UrlFragment selectionViewportUrlFragment() {
+    @Override final UrlFragment selectionViewportUrlFragment() {
         return this.rowUrlFragment();
     }
 
     abstract UrlFragment rowUrlFragment();
 
-    @Override
-    final SpreadsheetNameHistoryToken clear() {
+    @Override //
+    final HistoryToken clear() {
         return rowClear(
                 this.id(),
                 this.name(),
@@ -60,8 +57,8 @@ abstract public class SpreadsheetRowHistoryToken extends SpreadsheetViewportSele
         );
     }
 
-    @Override
-    final SpreadsheetNameHistoryToken delete() {
+    @Override //
+    final HistoryToken delete() {
         return rowDelete(
                 this.id(),
                 this.name(),
@@ -69,13 +66,13 @@ abstract public class SpreadsheetRowHistoryToken extends SpreadsheetViewportSele
         );
     }
 
-    @Override
+    @Override //
     final SpreadsheetNameHistoryToken formulaHistoryToken() {
         return this;
     }
 
-    @Override
-    final SpreadsheetNameHistoryToken freeze() {
+    @Override //
+    final HistoryToken freeze() {
         return rowFreeze(
                 this.id(),
                 this.name(),
@@ -83,8 +80,8 @@ abstract public class SpreadsheetRowHistoryToken extends SpreadsheetViewportSele
         );
     }
 
-    @Override
-    final SpreadsheetNameHistoryToken menu() {
+    @Override //
+    final HistoryToken menu() {
         return rowMenu(
                 this.id(),
                 this.name(),
@@ -92,28 +89,36 @@ abstract public class SpreadsheetRowHistoryToken extends SpreadsheetViewportSele
         );
     }
 
-    @Override
-    final SpreadsheetNameHistoryToken menu0(final SpreadsheetSelection selection) {
+    @Override //
+    final SpreadsheetViewportSelection menuHistoryTokenSpreadsheetViewportSelection(final SpreadsheetSelection selection) {
+        final SpreadsheetViewportSelection viewportSelection = this.viewportSelection();
+
         return selection.isRowReference() &&
-                this.viewportSelection()
+                viewportSelection
                         .selection()
                         .testRow(selection.toRow()) ?
-                this :
-                this.viewportSelectionHistoryToken(
-                        Optional.of(
-                                selection.setDefaultAnchor()
-                        )
-                ).menu();
+                viewportSelection :
+                selection.setDefaultAnchor();
     }
 
-    @Override
-    SpreadsheetNameHistoryToken pattern(final SpreadsheetPatternKind patternKind) {
+    @Override //
+    HistoryToken pattern(final SpreadsheetPatternKind patternKind) {
         return this; // TODO
     }
 
-    @Override
-    public final SpreadsheetViewportSelectionHistoryToken viewportSelectionHistoryToken() {
-        return row(
+    @Override //
+    HistoryToken save(final String value) {
+        return this;
+    }
+
+    @Override //
+    final HistoryToken style(final TextStylePropertyName<?> propertyName) {
+        return this; // row/1/style not currently supported
+    }
+
+    @Override //
+    final HistoryToken unfreeze() {
+        return rowUnfreeze(
                 this.id(),
                 this.name(),
                 this.viewportSelection()
@@ -121,18 +126,8 @@ abstract public class SpreadsheetRowHistoryToken extends SpreadsheetViewportSele
     }
 
     @Override
-    SpreadsheetNameHistoryToken save(final String value) {
-        return this;
-    }
-
-    @Override
-    final SpreadsheetNameHistoryToken style(final TextStylePropertyName<?> propertyName) {
-        return this; // row/1/style not currently supported
-    }
-
-    @Override
-    final SpreadsheetNameHistoryToken unfreeze() {
-        return rowUnfreeze(
+    public final HistoryToken viewportSelectionHistoryToken() {
+        return row(
                 this.id(),
                 this.name(),
                 this.viewportSelection()

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectHistoryToken.java
@@ -239,12 +239,12 @@ public final class SpreadsheetSelectHistoryToken extends SpreadsheetNameHistoryT
     }
 
     @Override
-    SpreadsheetNameHistoryToken clear() {
+    HistoryToken clear() {
         return this;
     }
 
     @Override
-    SpreadsheetNameHistoryToken delete() {
+    HistoryToken delete() {
         return this;
     }
 
@@ -254,27 +254,23 @@ public final class SpreadsheetSelectHistoryToken extends SpreadsheetNameHistoryT
     }
 
     @Override
-    SpreadsheetNameHistoryToken freeze() {
+    HistoryToken freeze() {
         return this;
     }
 
     @Override
-    SpreadsheetNameHistoryToken menu() {
+    HistoryToken menu() {
         return this;
     }
 
-    @Override
-    SpreadsheetNameHistoryToken menu0(final SpreadsheetSelection selection) {
-        return this.viewportSelectionHistoryToken(
-                Optional.of(
-                        selection.setDefaultAnchor()
-                )
-        ).menu();
+    @Override //
+    SpreadsheetViewportSelection menuHistoryTokenSpreadsheetViewportSelection(final SpreadsheetSelection selection) {
+        return selection.setDefaultAnchor();
     }
 
     // factory for /spreadsheet-id/spreadsheet-name/metadata/pattern/*
     @Override
-    SpreadsheetNameHistoryToken pattern(final SpreadsheetPatternKind patternKind) {
+    HistoryToken pattern(final SpreadsheetPatternKind patternKind) {
         return metadataPropertySelect(
                 this.id(),
                 this.name(),
@@ -283,13 +279,13 @@ public final class SpreadsheetSelectHistoryToken extends SpreadsheetNameHistoryT
     }
 
     @Override
-    SpreadsheetNameHistoryToken save(final String value) {
+    HistoryToken save(final String value) {
         return this;
     }
 
     // factory for /spreadsheet-id/spreadsheet-name/metadata/style/*
     @Override
-    SpreadsheetNameHistoryToken style(final TextStylePropertyName<?> propertyName) {
+    HistoryToken style(final TextStylePropertyName<?> propertyName) {
         return metadataPropertyStyle(
                 this.id(),
                 this.name(),
@@ -298,7 +294,7 @@ public final class SpreadsheetSelectHistoryToken extends SpreadsheetNameHistoryT
     }
 
     @Override
-    SpreadsheetNameHistoryToken unfreeze() {
+    HistoryToken unfreeze() {
         return this;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetViewportSelectionHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetViewportSelectionHistoryToken.java
@@ -60,8 +60,10 @@ public abstract class SpreadsheetViewportSelectionHistoryToken extends Spreadshe
     /**
      * Factory that returns a {@link SpreadsheetViewportSelectionHistoryToken} without any action and just the
      * {@link SpreadsheetViewportSelection}
+     *
+     * @return
      */
-    public abstract SpreadsheetViewportSelectionHistoryToken viewportSelectionHistoryToken();
+    public abstract HistoryToken viewportSelectionHistoryToken();
 
     final void deltaClearSelectionAndPushViewportSelectionHistoryToken(final AppContext context) {
         this.deltaClearSelection(context);

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormulaHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormulaHistoryTokenTestCase.java
@@ -18,49 +18,11 @@
 package walkingkooka.spreadsheet.dominokit.history;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
-import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
 public abstract class SpreadsheetCellFormulaHistoryTokenTestCase<T extends SpreadsheetCellFormulaHistoryToken> extends SpreadsheetCellHistoryTokenTestCase<T> {
 
     SpreadsheetCellFormulaHistoryTokenTestCase() {
         super();
-    }
-
-    // menu with selection..............................................................................................
-
-    @Test
-    public final void testCellMenuWithSameCell() {
-        final SpreadsheetCellReference cell = SpreadsheetSelection.A1;
-
-        this.menuAndCheck(
-                this.createHistoryToken(
-                        cell.setDefaultAnchor()
-                ),
-                cell,
-                HistoryToken.cellMenu(
-                        ID,
-                        NAME,
-                        cell.setDefaultAnchor()
-                )
-        );
-    }
-
-    @Test
-    public final void testCellMenuWithDifferentCell() {
-        final SpreadsheetCellReference cell = SpreadsheetSelection.parseCell("B2");
-
-        this.menuAndCheck(
-                this.createHistoryToken(
-                        SpreadsheetSelection.A1.setDefaultAnchor()
-                ),
-                cell,
-                HistoryToken.cellMenu(
-                        ID,
-                        NAME,
-                        cell.setDefaultAnchor()
-                )
-        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellHistoryTokenTestCase.java
@@ -26,6 +26,7 @@ import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
+import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelectionAnchor;
 
 public abstract class SpreadsheetCellHistoryTokenTestCase<T extends SpreadsheetCellHistoryToken> extends SpreadsheetViewportSelectionHistoryTokenTestCase<T> {
 
@@ -74,9 +75,9 @@ public abstract class SpreadsheetCellHistoryTokenTestCase<T extends SpreadsheetC
     }
 
     @Test
-    public final void testSelection() {
+    public final void testViewportSelectionHistoryToken() {
         final T token = this.createHistoryToken();
-        final SpreadsheetViewportSelectionHistoryToken selection = token.viewportSelectionHistoryToken();
+        final HistoryToken selection = token.viewportSelectionHistoryToken();
 
         this.checkEquals(
                 HistoryToken.cell(
@@ -91,6 +92,73 @@ public abstract class SpreadsheetCellHistoryTokenTestCase<T extends SpreadsheetC
     // menu with selection..............................................................................................
 
     @Test
+    public final void testCellMenuWithSameCell() {
+        final SpreadsheetCellReference cell = SpreadsheetSelection.A1;
+
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        cell.setDefaultAnchor()
+                ),
+                cell,
+                HistoryToken.cellMenu(
+                        ID,
+                        NAME,
+                        cell.setDefaultAnchor()
+                )
+        );
+    }
+
+    @Test
+    public final void testCellMenuWithDifferentCell() {
+        final SpreadsheetCellReference cell = SpreadsheetSelection.parseCell("B2");
+
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        SpreadsheetSelection.A1.setDefaultAnchor()
+                ),
+                cell,
+                HistoryToken.cellMenu(
+                        ID,
+                        NAME,
+                        cell.setDefaultAnchor()
+                )
+        );
+    }
+
+    @Test
+    public final void testCellRangeMenuWithCellInside() {
+        final SpreadsheetViewportSelection viewportSelection = SpreadsheetSelection.parseCellRange("A1:C3")
+                .setAnchor(SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT);
+
+        this.menuAndCheck(
+                this.createHistoryToken(viewportSelection),
+                SpreadsheetSelection.parseCell("B2"),
+                HistoryToken.cellMenu(
+                        ID,
+                        NAME,
+                        viewportSelection
+                )
+        );
+    }
+
+    @Test
+    public final void testCellRangeMenuWithCellOutside() {
+        final SpreadsheetCellReference cell = SpreadsheetSelection.parseCell("Z99");
+
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        SpreadsheetSelection.parseCellRange("A1:B2").setDefaultAnchor()
+                ),
+                cell,
+                HistoryToken.cellMenu(
+                        ID,
+                        NAME,
+                        cell.setDefaultAnchor()
+                )
+        );
+    }
+
+    @Test
     public final void testMenuWithColumn() {
         this.menuWithColumnAndCheck();
     }
@@ -99,7 +167,6 @@ public abstract class SpreadsheetCellHistoryTokenTestCase<T extends SpreadsheetC
     public final void testMenuWithRow() {
         this.menuWithRowAndCheck();
     }
-
 
     final void urlFragmentAndCheck(final SpreadsheetExpressionReference reference,
                                    final String expected) {

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellMenuHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellMenuHistoryTokenTest.java
@@ -20,8 +20,6 @@ package walkingkooka.spreadsheet.dominokit.history;
 import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
-import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
-import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelectionAnchor;
 
@@ -45,69 +43,6 @@ public final class SpreadsheetCellMenuHistoryTokenTest extends SpreadsheetCellHi
         this.urlFragmentAndCheck(
                 LABEL,
                 "/123/SpreadsheetName456/cell/Label123/menu"
-        );
-    }
-
-    // menu with selection..............................................................................................
-
-    @Test
-    public void testCellMenuWithSameCell() {
-        final SpreadsheetCellReference cell = SpreadsheetSelection.A1;
-
-        this.menuAndCheck(
-                this.createHistoryToken(
-                        cell.setDefaultAnchor()
-                ),
-                cell,
-                HistoryToken.cellMenu(
-                        ID,
-                        NAME,
-                        cell.setDefaultAnchor()
-                )
-        );
-    }
-
-    @Test
-    public void testCellMenuWithDifferentCell() {
-        final SpreadsheetCellReference cell = SpreadsheetSelection.parseCell("B2");
-
-        this.menuAndCheck(
-                this.createHistoryToken(
-                        SpreadsheetSelection.A1.setDefaultAnchor()
-                ),
-                cell,
-                HistoryToken.cellMenu(
-                        ID,
-                        NAME,
-                        cell.setDefaultAnchor()
-                )
-        );
-    }
-
-    @Test
-    public void testCellRangeMenuWithCellInside() {
-        this.menuAndCheck(
-                this.createHistoryToken(
-                        SpreadsheetSelection.parseCellRange("A1:C3").setDefaultAnchor()
-                ),
-                SpreadsheetSelection.parseCell("B2")
-        );
-    }
-
-    @Test
-    public void testCellRangeMenuWithCellOutside() {
-        final SpreadsheetCellReference cell = SpreadsheetSelection.parseCell("Z99");
-
-        this.menuAndCheck(
-                this.createHistoryToken(
-                        SpreadsheetSelection.parseCellRange("B2:C4").setDefaultAnchor()
-                ),
-                cell,
-                HistoryToken.cellMenu(
-                        ID,
-                        NAME,
-                        cell.setDefaultAnchor()
-                )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnHistoryTokenTestCase.java
@@ -24,6 +24,7 @@ import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReferenceRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
+import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelectionAnchor;
 
 public abstract class SpreadsheetColumnHistoryTokenTestCase<T extends SpreadsheetColumnHistoryToken> extends SpreadsheetViewportSelectionHistoryTokenTestCase<T> {
 
@@ -78,9 +79,9 @@ public abstract class SpreadsheetColumnHistoryTokenTestCase<T extends Spreadshee
     }
 
     @Test
-    public final void testSelection() {
+    public final void testViewportSelectionHistoryTokenn() {
         final T token = this.createHistoryToken();
-        final SpreadsheetViewportSelectionHistoryToken selection = token.viewportSelectionHistoryToken();
+        final HistoryToken selection = token.viewportSelectionHistoryToken();
 
         this.checkEquals(
                 HistoryToken.column(
@@ -97,6 +98,74 @@ public abstract class SpreadsheetColumnHistoryTokenTestCase<T extends Spreadshee
     @Test
     public final void testMenuWithCell() {
         this.menuWithCellAndCheck();
+    }
+
+    @Test
+    public final void testColumnMenuWithSameColumn() {
+        final SpreadsheetColumnReference column = COLUMN;
+
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        column.setDefaultAnchor()
+                ),
+                column,
+                HistoryToken.columnMenu(
+                        ID,
+                        NAME,
+                        column.setDefaultAnchor()
+                )
+        );
+    }
+
+    @Test
+    public final void testColumnMenuWithDifferentColumn() {
+        final SpreadsheetColumnReference column = COLUMN.add(1);
+
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        COLUMN.setDefaultAnchor()
+                ),
+                column,
+                HistoryToken.columnMenu(
+                        ID,
+                        NAME,
+                        column.setDefaultAnchor()
+                )
+        );
+    }
+
+
+    @Test
+    public final void testColumnRangeMenuWithColumnInside() {
+        final SpreadsheetViewportSelection viewportSelection = SpreadsheetSelection.parseColumnRange("A:C")
+                .setAnchor(SpreadsheetViewportSelectionAnchor.RIGHT);
+
+        this.menuAndCheck(
+                this.createHistoryToken(viewportSelection),
+                SpreadsheetSelection.parseColumn("B"),
+                HistoryToken.columnMenu(
+                        ID,
+                        NAME,
+                        viewportSelection
+                )
+        );
+    }
+
+    @Test
+    public final void testColumnRangeMenuWithColumnOutside() {
+        final SpreadsheetColumnReference column = SpreadsheetSelection.parseColumn("Z");
+
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        SpreadsheetSelection.parseColumnRange("A:C").setDefaultAnchor()
+                ),
+                column,
+                HistoryToken.columnMenu(
+                        ID,
+                        NAME,
+                        column.setDefaultAnchor()
+                )
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnMenuHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnMenuHistoryTokenTest.java
@@ -20,8 +20,6 @@ package walkingkooka.spreadsheet.dominokit.history;
 import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
-import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
-import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelectionAnchor;
 
@@ -39,69 +37,6 @@ public final class SpreadsheetColumnMenuHistoryTokenTest extends SpreadsheetColu
         this.urlFragmentAndCheck(
                 COLUMN_RANGE.setAnchor(SpreadsheetViewportSelectionAnchor.RIGHT),
                 "/123/SpreadsheetName456/column/B:C/right/menu"
-        );
-    }
-
-    // menu(Selection)..................................................................................................
-
-    @Test
-    public void testColumnMenuWithSameColumn() {
-        final SpreadsheetColumnReference column = SpreadsheetSelection.parseColumn("B");
-
-        this.menuAndCheck(
-                this.createHistoryToken(
-                        column.setDefaultAnchor()
-                ),
-                column,
-                HistoryToken.columnMenu(
-                        ID,
-                        NAME,
-                        column.setDefaultAnchor()
-                )
-        );
-    }
-
-    @Test
-    public void testColumnMenuWithDifferentColumn() {
-        final SpreadsheetColumnReference column = SpreadsheetSelection.parseColumn("B");
-
-        this.menuAndCheck(
-                this.createHistoryToken(
-                        SpreadsheetSelection.parseColumn("A").setDefaultAnchor()
-                ),
-                column,
-                HistoryToken.columnMenu(
-                        ID,
-                        NAME,
-                        column.setDefaultAnchor()
-                )
-        );
-    }
-
-    @Test
-    public void testColumnRangeMenuWithColumnInside() {
-        this.menuAndCheck(
-                this.createHistoryToken(
-                        SpreadsheetSelection.parseColumnRange("A:C").setDefaultAnchor()
-                ),
-                SpreadsheetSelection.parseColumn("B")
-        );
-    }
-
-    @Test
-    public void testColumnRangeMenuWithColumnOutside() {
-        final SpreadsheetColumnReference column = SpreadsheetSelection.parseColumn("Z");
-
-        this.menuAndCheck(
-                this.createHistoryToken(
-                        SpreadsheetSelection.parseColumnRange("A:C").setDefaultAnchor()
-                ),
-                column,
-                HistoryToken.columnMenu(
-                        ID,
-                        NAME,
-                        column.setDefaultAnchor()
-                )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNameHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNameHistoryTokenTestCase.java
@@ -172,13 +172,6 @@ public abstract class SpreadsheetNameHistoryTokenTestCase<T extends SpreadsheetN
     final void menuAndCheck(final SpreadsheetNameHistoryToken before,
                             final SpreadsheetSelection selection,
                             final SpreadsheetViewportSelectionHistoryToken expected) {
-        final String className = expected.getClass().getSimpleName();
-        this.checkEquals(
-                true,
-                className.contains("Menu"),
-                () -> className + " is not a Menu"
-        );
-
         this.checkEquals(
                 expected,
                 before.menu(selection),

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowHistoryTokenTestCase.java
@@ -78,9 +78,9 @@ public abstract class SpreadsheetRowHistoryTokenTestCase<T extends SpreadsheetRo
     }
 
     @Test
-    public final void testSelection() {
+    public final void testViewportSelectionHistoryTokenn() {
         final T token = this.createHistoryToken();
-        final SpreadsheetViewportSelectionHistoryToken selection = token.viewportSelectionHistoryToken();
+        final HistoryToken selection = token.viewportSelectionHistoryToken();
 
         this.checkEquals(
                 HistoryToken.row(
@@ -102,6 +102,74 @@ public abstract class SpreadsheetRowHistoryTokenTestCase<T extends SpreadsheetRo
     @Test
     public final void testMenuWithColumn() {
         this.menuWithColumnAndCheck();
+    }
+
+    @Test
+    public final void testRowMenuWithSameRow() {
+        final SpreadsheetRowReference row = ROW;
+
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        row.setDefaultAnchor()
+                ),
+                row,
+                HistoryToken.rowMenu(
+                        ID,
+                        NAME,
+                        row.setDefaultAnchor()
+                )
+        );
+    }
+
+    @Test
+    public final void testRowMenuWithDifferentRow() {
+        final SpreadsheetRowReference row = ROW.add(1);
+
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        ROW.setDefaultAnchor()
+                ),
+                row,
+                HistoryToken.rowMenu(
+                        ID,
+                        NAME,
+                        row.setDefaultAnchor()
+                )
+        );
+    }
+
+    @Test
+    public final void testRowRangeMenuWithRowInside() {
+        final SpreadsheetRowReferenceRange range = SpreadsheetSelection.parseRowRange("1:3");
+
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        range.setDefaultAnchor()
+                ),
+                SpreadsheetSelection.parseRow("2"),
+                HistoryToken.rowMenu(
+                        ID,
+                        NAME,
+                        range.setDefaultAnchor()
+                )
+        );
+    }
+
+    @Test
+    public final void testRowRangeMenuWithRowOutside() {
+        final SpreadsheetRowReference row = SpreadsheetSelection.parseRow("99");
+
+        this.menuAndCheck(
+                this.createHistoryToken(
+                        SpreadsheetSelection.parseRowRange("1:3").setDefaultAnchor()
+                ),
+                row,
+                HistoryToken.rowMenu(
+                        ID,
+                        NAME,
+                        row.setDefaultAnchor()
+                )
+        );
     }
 
     final void urlFragmentAndCheck(final SpreadsheetRowReference reference,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowMenuHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowMenuHistoryTokenTest.java
@@ -20,8 +20,6 @@ package walkingkooka.spreadsheet.dominokit.history;
 import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
-import walkingkooka.spreadsheet.reference.SpreadsheetRowReference;
-import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelectionAnchor;
 
@@ -40,69 +38,6 @@ public final class SpreadsheetRowMenuHistoryTokenTest extends SpreadsheetRowHist
         this.urlFragmentAndCheck(
                 ROW_RANGE.setAnchor(SpreadsheetViewportSelectionAnchor.BOTTOM),
                 "/123/SpreadsheetName456/row/2:3/bottom/menu"
-        );
-    }
-
-    // menu(Selection)..................................................................................................
-
-    @Test
-    public void testRowMenuWithSameRow() {
-        final SpreadsheetRowReference row = SpreadsheetSelection.parseRow("2");
-
-        this.menuAndCheck(
-                this.createHistoryToken(
-                        row.setDefaultAnchor()
-                ),
-                row,
-                HistoryToken.rowMenu(
-                        ID,
-                        NAME,
-                        row.setDefaultAnchor()
-                )
-        );
-    }
-
-    @Test
-    public void testRowMenuWithDifferentRow() {
-        final SpreadsheetRowReference row = SpreadsheetSelection.parseRow("2");
-
-        this.menuAndCheck(
-                this.createHistoryToken(
-                        SpreadsheetSelection.parseRow("1").setDefaultAnchor()
-                ),
-                row,
-                HistoryToken.rowMenu(
-                        ID,
-                        NAME,
-                        row.setDefaultAnchor()
-                )
-        );
-    }
-
-    @Test
-    public void testRowRangeMenuWithRowInside() {
-        this.menuAndCheck(
-                this.createHistoryToken(
-                        SpreadsheetSelection.parseRowRange("1:3").setDefaultAnchor()
-                ),
-                SpreadsheetSelection.parseRow("2")
-        );
-    }
-
-    @Test
-    public void testRowRangeMenuWithRowOutside() {
-        final SpreadsheetRowReference row = SpreadsheetSelection.parseRow("99");
-
-        this.menuAndCheck(
-                this.createHistoryToken(
-                        SpreadsheetSelection.parseRowRange("1:3").setDefaultAnchor()
-                ),
-                row,
-                HistoryToken.rowMenu(
-                        ID,
-                        NAME,
-                        row.setDefaultAnchor()
-                )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectionHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectionHistoryTokenTestCase.java
@@ -58,7 +58,7 @@ public abstract class SpreadsheetSelectionHistoryTokenTestCase<T extends Spreads
                         selection.setDefaultAnchor()
                 ),
                 this.createHistoryToken()
-                        .viewportSelectionHistoryToken(
+                        .setViewportSelection(
                                 Optional.of(
                                         selection.setDefaultAnchor()
                                 )
@@ -88,7 +88,7 @@ public abstract class SpreadsheetSelectionHistoryTokenTestCase<T extends Spreads
                         selection.setDefaultAnchor()
                 ),
                 this.createHistoryToken()
-                        .viewportSelectionHistoryToken(
+                        .setViewportSelection(
                                 Optional.of(
                                         selection.setDefaultAnchor()
                                 )
@@ -118,7 +118,7 @@ public abstract class SpreadsheetSelectionHistoryTokenTestCase<T extends Spreads
                         selection.setDefaultAnchor()
                 ),
                 this.createHistoryToken()
-                        .viewportSelectionHistoryToken(
+                        .setViewportSelection(
                                 Optional.of(
                                         selection.setDefaultAnchor()
                                 )


### PR DESCRIPTION
- Updated logic for menu so the result is always a menu HistoryToken.
- setViewportSelection was viewportSelectionHistoryToken, return type also changed to HistoryToken.
- new static factory viewportSelection(id, name, SpreadsheetViewportSelection), was previously instance method.