### PR TITLE
HistoryToken.setViewportSelectionDifferent

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryToken.java
@@ -665,26 +665,34 @@ public abstract class HistoryToken implements HasUrlFragment {
                                               final SpreadsheetName name);
 
     /**
-     * Factory that creates a {@link HistoryToken} only changing the {@link SpreadsheetViewportSelection} component.
+     * Factory that creates a {@link HistoryToken} changing the {@link SpreadsheetViewportSelection} component and clearing any action.
      */
     public final HistoryToken setViewportSelection(final Optional<SpreadsheetViewportSelection> viewportSelection) {
         Objects.requireNonNull(viewportSelection, "viewportSelection");
 
-        if (false == this instanceof SpreadsheetNameHistoryToken) {
-            throw new IllegalArgumentException("Unexpected token " + this);
+        return this.viewportSelectionOrEmpty().equals(viewportSelection) ?
+                this :
+                this.setDifferentViewportSelection(viewportSelection);
+    }
+
+    private HistoryToken setDifferentViewportSelection(final Optional<SpreadsheetViewportSelection> viewportSelection) {
+        HistoryToken token = this;
+
+        if (this instanceof SpreadsheetNameHistoryToken) {
+            final SpreadsheetNameHistoryToken spreadsheetNameHistoryToken = (SpreadsheetNameHistoryToken) this;
+
+            token = viewportSelection.isPresent() ?
+                    HistoryTokenSelectionSpreadsheetSelectionVisitor.selectionToken(
+                            spreadsheetNameHistoryToken,
+                            viewportSelection.get()
+                    ) :
+                    spreadsheetSelect(
+                            spreadsheetNameHistoryToken.id(),
+                            spreadsheetNameHistoryToken.name()
+                    );
         }
 
-        final SpreadsheetNameHistoryToken spreadsheetNameHistoryToken = (SpreadsheetNameHistoryToken) this;
-
-        return viewportSelection.isPresent() ?
-                HistoryTokenSelectionSpreadsheetSelectionVisitor.selectionToken(
-                        spreadsheetNameHistoryToken,
-                        viewportSelection.get()
-                ) :
-                spreadsheetSelect(
-                        spreadsheetNameHistoryToken.id(),
-                        spreadsheetNameHistoryToken.name()
-                );
+        return token;
     }
 
     /**

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellHistoryTokenTestCase.java
@@ -74,6 +74,40 @@ public abstract class SpreadsheetCellHistoryTokenTestCase<T extends SpreadsheetC
         );
     }
 
+    // setViewportSelection.............................................................................................
+
+    @Test
+    public final void testSetViewportSelectionWithSameCell() {
+        this.setViewportSelectionAndCheck(
+                CELL.setDefaultAnchor()
+        );
+    }
+
+    @Test
+    public final void testSetViewportSelectionWithSameCellRange() {
+        this.setViewportSelectionAndCheck(
+                SpreadsheetSelection.parseCellRange("A1:B2")
+                        .setAnchor(SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT)
+        );
+    }
+
+    @Test
+    public final void testSetViewportSelectionWithSameCellRange2() {
+        this.setViewportSelectionAndCheck(
+                SpreadsheetSelection.parseCellRange("A1:C3")
+                        .setAnchor(SpreadsheetViewportSelectionAnchor.TOP_LEFT)
+        );
+    }
+
+    @Test
+    public final void testSetViewportSelectionWithSameLabel() {
+        this.setViewportSelectionAndCheck(
+                LABEL.setAnchor(SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT)
+        );
+    }
+
+    // viewportSelection................................................................................................
+
     @Test
     public final void testViewportSelectionHistoryToken() {
         final T token = this.createHistoryToken();

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnHistoryTokenTestCase.java
@@ -78,6 +78,33 @@ public abstract class SpreadsheetColumnHistoryTokenTestCase<T extends Spreadshee
         );
     }
 
+    // setViewportSelection.............................................................................................
+
+    @Test
+    public final void testSetViewportSelectionWithSameColumn() {
+        this.setViewportSelectionAndCheck(
+                COLUMN.setDefaultAnchor()
+        );
+    }
+
+    @Test
+    public final void testSetViewportSelectionWithSameColumnRange() {
+        this.setViewportSelectionAndCheck(
+                SpreadsheetSelection.parseColumnRange("A:B")
+                        .setAnchor(SpreadsheetViewportSelectionAnchor.RIGHT)
+        );
+    }
+
+    @Test
+    public final void testSetViewportSelectionWithSameColumnRange2() {
+        this.setViewportSelectionAndCheck(
+                SpreadsheetSelection.parseColumnRange("A:C")
+                        .setAnchor(SpreadsheetViewportSelectionAnchor.LEFT)
+        );
+    }
+
+    // viewportSelection................................................................................................
+
     @Test
     public final void testViewportSelectionHistoryTokenn() {
         final T token = this.createHistoryToken();

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowHistoryTokenTestCase.java
@@ -24,6 +24,7 @@ import walkingkooka.spreadsheet.reference.SpreadsheetRowReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetRowReferenceRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
+import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelectionAnchor;
 
 public abstract class SpreadsheetRowHistoryTokenTestCase<T extends SpreadsheetRowHistoryToken> extends SpreadsheetViewportSelectionHistoryTokenTestCase<T> {
 
@@ -76,6 +77,33 @@ public abstract class SpreadsheetRowHistoryTokenTestCase<T extends SpreadsheetRo
                 "Got A:B expected row or row-range"
         );
     }
+
+    // setViewportSelection.............................................................................................
+
+    @Test
+    public final void testSetViewportSelectionWithSameColumn() {
+        this.setViewportSelectionAndCheck(
+                ROW.setDefaultAnchor()
+        );
+    }
+
+    @Test
+    public final void testSetViewportSelectionWithSameColumnRange() {
+        this.setViewportSelectionAndCheck(
+                SpreadsheetSelection.parseRowRange("1:2")
+                        .setAnchor(SpreadsheetViewportSelectionAnchor.TOP)
+        );
+    }
+
+    @Test
+    public final void testSetViewportSelectionWithSameColumnRange2() {
+        this.setViewportSelectionAndCheck(
+                SpreadsheetSelection.parseRowRange("1:3")
+                        .setAnchor(SpreadsheetViewportSelectionAnchor.BOTTOM)
+        );
+    }
+
+    // viewportSelection................................................................................................
 
     @Test
     public final void testViewportSelectionHistoryTokenn() {

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectionHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectionHistoryTokenTestCase.java
@@ -20,6 +20,7 @@ package walkingkooka.spreadsheet.dominokit.history;
 import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
 
 import java.util.Optional;
 
@@ -29,100 +30,110 @@ public abstract class SpreadsheetSelectionHistoryTokenTestCase<T extends Spreads
         super();
     }
 
+    // setViewportSelection.............................................................................................
+
     @Test
-    public final void testSelectionWithCell() {
-        this.selectionCellAndCheck(
-                SpreadsheetSelection.A1
+    public final void testSetViewportSelectionWithDifferentCell() {
+        this.setViewportSelectionCellAndCheck(
+                SpreadsheetSelection.parseCell("Z99")
         );
     }
 
     @Test
-    public final void testSelectionWithCellRange() {
-        this.selectionCellAndCheck(
+    public final void testSetViewportSelectionWithDifferentCellRange() {
+        this.setViewportSelectionCellAndCheck(
                 SpreadsheetSelection.parseCellRange("B2:C3")
         );
     }
 
     @Test
-    public final void testSelectionWithLabel() {
-        this.selectionCellAndCheck(
+    public final void testSetViewportSelectionWithDifferentLabel() {
+        this.setViewportSelectionCellAndCheck(
                 SpreadsheetSelection.labelName("Label123")
         );
     }
 
-    private void selectionCellAndCheck(final SpreadsheetExpressionReference selection) {
-        this.checkEquals(
+    private void setViewportSelectionCellAndCheck(final SpreadsheetExpressionReference selection) {
+        this.setViewportSelectionAndCheck(
+                selection,
                 HistoryToken.cell(
                         ID,
                         NAME,
                         selection.setDefaultAnchor()
-                ),
-                this.createHistoryToken()
-                        .setViewportSelection(
-                                Optional.of(
-                                        selection.setDefaultAnchor()
-                                )
-                        )
+                )
         );
     }
 
     @Test
-    public final void testSelectionWithColumn() {
-        this.selectionColumnAndCheck(
-                SpreadsheetSelection.parseColumn("A")
+    public final void testSetViewportSelectionWithDifferentColumn() {
+        this.setViewportSelectionColumnAndCheck(
+                SpreadsheetSelection.parseColumn("Z")
         );
     }
 
     @Test
-    public final void testSelectionWithColumnRange() {
-        this.selectionColumnAndCheck(
+    public final void testSetViewportSelectionWithDifferentColumnRange() {
+        this.setViewportSelectionColumnAndCheck(
                 SpreadsheetSelection.parseColumnRange("B:C")
         );
     }
 
-    private void selectionColumnAndCheck(final SpreadsheetSelection selection) {
-        this.checkEquals(
+    private void setViewportSelectionColumnAndCheck(final SpreadsheetSelection selection) {
+        this.setViewportSelectionAndCheck(
+                selection,
                 HistoryToken.column(
                         ID,
                         NAME,
                         selection.setDefaultAnchor()
-                ),
-                this.createHistoryToken()
-                        .setViewportSelection(
-                                Optional.of(
-                                        selection.setDefaultAnchor()
-                                )
-                        )
+                )
         );
     }
 
     @Test
-    public final void testSelectionWithRow() {
-        this.selectionRowAndCheck(
-                SpreadsheetSelection.parseRow("1")
+    public final void testSetViewportSelectionWithDifferentRow() {
+        this.setViewportSelectionRowAndCheck(
+                SpreadsheetSelection.parseRow("99")
         );
     }
 
     @Test
-    public final void testSelectionWithRowRange() {
-        this.selectionRowAndCheck(
+    public final void testSetViewportSelectionWithDifferentRowRange() {
+        this.setViewportSelectionRowAndCheck(
                 SpreadsheetSelection.parseRowRange("2:3")
         );
     }
 
-    private void selectionRowAndCheck(final SpreadsheetSelection selection) {
-        this.checkEquals(
+    private void setViewportSelectionRowAndCheck(final SpreadsheetSelection selection) {
+        this.setViewportSelectionAndCheck(
+                selection,
                 HistoryToken.row(
                         ID,
                         NAME,
                         selection.setDefaultAnchor()
-                ),
-                this.createHistoryToken()
-                        .setViewportSelection(
-                                Optional.of(
-                                        selection.setDefaultAnchor()
-                                )
+                )
+        );
+    }
+
+    private void setViewportSelectionAndCheck(final SpreadsheetSelection selection,
+                                              final HistoryToken expected) {
+        this.setViewportSelectionAndCheck(
+                this.createHistoryToken(),
+                selection.setDefaultAnchor(),
+                expected
+        );
+    }
+
+    final void setViewportSelectionAndCheck(final T token,
+                                            final SpreadsheetViewportSelection viewportSelection,
+                                            final HistoryToken expected) {
+        this.checkEquals(
+                expected,
+                token.setViewportSelection(
+                        Optional.of(
+                                viewportSelection
                         )
+                ),
+                () -> token + " setViewportSelection " + viewportSelection
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetViewportSelectionHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetViewportSelectionHistoryTokenTestCase.java
@@ -32,6 +32,20 @@ public abstract class SpreadsheetViewportSelectionHistoryTokenTestCase<T extends
         super();
     }
 
+    final void setViewportSelectionAndCheck(final SpreadsheetViewportSelection viewportSelection) {
+        final T token = this.createHistoryToken(viewportSelection);
+
+        this.setViewportSelectionAndCheck(
+                token,
+                viewportSelection,
+                token.setViewportSelection(
+                        Optional.of(
+                                viewportSelection
+                        )
+                )
+        );
+    }
+
     @Test
     public void testViewportSelectionOrEmpty() {
         final T token = this.createHistoryToken();


### PR DESCRIPTION
- If the new viewportSelection is the same return this, previously a cellSelect/columnSelect/rowSelect was created, meaning a cell menu would become a cell select history token.