### PR TITLE
SpreadsheetMetadataFetcher.patchMetadata(SpreadsheetId, JsonNode)

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/App.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/App.java
@@ -459,8 +459,7 @@ public class App implements EntryPoint, AppContext, HistoryTokenWatcher, Spreads
                 context.spreadsheetMetadataFetcher()
                         .patchMetadata(
                                 spreadsheetIdHistoryToken.id(),
-                                SpreadsheetMetadata.EMPTY.setOrRemove(
-                                        SpreadsheetMetadataPropertyName.SELECTION,
+                                SpreadsheetMetadataPropertyName.SELECTION.patch(
                                         viewportSelection.orElse(null)
                                 )
                         );

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/net/SpreadsheetMetadataFetcher.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/net/SpreadsheetMetadataFetcher.java
@@ -25,6 +25,7 @@ import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.dominokit.AppContext;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
+import walkingkooka.tree.json.JsonNode;
 
 import java.util.Objects;
 
@@ -71,9 +72,19 @@ public class SpreadsheetMetadataFetcher implements Fetcher {
                                   final T propertyValue) {
         this.patchMetadata(
                 id,
-                SpreadsheetMetadata.EMPTY.setOrRemove(
-                        propertyName,
-                        propertyValue
+                propertyName.patch(propertyValue)
+        );
+    }
+
+    /**
+     * Patches the {@link SpreadsheetMetadata}, with the patch created using {@link SpreadsheetMetadataPropertyName#patch(Object)}.
+     */
+    public void patchMetadata(final SpreadsheetId id,
+                              final JsonNode node) {
+        this.patch(
+                this.url(id),
+                this.toJson(
+                        node
                 )
         );
     }


### PR DESCRIPTION
- Fixes ignored PATCH SpreadsheetMetadata to remove the selection, which does nothing because an empty object is sent to the server.