### PR TITLE
SpreadsheetViewportWidget.onHistoryTokenChange() double focus removed

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportWidget.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportWidget.java
@@ -133,21 +133,6 @@ public final class SpreadsheetViewportWidget implements IsElement<HTMLDivElement
         final Optional<SpreadsheetViewportSelection> maybeViewportSelection = historyToken.viewportSelectionOrEmpty();
         this.setViewportSelection(maybeViewportSelection);
 
-        if (maybeViewportSelection.isPresent()) {
-            final SpreadsheetViewportSelection viewportSelection = maybeViewportSelection.get();
-
-            if (historyToken instanceof SpreadsheetCellFormulaHistoryToken) {
-                context.giveFcrmulaTextBoxFocus();
-            } else {
-                context.giveViewportFocus(
-                        viewportSelection.selection()
-                                .focused(
-                                        viewportSelection.anchor()
-                                )
-                );
-            }
-        }
-
         this.render();
     }
 


### PR DESCRIPTION
- Before this fix the focus was given to the same viewport selection or formula text box within a onHistoryTokenChange call.