### PR TITLE
SpreadsheetMetadataHistoryToken missing final modifiers added

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataHistoryToken.java
@@ -46,12 +46,11 @@ public abstract class SpreadsheetMetadataHistoryToken extends SpreadsheetNameHis
 
     abstract UrlFragment metadataUrlFragment();
 
-    @Override
-    HistoryToken parse0(final String component,
-                        final TextCursor cursor) {
+    @Override final HistoryToken parse0(final String component,
+                                        final TextCursor cursor) {
         HistoryToken result;
 
-        switch(component) {
+        switch (component) {
             case "pattern":
                 result = this.parsePattern(cursor);
                 break;
@@ -86,7 +85,7 @@ public abstract class SpreadsheetMetadataHistoryToken extends SpreadsheetNameHis
     }
 
     @Override
-    public HistoryToken formulaSaveHistoryToken(final String text) {
+    public final HistoryToken formulaSaveHistoryToken(final String text) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySaveHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySaveHistoryToken.java
@@ -23,7 +23,6 @@ import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.dominokit.AppContext;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
-import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.tree.text.TextStylePropertyName;
 
 import java.util.Objects;
@@ -67,26 +66,6 @@ public final class SpreadsheetMetadataPropertySaveHistoryToken<T> extends Spread
         return this.saveUrlFragment(
                 this.propertyValue()
         );
-    }
-
-    @Override
-    HistoryToken parse0(final String component,
-                        final TextCursor cursor) {
-        HistoryToken result = this;
-
-        switch (component) {
-            case "save":
-                result = this.parseSave(cursor);
-                break;
-            case "style":
-                result = this.parseStyle(cursor);
-                break;
-            default:
-                cursor.end();
-                break;
-        }
-
-        return result;
     }
 
     // new id/name but still metadata+property+value select

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySelectHistoryToken.java
@@ -22,7 +22,6 @@ import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.dominokit.AppContext;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
-import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.tree.text.TextStylePropertyName;
 
 import java.util.Optional;
@@ -52,24 +51,6 @@ public final class SpreadsheetMetadataPropertySelectHistoryToken<T> extends Spre
     @Override
     UrlFragment metadataPropertyUrlFragment() {
         return SELECT;
-    }
-
-    @Override
-    HistoryToken parse0(final String component,
-                        final TextCursor cursor) {
-        final HistoryToken result;
-
-        switch(component) {
-            case "save":
-                result = this.parseSave(cursor);
-                break;
-            default:
-                cursor.end();
-                result = this; // ignore
-                break;
-        }
-
-        return result;
     }
 
     // new id/name but still metadata+property select

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleHistoryToken.java
@@ -21,7 +21,6 @@ import walkingkooka.net.UrlFragment;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
-import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.tree.text.TextStyle;
 import walkingkooka.tree.text.TextStylePropertyName;
 
@@ -57,13 +56,6 @@ public abstract class SpreadsheetMetadataPropertyStyleHistoryToken<T> extends Sp
     }
 
     abstract UrlFragment styleUrlFragment();
-
-
-    @Override
-    HistoryToken parse0(final String component,
-                        final TextCursor cursor) {
-        throw new UnsupportedOperationException();
-    }
 
     @Override
     HistoryToken save(final String value) {

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSaveHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSaveHistoryToken.java
@@ -23,7 +23,6 @@ import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.dominokit.AppContext;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
-import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.tree.text.TextStyle;
 import walkingkooka.tree.text.TextStylePropertyName;
 
@@ -68,12 +67,6 @@ public final class SpreadsheetMetadataPropertyStyleSaveHistoryToken<T> extends S
         return this.saveUrlFragment(
                 this.stylePropertyValue()
         );
-    }
-
-    @Override
-    HistoryToken parse0(final String component,
-                        final TextCursor cursor) {
-        return this;
     }
 
     // new id/name but still metadata+style+property+value

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSelectHistoryToken.java
@@ -21,7 +21,6 @@ import walkingkooka.net.UrlFragment;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.dominokit.AppContext;
-import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.tree.text.TextStylePropertyName;
 
 public final class SpreadsheetMetadataPropertyStyleSelectHistoryToken<T> extends SpreadsheetMetadataPropertyStyleHistoryToken<T> {
@@ -49,29 +48,6 @@ public final class SpreadsheetMetadataPropertyStyleSelectHistoryToken<T> extends
     @Override
     UrlFragment styleUrlFragment() {
         return SELECT;
-    }
-
-    @Override
-    HistoryToken parse0(final String component,
-                        final TextCursor cursor) {
-        HistoryToken result = this;
-
-        switch (component) {
-            case "pattern":
-                result = this.parsePattern(cursor);
-                break;
-            case "save":
-                result = this.parseSave(cursor);
-                break;
-            case "style":
-                result = this.parseStyle(cursor);
-                break;
-            default:
-                cursor.end();
-                break;
-        }
-
-        return result;
     }
 
     // new id/name but still metadata+style+property select


### PR DESCRIPTION
- removed unnecessary parse0 in SpreadsheetMetadataPropertyHistoryToken sub-classes.