### PR TITLE
HistoryTokenWatchers replaces Set<HistoryWatcher>

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/App.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/App.java
@@ -39,6 +39,7 @@ import walkingkooka.spreadsheet.SpreadsheetViewportWindows;
 import walkingkooka.spreadsheet.dominokit.dom.Doms;
 import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
 import walkingkooka.spreadsheet.dominokit.history.HistoryTokenWatcher;
+import walkingkooka.spreadsheet.dominokit.history.HistoryTokenWatchers;
 import walkingkooka.spreadsheet.dominokit.history.SpreadsheetIdHistoryToken;
 import walkingkooka.spreadsheet.dominokit.history.SpreadsheetSelectionHistoryToken;
 import walkingkooka.spreadsheet.dominokit.net.SpreadsheetDeltaFetcher;
@@ -416,30 +417,12 @@ public class App implements EntryPoint, AppContext, HistoryTokenWatcher, Spreads
     private void fireOnHistoryTokenChange(final HistoryToken previous) {
         this.debug("App.fireOnHistoryTokenChange from " + previous + " to " + this.historyToken());
 
-        final String hash = DomGlobal.location.hash;
-
-        for (final HistoryTokenWatcher watcher : this.historyWatchers) {
-            final String hash2 = DomGlobal.location.hash;
-            if (false == hash.equals(hash2)) {
-                this.debug("App.fireOnHistoryTokenChange aborted " + hash + " to " + hash2);
-                break;
-            }
-
-            this.fireHistoryWatcher(
-                    previous,
-                    watcher
-            );
-        }
+        this.historyWatchers.onHistoryTokenChange(
+                previous,
+                this
+        );
 
         this.previousToken = this.historyToken();
-    }
-
-    private void fireHistoryWatcher(final HistoryToken token,
-                                    final HistoryTokenWatcher watcher) {
-        this.callAndCatch(
-                token,
-                watcher::onHistoryTokenChange
-        );
     }
 
     // AppContext history...............................................................................................
@@ -498,7 +481,7 @@ public class App implements EntryPoint, AppContext, HistoryTokenWatcher, Spreads
         this.historyWatchers.add(watcher);
     }
 
-    private final Set<HistoryTokenWatcher> historyWatchers = Sets.ordered();
+    private final HistoryTokenWatchers historyWatchers = HistoryTokenWatchers.empty();
 
     @Override
     public void onHistoryTokenChange(final HistoryToken previous,

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenWatchers.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenWatchers.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.dominokit.history;
+
+import walkingkooka.spreadsheet.dominokit.AppContext;
+import walkingkooka.store.Watchers;
+
+public final class HistoryTokenWatchers {
+
+    public static HistoryTokenWatchers empty() {
+        return new HistoryTokenWatchers();
+    }
+
+    public Runnable add(final HistoryTokenWatcher watcher) {
+        return this.watchers.addWatcher(
+                (e) -> e.accept(watcher)
+        );
+    }
+
+    public void onHistoryTokenChange(final HistoryToken previous,
+                                     final AppContext context) {
+        this.watchers.accept(
+                HistoryTokenWatchersEvent.with(
+                        previous,
+                        context
+                )
+        );
+    }
+
+    private final Watchers<HistoryTokenWatchersEvent> watchers = Watchers.create();
+
+    @Override
+    public String toString() {
+        return this.watchers.toString();
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenWatchersEvent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenWatchersEvent.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.dominokit.history;
+
+import walkingkooka.spreadsheet.dominokit.AppContext;
+
+import java.util.function.Consumer;
+
+/**
+ * The event payload used by {@link HistoryTokenWatchers}.
+ */
+final class HistoryTokenWatchersEvent implements Consumer<HistoryTokenWatcher> {
+
+    static HistoryTokenWatchersEvent with(final HistoryToken previous, final AppContext context) {
+        return new HistoryTokenWatchersEvent(previous, context);
+    }
+
+    private HistoryTokenWatchersEvent(final HistoryToken previous, final AppContext context) {
+        this.previous = previous;
+        this.context = context;
+    }
+
+    @Override
+    public void accept(final HistoryTokenWatcher watcher) {
+        try {
+            watcher.onHistoryTokenChange(
+                    this.previous,
+                    this.context
+            );
+        } catch (final Exception cause) {
+            this.context.error(
+                    "HistoryTokenWatchersEvent.accept exception: " + cause.getMessage(),
+                    cause
+            );
+        }
+    }
+
+    private final HistoryToken previous;
+
+    private final AppContext context;
+
+    @Override
+    public String toString() {
+        return this.previous + " " + this.context;
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenWatchersEventTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenWatchersEventTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.dominokit.history;
+
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
+
+public final class HistoryTokenWatchersEventTest implements ClassTesting<HistoryTokenWatchersEvent> {
+
+    @Override
+    public Class<HistoryTokenWatchersEvent> type() {
+        return HistoryTokenWatchersEvent.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PACKAGE_PRIVATE;
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenWatchersTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenWatchersTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.dominokit.history;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.net.UrlFragment;
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.spreadsheet.dominokit.AppContext;
+import walkingkooka.spreadsheet.dominokit.FakeAppContext;
+
+public final class HistoryTokenWatchersTest implements ClassTesting<HistoryTokenWatchers> {
+
+    @Test
+    public void testAddThenFire() {
+        final HistoryToken historyToken = HistoryToken.unknown(UrlFragment.EMPTY);
+        final AppContext appContext = new FakeAppContext();
+
+        final HistoryTokenWatchers watchers = HistoryTokenWatchers.empty();
+        watchers.add(
+                new HistoryTokenWatcher() {
+                    @Override
+                    public void onHistoryTokenChange(final HistoryToken previous,
+                                                     final AppContext context) {
+                        HistoryTokenWatchersTest.this.checkEquals(historyToken, previous);
+                        HistoryTokenWatchersTest.this.checkEquals(appContext, context);
+
+                        HistoryTokenWatchersTest.this.fired = true;
+                    }
+                });
+        watchers.onHistoryTokenChange(historyToken, appContext);
+
+        this.checkEquals(true, this.fired);
+    }
+
+    private boolean fired = false;
+
+    // ClassTesting....................................................................................................
+
+    @Override
+    public Class<HistoryTokenWatchers> type() {
+        return HistoryTokenWatchers.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PUBLIC;
+    }
+}


### PR DESCRIPTION
- Previously firing of HistoryTokenWatchers would abort if the history was changed, this guard was removed.