### PR TITLE
SpreadsheetMatcherWatchers extracted

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/App.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/App.java
@@ -28,7 +28,6 @@ import org.dominokit.domino.ui.layout.Layout;
 import org.gwtproject.core.client.Scheduler;
 import org.gwtproject.core.client.Scheduler.ScheduledCommand;
 import org.jboss.elemento.EventType;
-import walkingkooka.collect.set.Sets;
 import walkingkooka.color.Color;
 import walkingkooka.j2cl.locale.LocaleAware;
 import walkingkooka.net.UrlFragment;
@@ -47,6 +46,7 @@ import walkingkooka.spreadsheet.dominokit.net.SpreadsheetDeltaWatcher;
 import walkingkooka.spreadsheet.dominokit.net.SpreadsheetDeltaWatchers;
 import walkingkooka.spreadsheet.dominokit.net.SpreadsheetMetadataFetcher;
 import walkingkooka.spreadsheet.dominokit.net.SpreadsheetMetadataWatcher;
+import walkingkooka.spreadsheet.dominokit.net.SpreadsheetMetadataWatchers;
 import walkingkooka.spreadsheet.dominokit.viewport.SpreadsheetViewportToolbar;
 import walkingkooka.spreadsheet.dominokit.viewport.SpreadsheetViewportWidget;
 import walkingkooka.spreadsheet.engine.SpreadsheetDelta;
@@ -77,8 +77,6 @@ import walkingkooka.tree.text.WordBreak;
 import java.math.MathContext;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
-import java.util.function.BiConsumer;
 
 @LocaleAware
 public class App implements EntryPoint, AppContext, HistoryTokenWatcher, SpreadsheetMetadataWatcher, SpreadsheetDeltaWatcher, UncaughtExceptionHandler {
@@ -270,7 +268,7 @@ public class App implements EntryPoint, AppContext, HistoryTokenWatcher, Spreads
     /**
      * A collection of listeners for {@link SpreadsheetMetadataWatcher}
      */
-    final Set<SpreadsheetMetadataWatcher> metadataWatchers = Sets.ordered();
+    final SpreadsheetMetadataWatchers metadataWatchers = SpreadsheetMetadataWatchers.empty();
 
 
     @Override
@@ -289,48 +287,9 @@ public class App implements EntryPoint, AppContext, HistoryTokenWatcher, Spreads
     }
 
     private final SpreadsheetMetadataFetcher spreadsheetMetadataFetcher = SpreadsheetMetadataFetcher.with(
-            (d, c) -> this.fireSpreadsheetMetadata(d),
+            this.metadataWatchers,
             this
     );
-
-    public void fireSpreadsheetMetadata(final SpreadsheetMetadata metadata) {
-        this.spreadsheetMetadata = metadata;
-
-        final HistoryToken token = this.historyToken();
-        if (token instanceof SpreadsheetMetadataWatcher) {
-            this.fireSpreadsheetMetadata(
-                    metadata,
-                    (SpreadsheetMetadataWatcher) token
-            );
-        }
-
-        for (final SpreadsheetMetadataWatcher watcher : this.metadataWatchers) {
-            this.fireSpreadsheetMetadata(
-                    metadata,
-                    watcher
-            );
-        }
-    }
-
-    private void fireSpreadsheetMetadata(final SpreadsheetMetadata metadata,
-                                         final SpreadsheetMetadataWatcher watcher) {
-        this.callAndCatch(
-                metadata,
-                watcher::onSpreadsheetMetadata
-        );
-    }
-
-    private <T> void callAndCatch(final T value,
-                                  final BiConsumer<T, AppContext> fire) {
-        try {
-            fire.accept(
-                    value,
-                    this
-            );
-        } catch (final RuntimeException cause) {
-            this.error(cause);
-        }
-    }
 
     // misc..........................................................................................................
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/AppContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/AppContext.java
@@ -55,8 +55,6 @@ public interface AppContext extends LoggingContext, Context {
 
     SpreadsheetMetadataFetcher spreadsheetMetadataFetcher();
 
-    void fireSpreadsheetMetadata(final SpreadsheetMetadata metadata);
-
     /**
      * Returns the current or last loaded {@link SpreadsheetMetadata}.
      */

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/FakeAppContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/FakeAppContext.java
@@ -56,11 +56,6 @@ public class FakeAppContext implements AppContext {
     }
 
     @Override
-    public void fireSpreadsheetMetadata(final SpreadsheetMetadata metadata) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public SpreadsheetMetadata spreadsheetMetadata() {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/net/SpreadsheetMetadataWatchers.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/net/SpreadsheetMetadataWatchers.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.dominokit.net;
+
+import walkingkooka.spreadsheet.dominokit.AppContext;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
+import walkingkooka.store.Watchers;
+
+public final class SpreadsheetMetadataWatchers implements SpreadsheetMetadataWatcher {
+
+    public static SpreadsheetMetadataWatchers empty() {
+        return new SpreadsheetMetadataWatchers();
+    }
+
+    public Runnable add(final SpreadsheetMetadataWatcher watcher) {
+        return this.watchers.addWatcher(
+                (e) -> e.accept(watcher)
+        );
+    }
+
+    @Override
+    public void onSpreadsheetMetadata(final SpreadsheetMetadata metadata,
+                                      final AppContext context) {
+        this.watchers.accept(
+                SpreadsheetMetadataWatchersEvent.with(
+                        metadata,
+                        context
+                )
+        );
+    }
+
+    private final Watchers<SpreadsheetMetadataWatchersEvent> watchers = Watchers.create();
+
+    @Override
+    public String toString() {
+        return this.watchers.toString();
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/net/SpreadsheetMetadataWatchersEvent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/net/SpreadsheetMetadataWatchersEvent.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.dominokit.net;
+
+import walkingkooka.spreadsheet.dominokit.AppContext;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
+
+import java.util.function.Consumer;
+
+/**
+ * The event payload used by {@link SpreadsheetMetadataWatchers}.
+ */
+final class SpreadsheetMetadataWatchersEvent implements Consumer<SpreadsheetMetadataWatcher> {
+
+    static SpreadsheetMetadataWatchersEvent with(final SpreadsheetMetadata metadata,
+                                                 final AppContext context) {
+        return new SpreadsheetMetadataWatchersEvent(metadata, context);
+    }
+
+    private SpreadsheetMetadataWatchersEvent(final SpreadsheetMetadata metadata,
+                                             final AppContext context) {
+        this.metadata = metadata;
+        this.context = context;
+    }
+
+    @Override
+    public void accept(final SpreadsheetMetadataWatcher watcher) {
+        try {
+            watcher.onSpreadsheetMetadata(
+                    this.metadata,
+                    this.context
+            );
+        } catch (final Exception cause) {
+            this.context.error(
+                    "SpreadsheetMetadataWatchersEvent.accept exception: " + cause.getMessage(),
+                    cause
+            );
+        }
+    }
+
+    private final SpreadsheetMetadata metadata;
+
+    private final AppContext context;
+
+    @Override
+    public String toString() {
+        return this.metadata + " " + this.context;
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/net/SpreadsheetMetadataWatchersEventTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/net/SpreadsheetMetadataWatchersEventTest.java
@@ -15,14 +15,20 @@
  *
  */
 
-package walkingkooka.spreadsheet.dominokit;
+package walkingkooka.spreadsheet.dominokit.net;
 
-import com.google.gwt.junit.client.GWTTestCase;
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
 
-public final class AppTest extends GWTTestCase {
+public final class SpreadsheetMetadataWatchersEventTest implements ClassTesting<SpreadsheetMetadataWatchersEvent> {
 
     @Override
-    public String getModuleName() {                                         // (2)
-        return "walkingkooka.spreadsheet.dominokit.App";
+    public Class<SpreadsheetMetadataWatchersEvent> type() {
+        return SpreadsheetMetadataWatchersEvent.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PACKAGE_PRIVATE;
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/net/SpreadsheetMetadataWatchersTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/net/SpreadsheetMetadataWatchersTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.dominokit.net;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.spreadsheet.dominokit.AppContext;
+import walkingkooka.spreadsheet.dominokit.FakeAppContext;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
+
+public final class SpreadsheetMetadataWatchersTest implements ClassTesting<SpreadsheetMetadataWatchers> {
+
+    @Test
+    public void testAddThenFire() {
+        final SpreadsheetMetadata spreadsheetMetadata = SpreadsheetMetadata.EMPTY;
+        final AppContext appContext = new FakeAppContext();
+
+        final SpreadsheetMetadataWatchers watchers = SpreadsheetMetadataWatchers.empty();
+        watchers.add(
+                new SpreadsheetMetadataWatcher() {
+                    @Override
+                    public void onSpreadsheetMetadata(final SpreadsheetMetadata metadata,
+                                                      final AppContext context) {
+                        SpreadsheetMetadataWatchersTest.this.checkEquals(spreadsheetMetadata, metadata);
+                        SpreadsheetMetadataWatchersTest.this.checkEquals(appContext, context);
+
+                        SpreadsheetMetadataWatchersTest.this.fired = true;
+                    }
+                });
+        watchers.onSpreadsheetMetadata(spreadsheetMetadata, appContext);
+
+        this.checkEquals(true, this.fired);
+    }
+
+    private boolean fired = false;
+
+    // ClassTesting....................................................................................................
+
+    @Override
+    public Class<SpreadsheetMetadataWatchers> type() {
+        return SpreadsheetMetadataWatchers.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PUBLIC;
+    }
+}


### PR DESCRIPTION
- AppContext.fireSpreadsheetMetadata removed
- App.fireSpreadsheetMetadata check if historyToken implements SpreadsheetMetadataWatcher removed because was unused.