### PR TITLE
SpreadsheetCellPatternSelectHistoryToken.setPattern replace if different

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternSelectHistoryToken.java
@@ -71,7 +71,18 @@ public final class SpreadsheetCellPatternSelectHistoryToken extends SpreadsheetC
 
     @Override
     HistoryToken setPattern0(final SpreadsheetPatternKind patternKind) {
-        return this;
+        return this.patternKind().equals(patternKind) ?
+                this :
+                this.replacePatternKind(patternKind);
+    }
+
+    private HistoryToken replacePatternKind(final SpreadsheetPatternKind patternKind) {
+        return new SpreadsheetCellPatternSelectHistoryToken(
+                this.id(),
+                this.name(),
+                this.viewportSelection(),
+                patternKind
+        );
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellHistoryTokenTestCase.java
@@ -36,7 +36,7 @@ public abstract class SpreadsheetCellHistoryTokenTestCase<T extends SpreadsheetC
 
     final static SpreadsheetLabelName LABEL = SpreadsheetSelection.labelName("Label123");
 
-    private final static SpreadsheetViewportSelection VIEWPORT_SELECTION = CELL.setDefaultAnchor();
+    final static SpreadsheetViewportSelection VIEWPORT_SELECTION = CELL.setDefaultAnchor();
 
     SpreadsheetCellHistoryTokenTestCase() {
         super();

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternSelectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternSelectHistoryTokenTest.java
@@ -24,7 +24,67 @@ import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelectionAnchor;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
+
 public final class SpreadsheetCellPatternSelectHistoryTokenTest extends SpreadsheetCellPatternHistoryTokenTestCase<SpreadsheetCellPatternSelectHistoryToken> {
+
+    private final static SpreadsheetPatternKind KIND = SpreadsheetPatternKind.DATE_FORMAT_PATTERN;
+
+    // setPattern......................................................................................................
+
+    @Test
+    public void testSetPatternKindSame() {
+        final SpreadsheetCellPatternSelectHistoryToken historyToken = this.createHistoryToken();
+        assertSame(
+                historyToken,
+                historyToken.setPattern(KIND)
+        );
+    }
+
+    @Test
+    public void testSetPatterKindDifferent() {
+        final SpreadsheetPatternKind different = SpreadsheetPatternKind.TEXT_FORMAT_PATTERN;
+
+        this.setPatternKindAndCheck(
+                this.createHistoryToken(),
+                different,
+                SpreadsheetCellPatternSelectHistoryToken.with(
+                        ID,
+                        NAME,
+                        VIEWPORT_SELECTION,
+                        different
+                )
+        );
+    }
+
+    @Test
+    public void testSetPatterKindDifferent2() {
+        final SpreadsheetPatternKind different = SpreadsheetPatternKind.TIME_FORMAT_PATTERN;
+
+        this.setPatternKindAndCheck(
+                this.createHistoryToken(),
+                different,
+                SpreadsheetCellPatternSelectHistoryToken.with(
+                        ID,
+                        NAME,
+                        VIEWPORT_SELECTION,
+                        different
+                )
+        );
+    }
+
+    private void setPatternKindAndCheck(
+            final SpreadsheetCellPatternSelectHistoryToken historyToken,
+            final SpreadsheetPatternKind kind,
+            final HistoryToken expected) {
+        this.checkEquals(
+                expected,
+                historyToken.setPattern(kind),
+                () -> historyToken + " setPatternKind " + kind
+        );
+    }
+
+    // urlFragment......................................................................................................
 
     @Test
     public void testUrlFragmentCell() {
@@ -55,7 +115,7 @@ public final class SpreadsheetCellPatternSelectHistoryTokenTest extends Spreadsh
                 id,
                 name,
                 viewportSelection,
-                SpreadsheetPatternKind.DATE_FORMAT_PATTERN
+                KIND
         );
     }
 


### PR DESCRIPTION
- Previously setPattern ignored different patterns and always returned this.