### PR TITLE
AppContext.viewportCache() extracted from SpreadsheetViewportWidget

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/AppContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/AppContext.java
@@ -21,7 +21,6 @@ import elemental2.dom.Element;
 import org.dominokit.domino.ui.dropdown.DropdownAction;
 import walkingkooka.Context;
 import walkingkooka.spreadsheet.SpreadsheetCell;
-import walkingkooka.spreadsheet.SpreadsheetViewportWindows;
 import walkingkooka.spreadsheet.dominokit.dom.Anchor;
 import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
 import walkingkooka.spreadsheet.dominokit.history.HistoryTokenContext;
@@ -30,6 +29,7 @@ import walkingkooka.spreadsheet.dominokit.net.SpreadsheetDeltaFetcher;
 import walkingkooka.spreadsheet.dominokit.net.SpreadsheetDeltaWatcher;
 import walkingkooka.spreadsheet.dominokit.net.SpreadsheetMetadataFetcher;
 import walkingkooka.spreadsheet.dominokit.net.SpreadsheetMetadataWatcher;
+import walkingkooka.spreadsheet.dominokit.viewport.SpreadsheetViewportCache;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelection;
@@ -100,9 +100,9 @@ public interface AppContext extends HistoryTokenContext, LoggingContext, Context
     void setFormula(final SpreadsheetSelection selection);
 
     /**
-     * Clears the viewport cache of cells and more.
+     * A cache for the viewport cache.
      */
-    void viewportCacheClear();
+    SpreadsheetViewportCache viewportCache();
 
     /**
      * Getter that returns a {@link SpreadsheetCell} if one exists for the {@link SpreadsheetSelection},
@@ -123,15 +123,7 @@ public interface AppContext extends HistoryTokenContext, LoggingContext, Context
      * Returns a {@link SpreadsheetSelection} resolving labels for the current viewport selection.
      * This basically exists to resolve labels to cells or cell-ranges.
      */
-    default Optional<SpreadsheetSelection> viewportNonLabelSelection() {
-        return this.viewportSelection()
-                .flatMap(this::nonLabelSelection);
-    }
-
-    /**
-     * Getter that returns the ranges of the viewport window.
-     */
-    SpreadsheetViewportWindows viewportWindow();
+    Optional<SpreadsheetSelection> viewportNonLabelSelection();
 
     TextStyle viewportAllStyle(final boolean selected);
 
@@ -140,12 +132,6 @@ public interface AppContext extends HistoryTokenContext, LoggingContext, Context
     TextStyle viewportColumnHeaderStyle(final boolean selected);
 
     TextStyle viewportRowHeaderStyle(final boolean selected);
-
-    /**
-     * If the {@link SpreadsheetSelection} is a {@link walkingkooka.spreadsheet.reference.SpreadsheetLabelName}
-     * return a {link SpreadsheetCellReference} otherwise return the original {@link SpreadsheetSelection}.
-     */
-    Optional<SpreadsheetSelection> nonLabelSelection(final SpreadsheetSelection selection);
 
     /**
      * If the {@link SpreadsheetSelection} is present, the element will be given focus.

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/FakeAppContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/FakeAppContext.java
@@ -19,13 +19,13 @@ package walkingkooka.spreadsheet.dominokit;
 
 import elemental2.dom.Element;
 import walkingkooka.spreadsheet.SpreadsheetCell;
-import walkingkooka.spreadsheet.SpreadsheetViewportWindows;
 import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
 import walkingkooka.spreadsheet.dominokit.history.HistoryTokenWatcher;
 import walkingkooka.spreadsheet.dominokit.net.SpreadsheetDeltaFetcher;
 import walkingkooka.spreadsheet.dominokit.net.SpreadsheetDeltaWatcher;
 import walkingkooka.spreadsheet.dominokit.net.SpreadsheetMetadataFetcher;
 import walkingkooka.spreadsheet.dominokit.net.SpreadsheetMetadataWatcher;
+import walkingkooka.spreadsheet.dominokit.viewport.SpreadsheetViewportCache;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallContext;
@@ -116,17 +116,17 @@ public class FakeAppContext implements AppContext {
     }
 
     @Override
-    public void viewportCacheClear() {
+    public SpreadsheetViewportCache viewportCache() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<SpreadsheetSelection> viewportNonLabelSelection() {
         throw new UnsupportedOperationException();
     }
 
     @Override
     public Optional<SpreadsheetCell> viewportCell(final SpreadsheetSelection selection) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public SpreadsheetViewportWindows viewportWindow() {
         throw new UnsupportedOperationException();
     }
 
@@ -147,11 +147,6 @@ public class FakeAppContext implements AppContext {
 
     @Override
     public TextStyle viewportRowHeaderStyle(final boolean selected) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Optional<SpreadsheetSelection> nonLabelSelection(final SpreadsheetSelection selection) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormulaSaveHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormulaSaveHistoryToken.java
@@ -118,7 +118,8 @@ public final class SpreadsheetCellFormulaSaveHistoryToken extends SpreadsheetCel
                 ).setQuery(
                         SpreadsheetDeltaFetcher.appendViewportSelectionAndWindow(
                                 viewportSelection,
-                                context.viewportWindow(),
+                                context.viewportCache()
+                                        .windows(),
                                 UrlQueryString.EMPTY
                         )
                 ),

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternSaveHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternSaveHistoryToken.java
@@ -126,7 +126,8 @@ public final class SpreadsheetCellPatternSaveHistoryToken extends SpreadsheetCel
                 ).setQuery(
                         SpreadsheetDeltaFetcher.appendViewportSelectionAndWindow(
                                 viewportSelection,
-                                context.viewportWindow(),
+                                context.viewportCache()
+                                        .windows(),
                                 UrlQueryString.EMPTY
                         )
                 ),

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleSaveHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleSaveHistoryToken.java
@@ -110,7 +110,8 @@ final public class SpreadsheetCellStyleSaveHistoryToken<T> extends SpreadsheetCe
                 ).setQuery(
                         SpreadsheetDeltaFetcher.appendViewportSelectionAndWindow(
                                 viewportSelection,
-                                context.viewportWindow(),
+                                context.viewportCache()
+                                        .windows(),
                                 UrlQueryString.EMPTY
                         )
                 ),

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetViewportSelectionHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetViewportSelectionHistoryToken.java
@@ -116,7 +116,8 @@ public abstract class SpreadsheetViewportSelectionHistoryToken extends Spreadshe
                 ).setQuery(
                         SpreadsheetDeltaFetcher.appendViewportSelectionAndWindow(
                                 viewportSelection,
-                                context.viewportWindow(),
+                                context.viewportCache()
+                                        .windows(),
                                 UrlQueryString.EMPTY
                         )
                 ),
@@ -196,7 +197,8 @@ public abstract class SpreadsheetViewportSelectionHistoryToken extends Spreadshe
     final void giveViewportFocus(final AppContext context) {
         final SpreadsheetViewportSelection viewportSelection = this.viewportSelection();
         final SpreadsheetSelection selection = viewportSelection.selection();
-        final Optional<SpreadsheetSelection> maybeNonLabelSelection = context.nonLabelSelection(selection);
+        final Optional<SpreadsheetSelection> maybeNonLabelSelection = context.viewportCache()
+                .nonLabelSelection(selection);
 
         if (maybeNonLabelSelection.isPresent()) {
             final SpreadsheetSelection nonLabelSelection = maybeNonLabelSelection.get();

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/net/SpreadsheetDeltaFetcher.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/net/SpreadsheetDeltaFetcher.java
@@ -166,7 +166,8 @@ public class SpreadsheetDeltaFetcher implements Fetcher {
                         Optional.empty()
                 ).setQuery(
                         SpreadsheetDeltaFetcher.appendWindow(
-                                this.context.viewportWindow(),
+                                this.context.viewportCache()
+                                        .windows(),
                                 UrlQueryString.EMPTY
                         )
                 )

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportCache.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportCache.java
@@ -230,12 +230,12 @@ public final class SpreadsheetViewportCache implements SpreadsheetDeltaWatcher, 
      * Attempts to resolve any labels to a non label {@link SpreadsheetSelection}.
      * This is useful when trying to show selected cells for a label.
      */
-    Optional<SpreadsheetSelection> nonLabelSelection(final SpreadsheetSelection selection) {
+    public Optional<SpreadsheetSelection> nonLabelSelection(final SpreadsheetSelection selection) {
         Objects.requireNonNull(selection, "selection");
 
         SpreadsheetSelection nonLabel = selection;
 
-        if(selection.isLabelName()) {
+        if (selection.isLabelName()) {
             nonLabel = this.labelToNonLabel.get((SpreadsheetLabelName) selection);
         }
 
@@ -323,7 +323,7 @@ public final class SpreadsheetViewportCache implements SpreadsheetDeltaWatcher, 
     /**
      * The viewport window.
      */
-    SpreadsheetViewportWindows windows() {
+    public SpreadsheetViewportWindows windows() {
         return this.windows;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportToolbar.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportToolbar.java
@@ -135,7 +135,9 @@ public final class SpreadsheetViewportToolbar implements HistoryTokenWatcher,
                 visibility = "visible";
 
                 // if window is missing might be browser refresh, and refreshComponents is happening before loadViewportCells etc
-                if (false == context.viewportWindow().isEmpty()) {
+                if (false == context.viewportCache()
+                        .windows()
+                        .isEmpty()) {
                     refreshComponents(selection, context);
                 }
             }
@@ -153,7 +155,8 @@ public final class SpreadsheetViewportToolbar implements HistoryTokenWatcher,
      */
     private void refreshComponents(final SpreadsheetSelection selection,
                                    final AppContext context) {
-        final SpreadsheetViewportWindows window = context.viewportWindow();
+        final SpreadsheetViewportCache cache = context.viewportCache();
+        final SpreadsheetViewportWindows window = cache.windows();
         context.debug("SpreadsheetViewportToolbar.refreshComponents begin " + selection + " window: " + window);
 
         final List<SpreadsheetViewportToolbarComponent> components = this.components;


### PR DESCRIPTION
- removed a few AppContext methods which were previously delegated to SpreadsheetViewportCache.