### PR TITLE
SpreadsheetPatternEditorWidget close button reopen fix 2/2

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportToolbarComponentButtonPattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportToolbarComponentButtonPattern.java
@@ -80,15 +80,18 @@ final class SpreadsheetViewportToolbarComponentButtonPattern extends Spreadsheet
     }
 
     /**
-     * Upon focus the history token is set {@link walkingkooka.spreadsheet.reference.SpreadsheetSelection} without the property name.
-     * A history token with the property name will actually open the {@link walkingkooka.spreadsheet.dominokit.pattern.SpreadsheetPatternEditorWidget}.
+     * Temporary fix for https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/722.
+     * Previously giving focus to the pattern icon would immediately open the {@link walkingkooka.spreadsheet.dominokit.pattern.SpreadsheetPatternEditorWidget}.
+     * This behaviour meant clicking the CLOSE button would give focus to the PATTERN ICON which would immediately re-open
+     * the {@link walkingkooka.spreadsheet.dominokit.pattern.SpreadsheetPatternEditorWidget}.
+     * This FIX also means tabbing to the PATTERN ICON results in it losing focus, this will be fixed by
+     * https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/759.
      */
     private void onFocus(final Event event) {
         final HistoryTokenContext context = this.context;
 
         context.historyToken()
                 .viewportSelectionHistoryTokenOrEmpty()
-                .map(t -> t.setPatternKind(this.spreadsheetPatternKind()))
                 .ifPresent(context::pushHistoryToken);
     }
 


### PR DESCRIPTION
- tab to pattern icon broken. TODO need to add support for url pattern /pattern without pattern kind.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/722
- SpreadsheetPatternEditorWidget Close button requires 2 clicks to close