### PR TITLE
SpreadsheetCellPatternHistoryToken click formula textBox Fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternHistoryToken.java
@@ -62,6 +62,10 @@ abstract public class SpreadsheetCellPatternHistoryToken extends SpreadsheetCell
 
     @Override
     public final HistoryToken setFormula() {
-        return this;
+        return formula(
+                this.id(),
+                this.name(),
+                this.viewportSelection()
+        );
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternHistoryTokenTestCase.java
@@ -25,6 +25,22 @@ public abstract class SpreadsheetCellPatternHistoryTokenTestCase<T extends Sprea
         super();
     }
 
+    // setFormula.......................................................................................................
+
+    @Test
+    public final void testSetFormula() {
+        final T token = this.createHistoryToken();
+
+        this.checkEquals(
+                HistoryToken.formula(
+                        ID,
+                        NAME,
+                        VIEWPORT_SELECTION
+                ),
+                token.setFormula()
+        );
+    }
+
     // setMenu1(Selection)..................................................................................................
 
     @Test


### PR DESCRIPTION
- Previously clicking on the formula textBox gave focus but did not update the history token hash.