### PR TITLE
SpreadsheetPatternEditorComponent dateParse fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/pattern/SpreadsheetPatternEditorComponentSampleRowProvider.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/pattern/SpreadsheetPatternEditorComponentSampleRowProvider.java
@@ -88,10 +88,10 @@ abstract class SpreadsheetPatternEditorComponentSampleRowProvider implements BiF
     }
 
     /**
-     * {@see SpreadsheetPatternEditorComponentSampleRowProviderDateTimeParse}
+     * {@see SpreadsheetPatternEditorComponentSampleRowProviderDateParse}
      */
     static SpreadsheetPatternEditorComponentSampleRowProvider dateParse() {
-        return SpreadsheetPatternEditorComponentSampleRowProviderDateTimeParse.INSTANCE;
+        return SpreadsheetPatternEditorComponentSampleRowProviderDateParse.INSTANCE;
     }
 
     /**


### PR DESCRIPTION
- was incorrectly using DateTimeParse

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/825
- SpreadsheetPatternEditorComponent kind=DateParse fails to parse a date/time pattern