### PR TITLE
SpreadsheetPatternEditorComponent close lifecycle consistency

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/pattern/SpreadsheetPatternEditorComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/pattern/SpreadsheetPatternEditorComponent.java
@@ -675,7 +675,6 @@ public final class SpreadsheetPatternEditorComponent implements ComponentLifecyc
         final SpreadsheetPatternEditorComponentContext context = this.context;
         context.debug("SpreadsheetPatternEditorComponent.onCloseButtonClick");
         context.close();
-        this.dialog.close();
     }
 
     /**


### PR DESCRIPTION
- Clicking close X or close button should not close the dialog. It should only update the history and eventually the SpreadsheetPatternEditorComponent history watcher will eventually call close().