### PR TITLE
Metadata panel toggle icon history token push

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/App.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/App.java
@@ -22,8 +22,11 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.GWT.UncaughtExceptionHandler;
 import elemental2.dom.DomGlobal;
 import elemental2.dom.Element;
+import elemental2.dom.Event;
 import org.dominokit.domino.ui.cards.Card;
 import org.dominokit.domino.ui.events.EventType;
+import org.dominokit.domino.ui.icons.Icon;
+import org.dominokit.domino.ui.icons.lib.Icons;
 import org.dominokit.domino.ui.layout.AppLayout;
 import org.dominokit.domino.ui.layout.RightDrawerSize;
 import org.dominokit.domino.ui.notifications.Notification;
@@ -195,11 +198,29 @@ public class App implements EntryPoint, AppContext, HistoryTokenWatcher,
                         ))
                 );
 
+        final Icon<?> rightToggleIcon = Icons.menu_open();
+        rightToggleIcon.addClickListener(this::appLayoutRightToggleIconOnClick);
+        layout.setRightDrawerToggleIcon(rightToggleIcon);
+
         DomGlobal.document.body.append(
                 layout.element()
         );
 
         return layout;
+    }
+
+    /**
+     * Handler that reacts to the right panel toggle icon being clicked, updating the history. The {@link SpreadsheetMetadataPanelComponent}
+     * will see the history token change and then open or hide itself.
+     */
+    private void appLayoutRightToggleIconOnClick(final Event event) {
+        HistoryToken token = this.historyToken();
+
+        this.pushHistoryToken(
+                this.layout.isRightDrawerOpen() ?
+                        token.metadataHide() :
+                        token.metadataShow()
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryToken.java
@@ -17,7 +17,6 @@
 
 package walkingkooka.spreadsheet.dominokit.history;
 
-import elemental2.dom.DomGlobal;
 import walkingkooka.Cast;
 import walkingkooka.net.HasUrlFragment;
 import walkingkooka.net.UrlFragment;
@@ -815,6 +814,40 @@ public abstract class HistoryToken implements HasUrlFragment {
         }
 
         return Optional.ofNullable(token);
+    }
+
+    /**
+     * Returns if a possible a {@link HistoryToken} which shows the metadata panel
+     */
+    public final HistoryToken metadataShow() {
+        HistoryToken token = this;
+
+        if (this instanceof SpreadsheetNameHistoryToken) {
+            final SpreadsheetNameHistoryToken spreadsheetNameHistoryToken = token.cast(SpreadsheetNameHistoryToken.class);
+            token = HistoryToken.metadataSelect(
+                    spreadsheetNameHistoryToken.id(),
+                    spreadsheetNameHistoryToken.name()
+            );
+        }
+
+        return token;
+    }
+
+    /**
+     * Returns if a possible a {@link HistoryToken} which hides the metadata panel
+     */
+    public final HistoryToken metadataHide() {
+        HistoryToken token = this;
+
+        if (this instanceof SpreadsheetMetadataHistoryToken) {
+            final SpreadsheetMetadataHistoryToken spreadsheetMetadataHistoryToken = token.cast(SpreadsheetMetadataHistoryToken.class);
+            token = HistoryToken.spreadsheetSelect(
+                    spreadsheetMetadataHistoryToken.id(),
+                    spreadsheetMetadataHistoryToken.name()
+            );
+        }
+
+        return token;
     }
 
     /**


### PR DESCRIPTION
- replaces original toggle icon with an identical one that includes a click listener.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/924
- Metadata panel settings icon history update when opened/closed.