### PR TITLE
SpreadsheetMetadataItemComponentNumber.pattern fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/meta/SpreadsheetMetadataItemComponentNumber.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/meta/SpreadsheetMetadataItemComponentNumber.java
@@ -52,6 +52,7 @@ final class SpreadsheetMetadataItemComponentNumber extends SpreadsheetMetadataIt
         );
 
         this.integerBox = this.integerBox()
+                .setPattern("#")
                 .setMinValue(min)
                 .setMaxValue(max)
                 .setStep(1);


### PR DESCRIPTION
- default Year property is now editable.