### PR TITLE
App selected/unselected cell style cached

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/App.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/App.java
@@ -390,6 +390,10 @@ public class App implements EntryPoint,
         final SpreadsheetMetadata previousMetadata = this.spreadsheetMetadata;
         this.spreadsheetMetadata = metadata;
 
+        final TextStyle cellStyle = metadata.effectiveStyle();
+        this.cellSelectedStyle = cellStyle.merge(CELL_SELECTED_STYLE);
+        this.cellUnselectedStyle = cellStyle.merge(CELL_UNSELECTED_STYLE);
+
         // update the global JsonNodeUnmarshallContext.
         this.unmarshallContext = JsonNodeUnmarshallContexts.basic(
                 metadata.expressionNumberKind(),
@@ -628,9 +632,12 @@ public class App implements EntryPoint,
     @Override
     public TextStyle viewportCellStyle(final boolean selected) {
         return selected ?
-                CELL_SELECTED_STYLE :
-                CELL_UNSELECTED_STYLE;
+                this.cellSelectedStyle :
+                this.cellUnselectedStyle;
     }
+
+    private TextStyle cellSelectedStyle;
+    private TextStyle cellUnselectedStyle;
 
     private final static Color BORDER_COLOR = Color.BLACK;
     private final static BorderStyle BORDER_STYLE = BorderStyle.SOLID;

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportComponent.java
@@ -666,8 +666,9 @@ public final class SpreadsheetViewportComponent implements IsElement<HTMLDivElem
         final SpreadsheetViewportCache cache = context.viewportCache();
         final Optional<SpreadsheetCell> maybeCell = cache.cell(cellReference);
 
-        TextStyle style = context.spreadsheetMetadata()
-                .effectiveStyle();
+        TextStyle style = context.viewportCellStyle(
+                this.isSelected(cellReference)
+        );
         TextNode content = null;
 
         // if an error is present add a tooltip below the cell with the error message.
@@ -686,10 +687,12 @@ public final class SpreadsheetViewportComponent implements IsElement<HTMLDivElem
                     .error();
         }
 
-        style = style.merge(
-                context.viewportCellStyle(this.isSelected(cellReference))
-                        .set(TextStylePropertyName.WIDTH, cache.columnWidth(cellReference.column()))
-                        .set(TextStylePropertyName.HEIGHT, cache.rowHeight(cellReference.row()))
+        style = style.set(
+                TextStylePropertyName.WIDTH,
+                cache.columnWidth(cellReference.column())
+        ).set(
+                TextStylePropertyName.HEIGHT,
+                cache.rowHeight(cellReference.row())
         );
 
         final TDElement td = ElementsFactory.elements.td()


### PR DESCRIPTION
- Previously the metadata effective style was merged with the selected/unselected styles from the AppContext during a renderCell.
- App.viewportCellStyle now caches the merged selected/unselected cell styles.

- Significantly lowers render time for SpreadsheetViewportComponent from 300ish to 100ms.