### PR TITLE
FetcherWatchers.addOnce support complete lifecycle fix

### DIFF
--- a/src/test/java/walkingkooka/spreadsheet/dominokit/net/FetcherWatchersTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/net/FetcherWatchersTest.java
@@ -17,11 +17,178 @@
 
 package walkingkooka.spreadsheet.dominokit.net;
 
+import elemental2.dom.Headers;
+import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
+import walkingkooka.net.Url;
+import walkingkooka.net.http.HttpMethod;
+import walkingkooka.net.http.HttpStatus;
+import walkingkooka.net.http.HttpStatusCode;
 import walkingkooka.reflect.ClassTesting;
 import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.spreadsheet.dominokit.AppContext;
+import walkingkooka.spreadsheet.dominokit.FakeAppContext;
+
+import java.util.Optional;
 
 public final class FetcherWatchersTest implements ClassTesting<FetcherWatchers<?>> {
+
+    // addOnce..........................................................................................................
+
+    @Test
+    public void testAddOnceAndFireSuccess() {
+        final TestFetcherWatchers watchers = new TestFetcherWatchers();
+
+        final AppContext context = new FakeAppContext();
+
+        final TestFetcherWatcher watcher = new TestFetcherWatcher();
+        watchers.addOnce(watcher);
+
+        watchers.onBegin(HttpMethod.GET, Url.EMPTY_RELATIVE_URL, Optional.of("Body"), context);
+        watchers.onSuccess(context);
+
+        this.checkEquals("onBeginonSuccess", watcher.toString());
+
+        watchers.onBegin(HttpMethod.GET, Url.EMPTY_RELATIVE_URL, Optional.of("Body"), context);
+        watchers.onSuccess(context);
+
+        this.checkEquals("onBeginonSuccess", watcher.toString());
+    }
+
+    @Test
+    public void testAddOnceAndFireSuccess2() {
+        final TestFetcherWatchers watchers = new TestFetcherWatchers();
+
+        final AppContext context = new FakeAppContext();
+
+        final TestFetcherWatcher onceWatcher = new TestFetcherWatcher();
+        watchers.addOnce(onceWatcher);
+
+        final TestFetcherWatcher watcher = new TestFetcherWatcher();
+        watchers.add(watcher);
+
+        watchers.onBegin(HttpMethod.GET, Url.EMPTY_RELATIVE_URL, Optional.of("Body"), context);
+        watchers.onSuccess(context);
+
+        this.checkEquals("onBeginonSuccess", onceWatcher.b.toString());
+        this.checkEquals("onBeginonSuccess", watcher.toString());
+
+        watchers.onBegin(HttpMethod.GET, Url.EMPTY_RELATIVE_URL, Optional.of("Body"), context);
+        watchers.onSuccess(context);
+
+        this.checkEquals("onBeginonSuccess", onceWatcher.b.toString());
+        this.checkEquals("onBeginonSuccessonBeginonSuccess", watcher.toString());
+    }
+
+    @Test
+    public void testAddOnceAndFireFailure() {
+        final TestFetcherWatchers watchers = new TestFetcherWatchers();
+
+        final AppContext context = new FakeAppContext();
+
+        final TestFetcherWatcher watcher = new TestFetcherWatcher();
+        watchers.addOnce(watcher);
+
+        watchers.onBegin(HttpMethod.GET, Url.EMPTY_RELATIVE_URL, Optional.of("Body"), context);
+        watchers.onFailure(HttpStatusCode.INTERNAL_SERVER_ERROR.status(), null, "Body", context);
+
+        this.checkEquals("onBeginonFailure", watcher.toString());
+
+        watchers.onBegin(HttpMethod.GET, Url.EMPTY_RELATIVE_URL, Optional.of("Body"), context);
+        watchers.onFailure(HttpStatusCode.INTERNAL_SERVER_ERROR.status(), null, "Body", context);
+
+        this.checkEquals("onBeginonFailure", watcher.toString());
+    }
+
+    @Test
+    public void testAddOnceAndFireError() {
+        final TestFetcherWatchers watchers = new TestFetcherWatchers();
+
+        final AppContext context = new FakeAppContext();
+
+        final TestFetcherWatcher watcher = new TestFetcherWatcher();
+        watchers.addOnce(watcher);
+
+        final Exception error = new Exception();
+
+        watchers.onBegin(HttpMethod.GET, Url.EMPTY_RELATIVE_URL, Optional.of("Body"), context);
+        watchers.onError(error, context);
+
+        this.checkEquals("onBeginonError", watcher.toString());
+
+        watchers.onBegin(HttpMethod.GET, Url.EMPTY_RELATIVE_URL, Optional.of("Body"), context);
+        watchers.onError(error, context);
+
+        this.checkEquals("onBeginonError", watcher.toString());
+    }
+
+    static final class TestFetcherWatchers extends FetcherWatchers<TestFetcherWatcher> {
+
+        public void onSuccess(final AppContext context) {
+            this.fire(
+                    new TestSuccessFetcherWatcherEvent(
+                            context
+                    )
+            );
+        }
+    }
+
+    static final class TestFetcherWatcher implements FetcherWatcher {
+
+        private final StringBuilder b = new StringBuilder();
+
+        @Override
+        public void onBegin(final HttpMethod method,
+                            final Url url,
+                            final Optional<String> body,
+                            final AppContext context) {
+            this.b.append("onBegin");
+        }
+
+        public void onSuccess(final AppContext context) {
+            this.b.append("onSuccess");
+        }
+
+        @Override
+        public void onFailure(final HttpStatus status,
+                              final Headers headers,
+                              final String body,
+                              final AppContext context) {
+            this.b.append("onFailure");
+        }
+
+        @Override
+        public void onError(final Object cause,
+                            final AppContext context) {
+            this.b.append("onError");
+        }
+
+        @Override
+        public String toString() {
+            return this.b.toString();
+        }
+    }
+
+    static final class TestSuccessFetcherWatcherEvent extends FetcherWatchersEvent<TestFetcherWatcher> {
+
+        TestSuccessFetcherWatcherEvent(final AppContext context) {
+            super(context);
+        }
+
+        @Override
+        public void accept(final TestFetcherWatcher watcher) {
+            watcher.onSuccess(
+                    this.context
+            );
+        }
+
+        @Override
+        public String toString() {
+            return "TestFetcherWatcherEvent";
+        }
+    }
+
+    // ClassTesting.....................................................................................................
 
     @Override
     public Class<FetcherWatchers<?>> type() {


### PR DESCRIPTION
- Cannot use Watchers.addOnce because firing an event would remove once watchers immediately resulting in those watchers being gone by the time following lifecycle events happen.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/1102
- BUG: fetcher addOnce watchers are removed after begin phase, which means the watchers never receive following lifecycle events for a single fetch