### PR TITLE
insert before column/row when cell selection update fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnInsertAfterHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnInsertAfterHistoryToken.java
@@ -89,7 +89,7 @@ public class SpreadsheetColumnInsertAfterHistoryToken extends SpreadsheetColumnI
                 );
 
         context.pushHistoryToken(
-                this.clearAction()
+                previous.clearAction()
         );
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnInsertBeforeHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnInsertBeforeHistoryToken.java
@@ -17,7 +17,6 @@
 
 package walkingkooka.spreadsheet.dominokit.history;
 
-import org.gwtproject.editor.shaded.afu.org.checkerframework.checker.oigj.qual.O;
 import walkingkooka.net.UrlFragment;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
@@ -89,11 +88,17 @@ public class SpreadsheetColumnInsertBeforeHistoryToken extends SpreadsheetColumn
                                 )
                         )
                 );
-
         context.pushHistoryToken(
-                this.clearAction()
-                        .setColumn(
-                                selection.addSaturated(count)
+                previous.clearAction()
+                        .setSelection(
+                                previous.selectionOrEmpty()
+                                        .map(
+                                                a -> a.selection()
+                                                        .addSaturated(
+                                                                count,
+                                                                0
+                                                        ).setAnchor(a.anchor())
+                                        )
                         )
         );
     }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowInsertAfterHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowInsertAfterHistoryToken.java
@@ -89,7 +89,7 @@ public class SpreadsheetRowInsertAfterHistoryToken extends SpreadsheetRowInsertH
                 );
 
         context.pushHistoryToken(
-                this.clearAction()
+                previous.clearAction()
         );
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowInsertBeforeHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowInsertBeforeHistoryToken.java
@@ -78,7 +78,7 @@ public class SpreadsheetRowInsertBeforeHistoryToken extends SpreadsheetRowInsert
         final int count = this.count();
 
         context.spreadsheetDeltaFetcher()
-                .insertBeforeColumn(
+                .insertBeforeRow(
                         this.id(),
                         selection,
                         count,
@@ -88,11 +88,17 @@ public class SpreadsheetRowInsertBeforeHistoryToken extends SpreadsheetRowInsert
                                 )
                         )
                 );
-
         context.pushHistoryToken(
-                this.clearAction()
-                        .setRow(
-                                selection.addSaturated(count)
+                previous.clearAction()
+                        .setSelection(
+                                previous.selectionOrEmpty()
+                                        .map(
+                                                a -> a.selection()
+                                                        .addSaturated(
+                                                                0,
+                                                                count
+                                                        ).setAnchor(a.anchor())
+                                        )
                         )
         );
     }


### PR DESCRIPTION
- Previously selecting a cell, opening context menu and doing a insert before column/row would result in the cell losing selection leaving just the updated column/row.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/1156
- selecting cell and inserting column from context menu, should restore original cell selection without menu history token.