### PR TITLE
Context menu anchors remove margin-left fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/AppContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/AppContext.java
@@ -148,6 +148,10 @@ public interface AppContext extends CanGiveFocus,
                             historyToken.get()
                     )
             );
+            // need to kill margin other menu items with links wont line up with text-only menu items.
+            anchor.element()
+                    .style
+                    .setProperty("margin-left", "0");
         }
         return menu;
     }


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/1170
- Anchors within a context menu shouldnt have left padding