### PR TITLE
https://github.com/mP1/walkingkooka-spreadsheet/pull/3328 Spreadsheet…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryToken.java
@@ -182,12 +182,25 @@ public abstract class HistoryToken implements HasUrlFragment {
     }
 
     /**
-     * {@see SpreadsheetCellPatternToolbarHistoryToken}
+     * {@see SpreadsheetCellPatternToolbarFormatHistoryToken}
      */
-    public static SpreadsheetCellPatternToolbarHistoryToken cellPatternToolbar(final SpreadsheetId id,
-                                                                               final SpreadsheetName name,
-                                                                               final AnchoredSpreadsheetSelection selection) {
-        return SpreadsheetCellPatternToolbarHistoryToken.with(
+    public static SpreadsheetCellPatternToolbarHistoryToken cellFormatPatternToolbar(final SpreadsheetId id,
+                                                                                     final SpreadsheetName name,
+                                                                                     final AnchoredSpreadsheetSelection selection) {
+        return SpreadsheetCellPatternToolbarFormatHistoryToken.with(
+                id,
+                name,
+                selection
+        );
+    }
+
+    /**
+     * {@see SpreadsheetCellPatternToolbarParseHistoryToken}
+     */
+    public static SpreadsheetCellPatternToolbarHistoryToken cellParsePatternToolbar(final SpreadsheetId id,
+                                                                                    final SpreadsheetName name,
+                                                                                    final AnchoredSpreadsheetSelection selection) {
+        return SpreadsheetCellPatternToolbarParseHistoryToken.with(
                 id,
                 name,
                 selection
@@ -750,11 +763,24 @@ public abstract class HistoryToken implements HasUrlFragment {
         }
         if (this instanceof SpreadsheetCellPatternSelectHistoryToken) {
             final SpreadsheetCellPatternSelectHistoryToken patternSelect = (SpreadsheetCellPatternSelectHistoryToken) this;
-            closed = cellPatternToolbar(
-                    patternSelect.id(),
-                    patternSelect.name(),
-                    patternSelect.selection()
-            );
+
+            final SpreadsheetId id = patternSelect.id();
+            final SpreadsheetName name = patternSelect.name();
+            final AnchoredSpreadsheetSelection selection = patternSelect.selection();
+
+            closed = patternSelect.patternKind()
+                    .get()
+                    .isFormatPattern() ?
+                    cellFormatPatternToolbar(
+                            id,
+                            name,
+                            selection
+                    ) :
+                    cellParsePatternToolbar(
+                            id,
+                            name,
+                            selection
+                    );
         }
         if (this instanceof SpreadsheetMetadataPropertyHistoryToken) {
             final SpreadsheetMetadataPropertyHistoryToken<?> metadata = (SpreadsheetMetadataPropertyHistoryToken<?>) this;

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellClearHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellClearHistoryToken.java
@@ -59,6 +59,11 @@ public final class SpreadsheetCellClearHistoryToken extends SpreadsheetCellHisto
     }
 
     @Override
+    public HistoryToken setFormatPattern() {
+        return this;
+    }
+
+    @Override
     public HistoryToken setFormula() {
         return setFormula0();
     }
@@ -71,6 +76,11 @@ public final class SpreadsheetCellClearHistoryToken extends SpreadsheetCellHisto
                 name,
                 this.selection()
         );
+    }
+
+    @Override
+    public HistoryToken setParsePattern() {
+        return this;
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellDeleteHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellDeleteHistoryToken.java
@@ -59,6 +59,11 @@ public final class SpreadsheetCellDeleteHistoryToken extends SpreadsheetCellHist
     }
 
     @Override
+    public HistoryToken setFormatPattern() {
+        return this;
+    }
+
+    @Override
     public HistoryToken setFormula() {
         return setFormula0();
     }
@@ -71,6 +76,11 @@ public final class SpreadsheetCellDeleteHistoryToken extends SpreadsheetCellHist
                 name,
                 this.selection()
         );
+    }
+
+    @Override
+    public HistoryToken setParsePattern() {
+        return this;
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormulaHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormulaHistoryToken.java
@@ -48,6 +48,16 @@ abstract public class SpreadsheetCellFormulaHistoryToken extends SpreadsheetCell
     abstract UrlFragment formulaUrlFragment();
 
     @Override
+    public final HistoryToken setFormatPattern() {
+        return this;
+    }
+
+    @Override
+    public final HistoryToken setParsePattern() {
+        return this;
+    }
+
+    @Override
     HistoryToken setPatternKind0(final Optional<SpreadsheetPatternKind> patternKind) {
         return this; // ignore extra pattern
     }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFreezeHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFreezeHistoryToken.java
@@ -74,6 +74,11 @@ public final class SpreadsheetCellFreezeHistoryToken extends SpreadsheetCellHist
     }
 
     @Override
+    public HistoryToken setFormatPattern() {
+        return this;
+    }
+
+    @Override
     public HistoryToken setFormula() {
         return setFormula0();
     }
@@ -86,6 +91,11 @@ public final class SpreadsheetCellFreezeHistoryToken extends SpreadsheetCellHist
                 name,
                 this.selection()
         );
+    }
+
+    @Override
+    public HistoryToken setParsePattern() {
+        return this;
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternHistoryToken.java
@@ -17,10 +17,8 @@
 
 package walkingkooka.spreadsheet.dominokit.history;
 
-import walkingkooka.net.UrlFragment;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
-import walkingkooka.spreadsheet.SpreadsheetUrlFragments;
 import walkingkooka.spreadsheet.format.pattern.HasSpreadsheetPatternKind;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
 import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
@@ -45,23 +43,21 @@ abstract public class SpreadsheetCellPatternHistoryToken extends SpreadsheetCell
     }
 
     @Override
+    public final HistoryToken setFormatPattern() {
+        return this;
+    }
+
+    @Override
+    public final HistoryToken setParsePattern() {
+        return this;
+    }
+
+    @Override
     public final Optional<SpreadsheetPatternKind> patternKind() {
         return this.patternKind;
     }
 
     private final Optional<SpreadsheetPatternKind> patternKind;
-
-    @Override
-    UrlFragment cellUrlFragment() {
-        return this.patternKind()
-                .map(k -> k.urlFragment().append(this.patternUrlFragment()))
-                .orElse(SpreadsheetUrlFragments.PATTERN);
-    }
-
-    /**
-     * Sub-classes append the action and its related parameters.
-     */
-    abstract UrlFragment patternUrlFragment();
 
     @Override
     public final HistoryToken setFormula() {

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternSaveHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternSaveHistoryToken.java
@@ -97,11 +97,19 @@ public final class SpreadsheetCellPatternSaveHistoryToken extends SpreadsheetCel
 
     private final Optional<SpreadsheetPattern> pattern;
 
+    // /cell/A1/format-pattern/text/save/@@
+    //
+    // /cell/A1/parse-pattern/date/save
     @Override
-    UrlFragment patternUrlFragment() {
-        return this.saveUrlFragment(
-                this.pattern()
-        );
+    UrlFragment cellUrlFragment() {
+        return this.patternKind()
+                .get()
+                .urlFragment()
+                .append(
+                        this.saveUrlFragment(
+                                this.pattern()
+                        )
+                );
     }
 
     @Override
@@ -127,9 +135,9 @@ public final class SpreadsheetCellPatternSaveHistoryToken extends SpreadsheetCel
 
         // clear the save from the history token.
         context.pushHistoryToken(
-                this.setPatternKind(
+                previous.setPatternKind(
                         Optional.of(kind)
-                )
+                ).clearAction()
         );
 
         final SpreadsheetDeltaFetcher fetcher = context.spreadsheetDeltaFetcher();

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternSelectHistoryToken.java
@@ -53,8 +53,10 @@ public final class SpreadsheetCellPatternSelectHistoryToken extends SpreadsheetC
     }
 
     @Override
-    UrlFragment patternUrlFragment() {
-        return SELECT;
+    UrlFragment cellUrlFragment() {
+        return this.patternKind()
+                .get()
+                .urlFragment();
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternToolbarFormatHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternToolbarFormatHistoryToken.java
@@ -20,52 +20,34 @@ package walkingkooka.spreadsheet.dominokit.history;
 import walkingkooka.net.UrlFragment;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
+import walkingkooka.spreadsheet.SpreadsheetUrlFragments;
 import walkingkooka.spreadsheet.dominokit.AppContext;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
 import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
 
-import java.util.Optional;
+/**
+ * This {@link HistoryToken} is used to represent the selection of the toolbar format-pattern icon.
+ */
+public final class SpreadsheetCellPatternToolbarFormatHistoryToken extends SpreadsheetCellPatternToolbarHistoryToken {
 
-public final class SpreadsheetCellMenuHistoryToken extends SpreadsheetCellHistoryToken {
-
-    static SpreadsheetCellMenuHistoryToken with(final SpreadsheetId id,
-                                                final SpreadsheetName name,
-                                                final AnchoredSpreadsheetSelection selection) {
-        return new SpreadsheetCellMenuHistoryToken(
+    static SpreadsheetCellPatternToolbarFormatHistoryToken with(final SpreadsheetId id,
+                                                                final SpreadsheetName name,
+                                                                final AnchoredSpreadsheetSelection selection) {
+        return new SpreadsheetCellPatternToolbarFormatHistoryToken(
                 id,
                 name,
                 selection
         );
     }
 
-    private SpreadsheetCellMenuHistoryToken(final SpreadsheetId id,
-                                            final SpreadsheetName name,
-                                            final AnchoredSpreadsheetSelection selection) {
+    private SpreadsheetCellPatternToolbarFormatHistoryToken(final SpreadsheetId id,
+                                                            final SpreadsheetName name,
+                                                            final AnchoredSpreadsheetSelection selection) {
         super(
                 id,
                 name,
                 selection
         );
-    }
-
-    @Override
-    UrlFragment cellUrlFragment() {
-        return MENU;
-    }
-
-    @Override
-    public HistoryToken clearAction() {
-        return this.selectionSelect();
-    }
-
-    @Override
-    public HistoryToken setFormatPattern() {
-        return this;
-    }
-
-    @Override
-    public HistoryToken setFormula() {
-        return setFormula0();
     }
 
     @Override
@@ -79,23 +61,18 @@ public final class SpreadsheetCellMenuHistoryToken extends SpreadsheetCellHistor
     }
 
     @Override
-    public HistoryToken setParsePattern() {
-        return this;
+    UrlFragment cellUrlFragment() {
+        return SpreadsheetUrlFragments.FORMAT_PATTERN;
     }
 
     @Override
-    HistoryToken setPatternKind0(final Optional<SpreadsheetPatternKind> patternKind) {
-        return this;
-    }
-
-    @Override
-    HistoryToken setSave0(final String value) {
-        return this;
+    boolean isCompatible(final SpreadsheetPatternKind kind) {
+        return kind.isFormatPattern();
     }
 
     @Override
     void onHistoryTokenChange0(final HistoryToken previous,
                                final AppContext context) {
-        // SpreadsheetViewportComponent will open a cell menu
+        // give focus to viewport icon
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternToolbarHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternToolbarHistoryToken.java
@@ -17,33 +17,18 @@
 
 package walkingkooka.spreadsheet.dominokit.history;
 
-import walkingkooka.net.UrlFragment;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
-import walkingkooka.spreadsheet.dominokit.AppContext;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
 import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
 
 import java.util.Optional;
 
-/**
- * This {@link HistoryToken} is used to represent the selection of the toolbar pattern icon.
- */
-public final class SpreadsheetCellPatternToolbarHistoryToken extends SpreadsheetCellPatternHistoryToken {
+public abstract class SpreadsheetCellPatternToolbarHistoryToken extends SpreadsheetCellPatternHistoryToken {
 
-    static SpreadsheetCellPatternToolbarHistoryToken with(final SpreadsheetId id,
-                                                          final SpreadsheetName name,
-                                                          final AnchoredSpreadsheetSelection selection) {
-        return new SpreadsheetCellPatternToolbarHistoryToken(
-                id,
-                name,
-                selection
-        );
-    }
-
-    private SpreadsheetCellPatternToolbarHistoryToken(final SpreadsheetId id,
-                                                      final SpreadsheetName name,
-                                                      final AnchoredSpreadsheetSelection selection) {
+    SpreadsheetCellPatternToolbarHistoryToken(final SpreadsheetId id,
+                                              final SpreadsheetName name,
+                                              final AnchoredSpreadsheetSelection selection) {
         super(
                 id,
                 name,
@@ -53,73 +38,35 @@ public final class SpreadsheetCellPatternToolbarHistoryToken extends Spreadsheet
     }
 
     @Override
-    UrlFragment patternUrlFragment() {
-        return UrlFragment.EMPTY;
-    }
-
-    @Override
-    public HistoryToken clearAction() {
+    public final HistoryToken clearAction() {
         return this;
     }
 
-    @Override
-    public HistoryToken setIdAndName(final SpreadsheetId id,
-                                     final SpreadsheetName name) {
-        return with(
-                id,
-                name,
-                this.selection()
-        );
-    }
-
-    @Override
-    HistoryToken setPatternKind0(final Optional<SpreadsheetPatternKind> patternKind) {
-        return this.patternKind().equals(patternKind) ?
+    @Override //
+    final HistoryToken setPatternKind0(final Optional<SpreadsheetPatternKind> patternKind) {
+        return false == patternKind.isPresent() ?
                 this :
-                this.replacePatternKind(patternKind);
-    }
-
-    private HistoryToken replacePatternKind(final Optional<SpreadsheetPatternKind> patternKind) {
-        final SpreadsheetId id = this.id();
-        final SpreadsheetName name = this.name();
-        final AnchoredSpreadsheetSelection selection = this.selection();
-
-        return patternKind.isPresent() ?
-                cellPattern(
-                        id,
-                        name,
-                        selection,
+                this.replacePatternKind(
                         patternKind.get()
-                ) :
-                cell(
-                        id,
-                        name,
-                        selection
                 );
     }
 
-    @Override
-    HistoryToken setSave0(final String pattern) {
-        final SpreadsheetPatternKind patternKind = this.patternKind()
-                .get();
-
-
-        return cellPatternSave(
-                this.id(),
-                this.name(),
-                this.selection(),
-                patternKind,
-                Optional.ofNullable(
-                        pattern.isEmpty() ?
-                                null :
-                                patternKind.parse(pattern)
-                )
-        );
+    private HistoryToken replacePatternKind(final SpreadsheetPatternKind patternKind) {
+        return this.isCompatible(patternKind) ?
+                cellPattern(
+                        this.id(),
+                        this.name(),
+                        this.selection(),
+                        patternKind
+                ) :
+                this;
     }
 
-    @Override
-    void onHistoryTokenChange0(final HistoryToken previous,
-                               final AppContext context) {
-        // give focus to viewport icon
+    abstract boolean isCompatible(final SpreadsheetPatternKind kind);
+
+    // ignore save value and return this.
+    @Override //
+    final HistoryToken setSave0(final String value) {
+        return this;
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternToolbarParseHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternToolbarParseHistoryToken.java
@@ -20,52 +20,34 @@ package walkingkooka.spreadsheet.dominokit.history;
 import walkingkooka.net.UrlFragment;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
+import walkingkooka.spreadsheet.SpreadsheetUrlFragments;
 import walkingkooka.spreadsheet.dominokit.AppContext;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
 import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
 
-import java.util.Optional;
+/**
+ * This {@link HistoryToken} is used to represent the selection of the toolbar format-pattern icon.
+ */
+public final class SpreadsheetCellPatternToolbarParseHistoryToken extends SpreadsheetCellPatternToolbarHistoryToken {
 
-public final class SpreadsheetCellMenuHistoryToken extends SpreadsheetCellHistoryToken {
-
-    static SpreadsheetCellMenuHistoryToken with(final SpreadsheetId id,
-                                                final SpreadsheetName name,
-                                                final AnchoredSpreadsheetSelection selection) {
-        return new SpreadsheetCellMenuHistoryToken(
+    static SpreadsheetCellPatternToolbarParseHistoryToken with(final SpreadsheetId id,
+                                                               final SpreadsheetName name,
+                                                               final AnchoredSpreadsheetSelection selection) {
+        return new SpreadsheetCellPatternToolbarParseHistoryToken(
                 id,
                 name,
                 selection
         );
     }
 
-    private SpreadsheetCellMenuHistoryToken(final SpreadsheetId id,
-                                            final SpreadsheetName name,
-                                            final AnchoredSpreadsheetSelection selection) {
+    private SpreadsheetCellPatternToolbarParseHistoryToken(final SpreadsheetId id,
+                                                           final SpreadsheetName name,
+                                                           final AnchoredSpreadsheetSelection selection) {
         super(
                 id,
                 name,
                 selection
         );
-    }
-
-    @Override
-    UrlFragment cellUrlFragment() {
-        return MENU;
-    }
-
-    @Override
-    public HistoryToken clearAction() {
-        return this.selectionSelect();
-    }
-
-    @Override
-    public HistoryToken setFormatPattern() {
-        return this;
-    }
-
-    @Override
-    public HistoryToken setFormula() {
-        return setFormula0();
     }
 
     @Override
@@ -79,23 +61,18 @@ public final class SpreadsheetCellMenuHistoryToken extends SpreadsheetCellHistor
     }
 
     @Override
-    public HistoryToken setParsePattern() {
-        return this;
+    UrlFragment cellUrlFragment() {
+        return SpreadsheetUrlFragments.PARSE_PATTERN;
     }
 
     @Override
-    HistoryToken setPatternKind0(final Optional<SpreadsheetPatternKind> patternKind) {
-        return this;
-    }
-
-    @Override
-    HistoryToken setSave0(final String value) {
-        return this;
+    boolean isCompatible(final SpreadsheetPatternKind kind) {
+        return kind.isParsePattern();
     }
 
     @Override
     void onHistoryTokenChange0(final HistoryToken previous,
                                final AppContext context) {
-        // SpreadsheetViewportComponent will open a cell menu
+        // give focus to viewport icon
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSelectHistoryToken.java
@@ -59,6 +59,15 @@ public final class SpreadsheetCellSelectHistoryToken extends SpreadsheetCellHist
     }
 
     @Override
+    public HistoryToken setFormatPattern() {
+        return cellFormatPatternToolbar(
+                this.id(),
+                this.name(),
+                this.selection()
+        );
+    }
+
+    @Override
     public HistoryToken setFormula() {
         return setFormula0();
     }
@@ -69,6 +78,15 @@ public final class SpreadsheetCellSelectHistoryToken extends SpreadsheetCellHist
         return with(
                 id,
                 name,
+                this.selection()
+        );
+    }
+
+    @Override
+    public HistoryToken setParsePattern() {
+        return cellParsePatternToolbar(
+                this.id(),
+                this.name(),
                 this.selection()
         );
     }
@@ -86,11 +104,7 @@ public final class SpreadsheetCellSelectHistoryToken extends SpreadsheetCellHist
                         selection,
                         patternKind.get()
                 ) :
-                cellPatternToolbar(
-                        id,
-                        name,
-                        selection
-                );
+                this;
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleHistoryToken.java
@@ -62,8 +62,18 @@ abstract public class SpreadsheetCellStyleHistoryToken<T> extends SpreadsheetCel
     }
 
     @Override
+    public final HistoryToken setFormatPattern() {
+        return this;
+    }
+
+    @Override
     public final HistoryToken setFormula() {
         return this.setFormula0();
+    }
+
+    @Override
+    public final HistoryToken setParsePattern() {
+        return this;
     }
 
     @Override //

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellUnfreezeHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellUnfreezeHistoryToken.java
@@ -74,6 +74,11 @@ public final class SpreadsheetCellUnfreezeHistoryToken extends SpreadsheetCellHi
     }
 
     @Override
+    public HistoryToken setFormatPattern() {
+        return this;
+    }
+
+    @Override
     public HistoryToken setFormula() {
         return this.setFormula0();
     }
@@ -86,6 +91,11 @@ public final class SpreadsheetCellUnfreezeHistoryToken extends SpreadsheetCellHi
                 name,
                 this.selection()
         );
+    }
+
+    @Override
+    public HistoryToken setParsePattern() {
+        return this;
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnHistoryToken.java
@@ -75,6 +75,11 @@ abstract public class SpreadsheetColumnHistoryToken extends AnchoredSpreadsheetS
     }
 
     @Override
+    public final HistoryToken setFormatPattern() {
+        return this;
+    }
+
+    @Override
     public final HistoryToken setFormula() {
         return this;
     }
@@ -127,6 +132,11 @@ abstract public class SpreadsheetColumnHistoryToken extends AnchoredSpreadsheetS
                         .testColumn(selection.toColumn()) ?
                 anchored :
                 selection.setDefaultAnchor();
+    }
+
+    @Override
+    public final HistoryToken setParsePattern() {
+        return this;
     }
 
     @Override //

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingHistoryToken.java
@@ -71,6 +71,11 @@ public abstract class SpreadsheetLabelMappingHistoryToken extends SpreadsheetSel
     }
 
     @Override
+    public final HistoryToken setFormatPattern() {
+        return this;
+    }
+
+    @Override
     public final HistoryToken setFormula() {
         return this;
     }
@@ -98,6 +103,11 @@ public abstract class SpreadsheetLabelMappingHistoryToken extends SpreadsheetSel
     @Override //
     final AnchoredSpreadsheetSelection setMenuSelection(final SpreadsheetSelection selection) {
         return selection.setDefaultAnchor();
+    }
+
+    @Override
+    public final HistoryToken setParsePattern() {
+        return this;
     }
 
     @Override //

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataHistoryToken.java
@@ -20,9 +20,12 @@ package walkingkooka.spreadsheet.dominokit.history;
 import walkingkooka.net.UrlFragment;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
+import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
 import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.text.cursor.TextCursor;
+
+import java.util.Optional;
 
 public abstract class SpreadsheetMetadataHistoryToken extends SpreadsheetNameHistoryToken {
 
@@ -34,7 +37,8 @@ public abstract class SpreadsheetMetadataHistoryToken extends SpreadsheetNameHis
         );
     }
 
-    @Override final UrlFragment spreadsheetUrlFragment() {
+    @Override //
+    final UrlFragment spreadsheetUrlFragment() {
         return METADATA.append(
                 this.metadataUrlFragment()
         );
@@ -47,12 +51,10 @@ public abstract class SpreadsheetMetadataHistoryToken extends SpreadsheetNameHis
     @Override //
     final HistoryToken parse0(final String component,
                               final TextCursor cursor) {
-        HistoryToken result;
+        final HistoryToken result;
 
+        Switch:
         switch (component) {
-            case "pattern":
-                result = this.parsePattern(cursor);
-                break;
             case "save":
                 result = this.parseSave(cursor);
                 break;
@@ -60,6 +62,15 @@ public abstract class SpreadsheetMetadataHistoryToken extends SpreadsheetNameHis
                 result = this.parseStyle(cursor);
                 break;
             default:
+                for (final SpreadsheetPatternKind kind : SpreadsheetPatternKind.values()) {
+                    if (kind.urlFragment().value().equals(component)) {
+                        result = this.setPatternKind(
+                                Optional.of(kind)
+                        );
+                        break Switch;
+                    }
+                }
+
                 cursor.end();
                 result = this; // ignore
                 break;
@@ -80,6 +91,11 @@ public abstract class SpreadsheetMetadataHistoryToken extends SpreadsheetNameHis
 
     @Override
     public final HistoryToken setFormula() {
+        return this;
+    }
+
+    @Override
+    public final HistoryToken setFormatPattern() {
         return this;
     }
 
@@ -106,6 +122,11 @@ public abstract class SpreadsheetMetadataHistoryToken extends SpreadsheetNameHis
     @Override //
     final AnchoredSpreadsheetSelection setMenuSelection(final SpreadsheetSelection selection) {
         return selection.setDefaultAnchor();
+    }
+
+    @Override
+    public final HistoryToken setParsePattern() {
+        return this;
     }
 
     @Override //

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyHistoryToken.java
@@ -59,10 +59,13 @@ public abstract class SpreadsheetMetadataPropertyHistoryToken<T> extends Spreads
 
     // HasUrlFragment...................................................................................................
 
-    @Override final UrlFragment metadataUrlFragment() {
-        return this.propertyName()
-                .urlFragment()
-                .append(this.metadataPropertyUrlFragment());
+    @Override //
+    final UrlFragment metadataUrlFragment() {
+        return UrlFragment.SLASH.append(
+                this.propertyName()
+                        .urlFragment()
+                        .append(this.metadataPropertyUrlFragment())
+        );
     }
 
     abstract UrlFragment metadataPropertyUrlFragment();

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNameHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNameHistoryToken.java
@@ -69,6 +69,11 @@ public abstract class SpreadsheetNameHistoryToken extends SpreadsheetIdHistoryTo
     abstract HistoryToken setDelete0();
 
     /**
+     * Creates a format pattern from {@link SpreadsheetNameHistoryToken}.
+     */
+    abstract HistoryToken setFormatPattern();
+
+    /**
      * Creates a freeze {@link SpreadsheetNameHistoryToken}.
      */
     abstract HistoryToken setFreeze0();
@@ -139,6 +144,11 @@ public abstract class SpreadsheetNameHistoryToken extends SpreadsheetIdHistoryTo
     abstract AnchoredSpreadsheetSelection setMenuSelection(final SpreadsheetSelection selection);
 
     /**
+     * Creates a parse pattern {@link SpreadsheetNameHistoryToken}.
+     */
+    abstract HistoryToken setParsePattern();
+
+    /**
      * Factory that creates a {@link SpreadsheetNameHistoryToken} with the given {@link SpreadsheetPatternKind}.
      */
     abstract HistoryToken setPatternKind0(final Optional<SpreadsheetPatternKind> patternKind);
@@ -160,13 +170,43 @@ public abstract class SpreadsheetNameHistoryToken extends SpreadsheetIdHistoryTo
 
     // parse............................................................................................................
 
-    final HistoryToken parsePattern(final TextCursor cursor) {
-        final Optional<String> patternKind = parseComponent(cursor);
-        return this.setPatternKind(
-                patternKind.map(
-                        k -> SpreadsheetPatternKind.fromTypeName("spreadsheet-" + k + "-pattern")
-                )
-        );
+    final HistoryToken parseFormatPattern(final TextCursor cursor) {
+        return this.setFormatPattern()
+                .setPatternKind(
+                        this.parsePatternKind(
+                                cursor,
+                                "/format-pattern"
+                        )
+                );
+    }
+
+    final HistoryToken parseParsePattern(final TextCursor cursor) {
+        return this.setParsePattern()
+                .setPatternKind(
+                        this.parsePatternKind(
+                                cursor,
+                                "/parse-pattern"
+                        )
+                );
+    }
+
+    private Optional<SpreadsheetPatternKind> parsePatternKind(final TextCursor cursor,
+                                                              final String prefix) {
+        return parseComponent(cursor)
+                .flatMap(
+                        k -> {
+                            SpreadsheetPatternKind kind = null;
+
+                            for (final SpreadsheetPatternKind possible : SpreadsheetPatternKind.values()) {
+                                if (possible.urlFragment().value().equals(prefix + "/" + k)) {
+                                    kind = possible;
+                                    break;
+                                }
+                            }
+
+                            return Optional.ofNullable(kind);
+                        }
+                );
     }
 
     final HistoryToken parseSave(final TextCursor cursor) {

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowHistoryToken.java
@@ -74,6 +74,11 @@ abstract public class SpreadsheetRowHistoryToken extends AnchoredSpreadsheetSele
     }
 
     @Override
+    public final HistoryToken setFormatPattern() {
+        return this;
+    }
+
+    @Override
     public final HistoryToken setFormula() {
         return this;
     }
@@ -125,6 +130,11 @@ abstract public class SpreadsheetRowHistoryToken extends AnchoredSpreadsheetSele
                         .testRow(selection.toRow()) ?
                 anchored :
                 selection.setDefaultAnchor();
+    }
+
+    @Override
+    public final HistoryToken setParsePattern() {
+        return this;
     }
 
     @Override //

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectHistoryToken.java
@@ -177,9 +177,6 @@ public final class SpreadsheetSelectHistoryToken extends SpreadsheetNameHistoryT
 
             try {
                 switch (next) {
-                    case "pattern":
-                        result = this.parsePattern(cursor);
-                        break;
                     case "style":
                         result = this.parseStyle(cursor);
                         break;
@@ -222,6 +219,11 @@ public final class SpreadsheetSelectHistoryToken extends SpreadsheetNameHistoryT
     }
 
     @Override
+    public HistoryToken setFormatPattern() {
+        return this;
+    }
+
+    @Override
     public HistoryToken setFormula() {
         return this;
     }
@@ -258,6 +260,11 @@ public final class SpreadsheetSelectHistoryToken extends SpreadsheetNameHistoryT
     @Override //
     AnchoredSpreadsheetSelection setMenuSelection(final SpreadsheetSelection selection) {
         return selection.setDefaultAnchor();
+    }
+
+    @Override
+    public HistoryToken setParsePattern() {
+        return this;
     }
 
     // factory for /spreadsheet-id/spreadsheet-name/metadata/pattern/*

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectionHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectionHistoryToken.java
@@ -53,6 +53,9 @@ abstract public class SpreadsheetSelectionHistoryToken extends SpreadsheetNameHi
             case "delete":
                 result = this.setDelete();
                 break;
+            case "format-pattern":
+                result = this.parseFormatPattern(cursor);
+                break;
             case "formula":
                 result = this.setFormula();
                 break;
@@ -72,8 +75,8 @@ abstract public class SpreadsheetSelectionHistoryToken extends SpreadsheetNameHi
             case "menu":
                 result = this.setMenu(Optional.empty());
                 break;
-            case "pattern":
-                result = this.parsePattern(cursor);
+            case "parse-pattern":
+                result = this.parseParsePattern(cursor);
                 break;
             case "save":
                 result = this.parseSave(cursor);

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTest.java
@@ -1973,10 +1973,10 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>, Parse
     // cell/pattern.......................................................................................................
 
     @Test
-    public void testParseSpreadsheetIdSpreadsheetNameCellPatternMissingPatternKind() {
+    public void testParseSpreadsheetIdSpreadsheetNameCellFormatPatternMissingPatternKind() {
         this.parseStringAndCheck(
-                "/123/SpreadsheetName456/cell/A1/pattern",
-                HistoryToken.cellPatternToolbar(
+                "/123/SpreadsheetName456/cell/A1/format-pattern",
+                HistoryToken.cellFormatPatternToolbar(
                         ID,
                         NAME,
                         CELL.setDefaultAnchor()
@@ -1985,17 +1985,33 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>, Parse
     }
 
     @Test
-    public void testParseSpreadsheetIdSpreadsheetNameCellPatternInvalidPatternKind() {
+    public void testParseSpreadsheetIdSpreadsheetNameCellParsePatternMissingPatternKind() {
         this.parseStringAndCheck(
-                "/123/SpreadsheetName456/cell/A1/pattern/!invalid",
-                CELL_HHT
+                "/123/SpreadsheetName456/cell/A1/parse-pattern",
+                HistoryToken.cellParsePatternToolbar(
+                        ID,
+                        NAME,
+                        CELL.setDefaultAnchor()
+                )
+        );
+    }
+
+    @Test
+    public void testParseSpreadsheetIdSpreadsheetNameCellFormatPatternInvalidPatternKind() {
+        this.parseStringAndCheck(
+                "/123/SpreadsheetName456/cell/A1/format-pattern/!invalid",
+                HistoryToken.cellFormatPatternToolbar(
+                        ID,
+                        NAME,
+                        CELL.setDefaultAnchor()
+                )
         );
     }
 
     @Test
     public void testParseSpreadsheetIdSpreadsheetNameCellPatternPatternKind() {
         this.parseStringAndCheck(
-                "/123/SpreadsheetName456/cell/A1/pattern/date-format",
+                "/123/SpreadsheetName456/cell/A1/format-pattern/date",
                 HistoryToken.cellPattern(
                         ID,
                         NAME,
@@ -2008,7 +2024,7 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>, Parse
     @Test
     public void testParseSpreadsheetIdSpreadsheetNameCellPatternSaveEmptyDateFormat() {
         this.parseStringAndCheck(
-                "/123/SpreadsheetName456/cell/A1/pattern/date-format/save/",
+                "/123/SpreadsheetName456/cell/A1/format-pattern/date/save/",
                 HistoryToken.cellPatternSave(
                         ID,
                         NAME,
@@ -2024,7 +2040,7 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>, Parse
         final String pattern = "yyyymmdd";
 
         this.parseStringAndCheck(
-                "/123/SpreadsheetName456/cell/A1/pattern/date-format/save/" + pattern,
+                "/123/SpreadsheetName456/cell/A1/format-pattern/date/save/" + pattern,
                 HistoryToken.cellPatternSave(
                         ID,
                         NAME,
@@ -2042,7 +2058,7 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>, Parse
         final String pattern = "hh:mm:ss";
 
         this.parseStringAndCheck(
-                "/123/SpreadsheetName456/cell/A1/pattern/time-parse/save/" + pattern,
+                "/123/SpreadsheetName456/cell/A1/parse-pattern/time/save/" + pattern,
                 HistoryToken.cellPatternSave(
                         ID,
                         NAME,
@@ -2365,7 +2381,7 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>, Parse
     @Test
     public void testParseSpreadsheetIdSpreadsheetNameColumnPattern() {
         this.parseStringAndCheck(
-                "/123/SpreadsheetName456/column/AA/pattern/date-format/yymmdd",
+                "/123/SpreadsheetName456/column/AA/format-pattern/date/yymmdd",
                 HistoryToken.column(
                         ID,
                         NAME,
@@ -2655,7 +2671,7 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>, Parse
     @Test
     public void testParseSpreadsheetIdSpreadsheetNameRowPattern() {
         this.parseStringAndCheck(
-                "/123/SpreadsheetName456/row/11/pattern/date-format/yymmdd",
+                "/123/SpreadsheetName456/row/11/format-pattern/date/yymmdd",
                 HistoryToken.row(
                         ID,
                         NAME,
@@ -2843,7 +2859,7 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>, Parse
     @Test
     public void testParseSpreadsheetIdSpreadsheetNameLabelPattern() {
         this.parseStringAndCheck(
-                "/123/SpreadsheetName456/label/Label123/pattern/date-format/yymmdd",
+                "/123/SpreadsheetName456/label/Label123/format-pattern/date/yymmdd",
                 LABEL_MAPPING_HHT
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTestCase.java
@@ -178,6 +178,24 @@ public abstract class HistoryTokenTestCase<T extends HistoryToken> implements Cl
         );
     }
 
+    final void setPatternKindAndCheck(final SpreadsheetPatternKind patternKind) {
+        this.setPatternKindAndCheck(
+                this.createHistoryToken(),
+                patternKind
+        );
+    }
+
+    final void setPatternKindAndCheck(final HistoryToken token,
+                                      final SpreadsheetPatternKind patternKind) {
+        assertSame(
+                token,
+                token.setPatternKind(
+                        Optional.of(patternKind)
+                ),
+                () -> token + " setPatternKind " + patternKind
+        );
+    }
+
     final void setPatternKindAndCheck(final HistoryToken token,
                                       final SpreadsheetPatternKind patternKind,
                                       final HistoryToken expected) {

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternSaveHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternSaveHistoryTokenTest.java
@@ -70,14 +70,14 @@ public final class SpreadsheetCellPatternSaveHistoryTokenTest extends Spreadshee
 
     @Test
     public void testUrlFragmentCell() {
-        this.urlFragmentAndCheck("/123/SpreadsheetName456/cell/A1/pattern/date-format/save/yyyy-mm-dd");
+        this.urlFragmentAndCheck("/123/SpreadsheetName456/cell/A1/format-pattern/date/save/yyyy-mm-dd");
     }
 
     @Test
     public void testUrlFragmentCellRange() {
         this.urlFragmentAndCheck(
                 RANGE.setAnchor(SpreadsheetViewportAnchor.TOP_LEFT),
-                "/123/SpreadsheetName456/cell/B2:C3/top-left/pattern/date-format/save/yyyy-mm-dd"
+                "/123/SpreadsheetName456/cell/B2:C3/top-left/format-pattern/date/save/yyyy-mm-dd"
         );
     }
 
@@ -85,7 +85,7 @@ public final class SpreadsheetCellPatternSaveHistoryTokenTest extends Spreadshee
     public void testUrlFragmentLabel() {
         this.urlFragmentAndCheck(
                 LABEL,
-                "/123/SpreadsheetName456/cell/Label123/pattern/date-format/save/yyyy-mm-dd"
+                "/123/SpreadsheetName456/cell/Label123/format-pattern/date/save/yyyy-mm-dd"
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternToolbarFormatHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternToolbarFormatHistoryTokenTest.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-public final class SpreadsheetCellPatternToolbarHistoryTokenTest extends SpreadsheetCellPatternHistoryTokenTestCase<SpreadsheetCellPatternToolbarHistoryToken> {
+public final class SpreadsheetCellPatternToolbarFormatHistoryTokenTest extends SpreadsheetCellPatternHistoryTokenTestCase<SpreadsheetCellPatternToolbarFormatHistoryToken> {
 
     // clearAction......................................................................................................
 
@@ -41,7 +41,7 @@ public final class SpreadsheetCellPatternToolbarHistoryTokenTest extends Spreads
 
     @Test
     public void testSetPatternKindSame() {
-        final SpreadsheetCellPatternToolbarHistoryToken historyToken = this.createHistoryToken();
+        final SpreadsheetCellPatternToolbarFormatHistoryToken historyToken = this.createHistoryToken();
         assertSame(
                 historyToken,
                 historyToken.setPatternKind(Optional.empty())
@@ -85,7 +85,7 @@ public final class SpreadsheetCellPatternToolbarHistoryTokenTest extends Spreads
         this.setPatternKindAndCheck(
                 this.createHistoryToken(),
                 Optional.empty(),
-                SpreadsheetCellPatternToolbarHistoryToken.with(
+                SpreadsheetCellPatternToolbarFormatHistoryToken.with(
                         ID,
                         NAME,
                         SELECTION
@@ -94,7 +94,7 @@ public final class SpreadsheetCellPatternToolbarHistoryTokenTest extends Spreads
     }
 
     private void setPatternKindAndCheck(
-            final SpreadsheetCellPatternToolbarHistoryToken historyToken,
+            final SpreadsheetCellPatternToolbarFormatHistoryToken historyToken,
             final Optional<SpreadsheetPatternKind> kind,
             final HistoryToken expected) {
         this.checkEquals(
@@ -108,14 +108,14 @@ public final class SpreadsheetCellPatternToolbarHistoryTokenTest extends Spreads
 
     @Test
     public void testUrlFragmentCell() {
-        this.urlFragmentAndCheck("/123/SpreadsheetName456/cell/A1/pattern");
+        this.urlFragmentAndCheck("/123/SpreadsheetName456/cell/A1/format-pattern");
     }
 
     @Test
     public void testUrlFragmentCellRange() {
         this.urlFragmentAndCheck(
                 RANGE.setAnchor(SpreadsheetViewportAnchor.TOP_LEFT),
-                "/123/SpreadsheetName456/cell/B2:C3/top-left/pattern"
+                "/123/SpreadsheetName456/cell/B2:C3/top-left/format-pattern"
         );
     }
 
@@ -123,15 +123,15 @@ public final class SpreadsheetCellPatternToolbarHistoryTokenTest extends Spreads
     public void testUrlFragmentLabel() {
         this.urlFragmentAndCheck(
                 LABEL,
-                "/123/SpreadsheetName456/cell/Label123/pattern"
+                "/123/SpreadsheetName456/cell/Label123/format-pattern"
         );
     }
 
     @Override
-    SpreadsheetCellPatternToolbarHistoryToken createHistoryToken(final SpreadsheetId id,
+    SpreadsheetCellPatternToolbarFormatHistoryToken createHistoryToken(final SpreadsheetId id,
                                                                  final SpreadsheetName name,
                                                                  final AnchoredSpreadsheetSelection selection) {
-        return SpreadsheetCellPatternToolbarHistoryToken.with(
+        return SpreadsheetCellPatternToolbarFormatHistoryToken.with(
                 id,
                 name,
                 selection
@@ -139,7 +139,7 @@ public final class SpreadsheetCellPatternToolbarHistoryTokenTest extends Spreads
     }
 
     @Override
-    public Class<SpreadsheetCellPatternToolbarHistoryToken> type() {
-        return SpreadsheetCellPatternToolbarHistoryToken.class;
+    public Class<SpreadsheetCellPatternToolbarFormatHistoryToken> type() {
+        return SpreadsheetCellPatternToolbarFormatHistoryToken.class;
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternToolbarParseHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellPatternToolbarParseHistoryTokenTest.java
@@ -28,9 +28,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-public final class SpreadsheetCellPatternSelectHistoryTokenTest extends SpreadsheetCellPatternHistoryTokenTestCase<SpreadsheetCellPatternSelectHistoryToken> {
-
-    private final static SpreadsheetPatternKind KIND = SpreadsheetPatternKind.DATE_FORMAT_PATTERN;
+public final class SpreadsheetCellPatternToolbarParseHistoryTokenTest extends SpreadsheetCellPatternHistoryTokenTestCase<SpreadsheetCellPatternToolbarParseHistoryToken> {
 
     // clearAction......................................................................................................
 
@@ -43,34 +41,32 @@ public final class SpreadsheetCellPatternSelectHistoryTokenTest extends Spreadsh
 
     @Test
     public void testSetPatternKindSame() {
-        final SpreadsheetCellPatternSelectHistoryToken historyToken = this.createHistoryToken();
+        final SpreadsheetCellPatternToolbarParseHistoryToken historyToken = this.createHistoryToken();
         assertSame(
                 historyToken,
-                historyToken.setPatternKind(
-                        Optional.of(KIND)
-                )
+                historyToken.setPatternKind(Optional.empty())
+        );
+    }
+
+    @Test
+    public void testSetPatternKindDateFormat() {
+        final SpreadsheetPatternKind different = SpreadsheetPatternKind.DATE_FORMAT_PATTERN;
+
+        this.setPatternKindAndCheck(
+                different
+        );
+    }
+
+    @Test
+    public void testSetPatternKindTextFormat() {
+        this.setPatternKindAndCheck(
+                SpreadsheetPatternKind.TEXT_FORMAT_PATTERN
         );
     }
 
     @Test
     public void testSetPatternKindDifferent() {
-        final SpreadsheetPatternKind different = SpreadsheetPatternKind.TEXT_FORMAT_PATTERN;
-
-        this.setPatternKindAndCheck(
-                this.createHistoryToken(),
-                different,
-                SpreadsheetCellPatternSelectHistoryToken.with(
-                        ID,
-                        NAME,
-                        SELECTION,
-                        different
-                )
-        );
-    }
-
-    @Test
-    public void testSetPatternKindDifferent2() {
-        final SpreadsheetPatternKind different = SpreadsheetPatternKind.TIME_FORMAT_PATTERN;
+        final SpreadsheetPatternKind different = SpreadsheetPatternKind.DATE_PARSE_PATTERN;
 
         this.setPatternKindAndCheck(
                 this.createHistoryToken(),
@@ -88,7 +84,8 @@ public final class SpreadsheetCellPatternSelectHistoryTokenTest extends Spreadsh
     public void testSetPatternKindEmpty() {
         this.setPatternKindAndCheck(
                 this.createHistoryToken(),
-                HistoryToken.cell(
+                Optional.empty(),
+                SpreadsheetCellPatternToolbarParseHistoryToken.with(
                         ID,
                         NAME,
                         SELECTION
@@ -96,18 +93,29 @@ public final class SpreadsheetCellPatternSelectHistoryTokenTest extends Spreadsh
         );
     }
 
+    private void setPatternKindAndCheck(
+            final SpreadsheetCellPatternToolbarParseHistoryToken historyToken,
+            final Optional<SpreadsheetPatternKind> kind,
+            final HistoryToken expected) {
+        this.checkEquals(
+                expected,
+                historyToken.setPatternKind(kind),
+                () -> historyToken + " setPatternKind " + kind
+        );
+    }
+
     // urlFragment......................................................................................................
 
     @Test
     public void testUrlFragmentCell() {
-        this.urlFragmentAndCheck("/123/SpreadsheetName456/cell/A1/format-pattern/date");
+        this.urlFragmentAndCheck("/123/SpreadsheetName456/cell/A1/parse-pattern");
     }
 
     @Test
     public void testUrlFragmentCellRange() {
         this.urlFragmentAndCheck(
                 RANGE.setAnchor(SpreadsheetViewportAnchor.TOP_LEFT),
-                "/123/SpreadsheetName456/cell/B2:C3/top-left/format-pattern/date"
+                "/123/SpreadsheetName456/cell/B2:C3/top-left/parse-pattern"
         );
     }
 
@@ -115,24 +123,23 @@ public final class SpreadsheetCellPatternSelectHistoryTokenTest extends Spreadsh
     public void testUrlFragmentLabel() {
         this.urlFragmentAndCheck(
                 LABEL,
-                "/123/SpreadsheetName456/cell/Label123/format-pattern/date"
+                "/123/SpreadsheetName456/cell/Label123/parse-pattern"
         );
     }
 
     @Override
-    SpreadsheetCellPatternSelectHistoryToken createHistoryToken(final SpreadsheetId id,
-                                                                final SpreadsheetName name,
-                                                                final AnchoredSpreadsheetSelection selection) {
-        return SpreadsheetCellPatternSelectHistoryToken.with(
+    SpreadsheetCellPatternToolbarParseHistoryToken createHistoryToken(final SpreadsheetId id,
+                                                                 final SpreadsheetName name,
+                                                                 final AnchoredSpreadsheetSelection selection) {
+        return SpreadsheetCellPatternToolbarParseHistoryToken.with(
                 id,
                 name,
-                selection,
-                KIND
+                selection
         );
     }
 
     @Override
-    public Class<SpreadsheetCellPatternSelectHistoryToken> type() {
-        return SpreadsheetCellPatternSelectHistoryToken.class;
+    public Class<SpreadsheetCellPatternToolbarParseHistoryToken> type() {
+        return SpreadsheetCellPatternToolbarParseHistoryToken.class;
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetHistoryTokenTestCase.java
@@ -48,7 +48,8 @@ public abstract class SpreadsheetHistoryTokenTestCase<T extends SpreadsheetHisto
                              final SpreadsheetHistoryToken token) {
         this.checkEquals(
                 token,
-                HistoryToken.parse(fragment)
+                HistoryToken.parse(fragment),
+                () -> "parse " + fragment
         );
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySaveHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySaveHistoryTokenTest.java
@@ -108,7 +108,7 @@ public final class SpreadsheetMetadataPropertySaveHistoryTokenTest extends Sprea
                         SpreadsheetMetadataPropertyName.DATE_FORMAT_PATTERN,
                         Optional.empty()
                 ),
-                "/123/SpreadsheetName456/metadata/pattern/date-format/save/"
+                "/123/SpreadsheetName456/metadata/date-format-pattern/save/"
         );
     }
 
@@ -123,7 +123,7 @@ public final class SpreadsheetMetadataPropertySaveHistoryTokenTest extends Sprea
                                 SpreadsheetPattern.parseDateFormatPattern("yymmdd")
                         )
                 ),
-                "/123/SpreadsheetName456/metadata/pattern/date-format/save/yymmdd"
+                "/123/SpreadsheetName456/metadata/date-format-pattern/save/yymmdd"
         );
     }
 
@@ -145,7 +145,7 @@ public final class SpreadsheetMetadataPropertySaveHistoryTokenTest extends Sprea
     @Test
     public void testParseDateFormatPattern() {
         this.parseAndCheck(
-                "/123/SpreadsheetName456/metadata/pattern/date-format/save/yymmdd",
+                "/123/SpreadsheetName456/metadata/date-format-pattern/save/yymmdd",
                 SpreadsheetMetadataPropertySaveHistoryToken.with(
                         ID,
                         NAME,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySelectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySelectHistoryTokenTest.java
@@ -84,7 +84,7 @@ public final class SpreadsheetMetadataPropertySelectHistoryTokenTest extends Spr
                         NAME,
                         SpreadsheetMetadataPropertyName.DATE_FORMAT_PATTERN
                 ),
-                "/123/SpreadsheetName456/metadata/pattern/date-format"
+                "/123/SpreadsheetName456/metadata/date-format-pattern"
         );
     }
 
@@ -105,7 +105,7 @@ public final class SpreadsheetMetadataPropertySelectHistoryTokenTest extends Spr
     @Test
     public void testParseDateFormatPattern() {
         this.parseAndCheck(
-                "/123/SpreadsheetName456/metadata/pattern/date-format",
+                "/123/SpreadsheetName456/metadata/date-format-pattern",
                 SpreadsheetMetadataPropertySelectHistoryToken.with(
                         ID,
                         NAME,


### PR DESCRIPTION
…PatternKind.urlFragment update

- https://github.com/mP1/walkingkooka-spreadsheet/pull/3328
- SpreadsheetPatternKind.urlFragment update

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/1173
- saving a cell pattern always displays pattern editor component

- TODO need two icons one for format-pattern and parse-pattern.
- TODO cell pattern editor should not mix both format-pattern & parse-pattern.