### PR TITLE
SpreadsheetViewportToolbarComponent separate format & parse buttons

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportToolbarComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportToolbarComponent.java
@@ -101,7 +101,8 @@ public final class SpreadsheetViewportToolbarComponent implements ComponentLifec
                 SpreadsheetViewportToolbarComponentItem.verticalAlignMiddle(context),
                 SpreadsheetViewportToolbarComponentItem.verticalAlignBottom(context),
                 SpreadsheetViewportToolbarComponentItem.clear(context),
-                SpreadsheetViewportToolbarComponentItem.pattern(context)
+                SpreadsheetViewportToolbarComponentItem.formatPattern(context),
+                SpreadsheetViewportToolbarComponentItem.parsePattern(context)
         );
     }
 
@@ -238,8 +239,12 @@ public final class SpreadsheetViewportToolbarComponent implements ComponentLifec
                 ).orElse("");
     }
 
-    public static String pattern() {
-        return VIEWPORT_TOOLBAR_ID_PREFIX + "-pattern";
+    public static String formatPattern() {
+        return VIEWPORT_TOOLBAR_ID_PREFIX + "-format-pattern";
+    }
+
+    public static String parsePattern() {
+        return VIEWPORT_TOOLBAR_ID_PREFIX + "-parse-pattern";
     }
 
     final static String VIEWPORT_TOOLBAR_ID_PREFIX = "viewport-toolbar-";

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportToolbarComponentItem.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportToolbarComponentItem.java
@@ -51,6 +51,13 @@ abstract class SpreadsheetViewportToolbarComponentItem implements IsElement<HTML
         );
     }
 
+    /**
+     * {@link SpreadsheetViewportToolbarComponentItemButtonPatternFormat}
+     */
+    static SpreadsheetViewportToolbarComponentItem formatPattern(final HistoryTokenContext context) {
+        return SpreadsheetViewportToolbarComponentItemButtonPatternFormat.with(context);
+    }
+
     static SpreadsheetViewportToolbarComponentItem italics(final HistoryTokenContext context) {
         return SpreadsheetViewportToolbarComponentItemButtonTextStyleProperty.with(
                 TextStylePropertyName.FONT_STYLE,
@@ -62,10 +69,10 @@ abstract class SpreadsheetViewportToolbarComponentItem implements IsElement<HTML
     }
 
     /**
-     * {@link SpreadsheetViewportToolbarComponentItemButtonPattern}
+     * {@link SpreadsheetViewportToolbarComponentItemButtonPatternParse}
      */
-    static SpreadsheetViewportToolbarComponentItem pattern(final HistoryTokenContext context) {
-        return SpreadsheetViewportToolbarComponentItemButtonPattern.with(context);
+    static SpreadsheetViewportToolbarComponentItem parsePattern(final HistoryTokenContext context) {
+        return SpreadsheetViewportToolbarComponentItemButtonPatternParse.with(context);
     }
 
     static SpreadsheetViewportToolbarComponentItem strikeThru(final HistoryTokenContext context) {

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportToolbarComponentItemButtonPatternFormat.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportToolbarComponentItemButtonPatternFormat.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.dominokit.viewport;
+
+import elemental2.dom.Event;
+import org.dominokit.domino.ui.events.EventType;
+import org.dominokit.domino.ui.icons.lib.Icons;
+import walkingkooka.collect.map.Maps;
+import walkingkooka.spreadsheet.SpreadsheetCell;
+import walkingkooka.spreadsheet.dominokit.AppContext;
+import walkingkooka.spreadsheet.dominokit.history.HistoryTokenContext;
+import walkingkooka.spreadsheet.format.pattern.SpreadsheetFormatPattern;
+import walkingkooka.spreadsheet.format.pattern.SpreadsheetParsePattern;
+import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
+import walkingkooka.tree.text.TextStyle;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A button component that may exist withing a toolbar, which actives the format pattern editor.
+ */
+final class SpreadsheetViewportToolbarComponentItemButtonPatternFormat extends SpreadsheetViewportToolbarComponentItemButtonPattern<SpreadsheetFormatPattern> {
+
+    static SpreadsheetViewportToolbarComponentItemButtonPatternFormat with(final HistoryTokenContext context) {
+        Objects.requireNonNull(context, "context");
+
+        return new SpreadsheetViewportToolbarComponentItemButtonPatternFormat(
+                context
+        );
+    }
+
+    private SpreadsheetViewportToolbarComponentItemButtonPatternFormat(final HistoryTokenContext context) {
+        super(
+                SpreadsheetViewportToolbarComponent.formatPattern(),
+                "Format pattern(s)",
+                context
+        );
+    }
+
+    @Override //
+    Optional<SpreadsheetFormatPattern> pattern(final SpreadsheetCell cell) {
+        return cell.formatPattern();
+    }
+
+    @Override//
+    SpreadsheetPatternKind defaultSpreadsheetPatternKind() {
+        return SpreadsheetPatternKind.TEXT_FORMAT_PATTERN;
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportToolbarComponentItemButtonPatternParse.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportToolbarComponentItemButtonPatternParse.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.dominokit.viewport;
+
+import elemental2.dom.Event;
+import org.dominokit.domino.ui.events.EventType;
+import org.dominokit.domino.ui.icons.lib.Icons;
+import walkingkooka.collect.map.Maps;
+import walkingkooka.spreadsheet.SpreadsheetCell;
+import walkingkooka.spreadsheet.dominokit.AppContext;
+import walkingkooka.spreadsheet.dominokit.history.HistoryTokenContext;
+import walkingkooka.spreadsheet.format.pattern.SpreadsheetFormatPattern;
+import walkingkooka.spreadsheet.format.pattern.SpreadsheetParsePattern;
+import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
+import walkingkooka.tree.text.TextStyle;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A button component that may exist withing a toolbar, which actives the parse pattern editor.
+ */
+final class SpreadsheetViewportToolbarComponentItemButtonPatternParse extends SpreadsheetViewportToolbarComponentItemButtonPattern<SpreadsheetParsePattern> {
+
+    static SpreadsheetViewportToolbarComponentItemButtonPatternParse with(final HistoryTokenContext context) {
+        Objects.requireNonNull(context, "context");
+
+        return new SpreadsheetViewportToolbarComponentItemButtonPatternParse(
+                context
+        );
+    }
+
+    private SpreadsheetViewportToolbarComponentItemButtonPatternParse(final HistoryTokenContext context) {
+        super(
+                SpreadsheetViewportToolbarComponent.parsePattern(),
+                "Parse pattern(s)",
+                context
+        );
+    }
+
+    @Override //
+    Optional<SpreadsheetParsePattern> pattern(final SpreadsheetCell cell) {
+        return cell.parsePattern();
+    }
+
+    @Override//
+    SpreadsheetPatternKind defaultSpreadsheetPatternKind() {
+        return SpreadsheetPatternKind.NUMBER_PARSE_PATTERN;
+    }
+}


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/1180
- Toolbar need two icons one for format-pattern and parse-pattern