### PR TITLE
SpreadsheetColorPickerComponent font-size fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/color/SpreadsheetColorPickerComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/color/SpreadsheetColorPickerComponent.java
@@ -37,8 +37,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
-import static org.dominokit.domino.ui.style.SpacingCss.dui_font_size_5;
-
 /**
  * A component that creates a grid and fills each cell with the current color value taken from {@link SpreadsheetMetadata}.
  * If a {@link SpreadsheetColorName} exists that will be used otherwise a name is formed by combining the "color-" and the color number.
@@ -77,7 +75,6 @@ public final class SpreadsheetColorPickerComponent implements SpreadsheetMetadat
             for(int x = 0; x < COLUMNS; x++) {
                 final TDElement td = ElementsFactory.elements.td();
                 td.style("width: 64px; height: 32px; border-color: black; border-width: 2px; border-style: solid; text-align: center;");
-                td.addCss(dui_font_size_5);
                 tr.appendChild(td);
 
                 final Anchor anchor = Anchor.empty();

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/public/index.html
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/public/index.html
@@ -40,7 +40,6 @@
 
         TABLE {
             border-spacing: 0;
-            font-size: small !important;
         }
 
         BUTTON {

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportComponent.java
@@ -533,6 +533,8 @@ public final class SpreadsheetViewportComponent implements IsElement<HTMLDivElem
 
         final HistoryToken saveColor = historyToken.setStyle(TextStylePropertyName.BACKGROUND_COLOR);
         final SpreadsheetColorPickerComponent colors = SpreadsheetColorPickerComponent.with(saveColor);
+        colors.element().className = "dui dui-menu-item";
+
         colors.refreshAll(
                 saveColor,
                 context.spreadsheetMetadata()


### PR DESCRIPTION
- clearing TABLE font-size also makes viewport header text match everything else.