### PR TITLE
fields helper text red

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/public/index.html
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/public/index.html
@@ -51,6 +51,10 @@
             outline-style: solid !important;
             outline-width: 3px !important;
         }
+
+        .dui-field-helper {
+            color: red !important
+        }
     </style>
 </head>
 </html>


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/1287
- SpreadsheetLabelMappingComponent errors below text fields should be red