### PR TITLE
Display SpreadsheetFormula parsing and execution errors as helper text.

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/formula/SpreadsheetFormulaComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/formula/SpreadsheetFormulaComponent.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.dominokit.ui.formula;
 
+import elemental2.dom.Element;
 import elemental2.dom.Event;
 import elemental2.dom.HTMLFieldSetElement;
 import elemental2.dom.KeyboardEvent;
@@ -25,6 +26,7 @@ import org.dominokit.domino.ui.IsElement;
 import org.dominokit.domino.ui.events.EventType;
 import org.dominokit.domino.ui.forms.TextBox;
 import org.dominokit.domino.ui.icons.lib.Icons;
+import org.dominokit.domino.ui.utils.DominoElement;
 import org.dominokit.domino.ui.utils.PostfixAddOn;
 import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.spreadsheet.dominokit.AppContext;
@@ -42,6 +44,8 @@ import walkingkooka.text.CharSequences;
 
 import java.util.Objects;
 import java.util.Optional;
+
+import static org.dominokit.domino.ui.utils.ElementsFactory.elements;
 
 /**
  * Provides a text box which supports editing of a formula belonging to a cell.
@@ -86,6 +90,13 @@ public final class SpreadsheetFormulaComponent implements IsElement<HTMLFieldSet
                                                 .addClickListener(this::onClear)
                                 )
                         )
+        );
+
+        textBox.setAutoValidation(true);
+        textBox.addValidator(
+                SpreadsheetFormulaComponentValidator.with(
+                        context
+                )
         );
 
         this.textBox = textBox;
@@ -155,6 +166,20 @@ public final class SpreadsheetFormulaComponent implements IsElement<HTMLFieldSet
     private final TextBox textBox;
 
     private final AppContext context;
+
+    /**
+     * Calling this method results in this component always having the same height regardless of whether errors are
+     * present or absent. Normally the height of this component is less when no errors are available.
+     */
+    public SpreadsheetFormulaComponent helperTextAlwaysExpanded() {
+        DominoElement<Element> e = elements.elementOf(
+                this.textBox.element()
+                        .firstElementChild
+        );
+        e.setCssProperty("height", "4em");
+
+        return this;
+    }
 
     // IsElement.......................................................................................................
 
@@ -236,11 +261,10 @@ public final class SpreadsheetFormulaComponent implements IsElement<HTMLFieldSet
                         .formula()
                         .text();
             }
-
-            // TODO show error somewhere in formula ?
         }
 
         this.setText(text);
+        this.textBox.validate();
         this.undoText = text;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/formula/SpreadsheetFormulaComponentValidator.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/formula/SpreadsheetFormulaComponentValidator.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.dominokit.ui.formula;
+
+import org.dominokit.domino.ui.forms.TextBox;
+import org.dominokit.domino.ui.forms.validations.ValidationResult;
+import org.dominokit.domino.ui.utils.HasValidation.Validator;
+import walkingkooka.spreadsheet.SpreadsheetCell;
+import walkingkooka.spreadsheet.SpreadsheetError;
+import walkingkooka.spreadsheet.SpreadsheetFormula;
+import walkingkooka.spreadsheet.dominokit.AppContext;
+import walkingkooka.spreadsheet.dominokit.ui.viewport.SpreadsheetViewportCache;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
+import walkingkooka.spreadsheet.parser.SpreadsheetParserContext;
+import walkingkooka.spreadsheet.parser.SpreadsheetParsers;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+import walkingkooka.text.CharSequences;
+import walkingkooka.text.cursor.TextCursors;
+import walkingkooka.text.cursor.parser.Parser;
+
+import java.util.Optional;
+
+/**
+ * Parse the text from the {@link SpreadsheetFormulaComponent}. Any caught {@link Exception#getMessage()} becomes the validation failure message.
+ */
+final class SpreadsheetFormulaComponentValidator implements Validator<TextBox> {
+
+    /**
+     * Factory
+     */
+    static SpreadsheetFormulaComponentValidator with(final AppContext context) {
+        return new SpreadsheetFormulaComponentValidator(
+                context
+        );
+    }
+
+    private SpreadsheetFormulaComponentValidator(final AppContext context) {
+        super();
+        this.context = context;
+    }
+
+    @Override
+    public ValidationResult isValid(final TextBox component) {
+        final AppContext context = this.context;
+        final SpreadsheetMetadata metadata = context.spreadsheetMetadata();
+
+        String errorMessage = null;
+        Parser<SpreadsheetParserContext> parser = null;
+
+        final SpreadsheetViewportCache viewportCache = context.viewportCache();
+        final SpreadsheetSelection nonLabelSelection = context.historyToken()
+                .selectionOrEmpty()
+                .map((a) -> viewportCache.nonLabelSelection(a.selection()).orElse(null))
+                .orElse(null);
+        if (null != nonLabelSelection) {
+            final Optional<SpreadsheetCell> maybeCell = viewportCache.cell(nonLabelSelection.toCell());
+            if (maybeCell.isPresent()) {
+                final SpreadsheetCell cell = maybeCell.get();
+                errorMessage = cell.formula()
+                        .error()
+                        .map(SpreadsheetError::message)
+                        .orElse(null);
+                parser = cell.parsePattern()
+                        .map(p -> p.parser())
+                        .orElseGet(() -> SpreadsheetParsers.valueOrExpression(
+                                        metadata.parser()
+                                )
+                        );
+            }
+        }
+        if (null == parser) {
+            parser = SpreadsheetParsers.valueOrExpression(
+                    metadata.parser()
+            );
+        }
+
+        try {
+            final SpreadsheetFormula formula = SpreadsheetFormula.parse(
+                    TextCursors.charSequence(
+                            component.getInputElement()
+                                    .element()
+                                    .value
+                    ),
+                    parser,
+                    metadata.parserContext(
+                            () -> context.now()
+                    )
+            );
+
+            errorMessage = formula.error()
+                    .map(SpreadsheetError::message)
+                    .orElse(errorMessage);
+
+        } catch (final Exception fail) {
+            errorMessage = fail.getMessage();
+
+            if (CharSequences.isNullOrEmpty(errorMessage)) {
+                errorMessage = "Failed to parse formula";
+            }
+        }
+        return null == errorMessage ?
+                ValidationResult.valid() :
+                ValidationResult.invalid(errorMessage);
+    }
+
+    private final AppContext context;
+
+    @Override
+    public String toString() {
+        return this.context.spreadsheetMetadata()
+                .toString();
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/viewport/SpreadsheetViewportComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/viewport/SpreadsheetViewportComponent.java
@@ -185,7 +185,8 @@ public final class SpreadsheetViewportComponent implements IsElement<HTMLDivElem
     // formulaComponent.................................................................................................
 
     private SpreadsheetFormulaComponent formulaComponent() {
-        return SpreadsheetFormulaComponent.with(this.context);
+        return SpreadsheetFormulaComponent.with(this.context)
+                .helperTextAlwaysExpanded();
     }
 
     private final SpreadsheetFormulaComponent formulaComponent;


### PR DESCRIPTION
- When the user blurs the formula text box the formula is validated and becomes a validation error.
- Formula errors also become validation errors.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/1309
- SpreadsheetFormulaComponent needs a Validator

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/1094
- SpreadsheetFormulaComponent show expression errors