### PR TITLE
SpreadsheetDialogComponent.close immediately not open fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/dialog/SpreadsheetDialogComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/dialog/SpreadsheetDialogComponent.java
@@ -110,13 +110,14 @@ public class SpreadsheetDialogComponent {
      * Tests if the dialog is open.
      */
     public boolean isOpen() {
-        return this.dialog.isOpen();
+        return this.open;
     }
 
     /**
      * Opens the modal dialog.
      */
     public void open() {
+        this.open = true;
         this.dialog.open();
     }
 
@@ -124,8 +125,14 @@ public class SpreadsheetDialogComponent {
      * Closes the modal dialog.
      */
     public void close() {
+        this.open = false;
         this.dialog.close();
     }
+
+    /**
+     * A flag is used to test if a {@link Dialog}, because {@link Dialog#close} reports true until closing animations finish.
+     */
+    private boolean open;
 
     private final Dialog dialog;
 


### PR DESCRIPTION
- This is necessary because Dialog.close() remains open while closing animations happen.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/1468
- open SpreadsheetPatternComponent then changing url to open Label results in ClassCastException