### PR TITLE
SpreadsheetFindComponent: invalid cell-range logs error fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/find/SpreadsheetFindComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/find/SpreadsheetFindComponent.java
@@ -522,14 +522,24 @@ public final class SpreadsheetFindComponent implements ComponentLifecycle,
 
     // History.........................................................................................................
 
-    private void historyTokenSetAndPush(final Function<SpreadsheetCellFindHistoryToken, SpreadsheetCellFindHistoryToken> updater) {
+    private void historyTokenSetAndPush(final Function<SpreadsheetCellFindHistoryToken, HistoryToken> updater) {
         final SpreadsheetFindComponentContext context = this.context;
-        context.pushHistoryToken(
-                updater.apply(
-                        context.historyToken()
-                                .cast(SpreadsheetCellFindHistoryToken.class)
-                )
-        );
+
+        // if setter failed ignore, validation will eventually show an error for the field.
+        HistoryToken token = null;
+        try {
+            token = updater.apply(
+                    context.historyToken()
+                            .cast(SpreadsheetCellFindHistoryToken.class)
+            );
+        } catch (final Exception ignore) {
+            token = null;
+        }
+
+        // only update history token if setter was successful.
+        if (token instanceof SpreadsheetCellFindHistoryToken) {
+            context.pushHistoryToken(token);
+        } ;
     }
 
     // UI...............................................................................................................


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/1475
- SpreadsheetFindComponent: clearing cell then blur, throws ClassCastException when it tries to push updated HistoryToken