### PR TITLE
SpreadsheetViewport broken render after find fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/net/PushHistoryTokenResponseSpreadsheetDeltaSelectionSpreadsheetDeltaFetcherWatcher.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/net/PushHistoryTokenResponseSpreadsheetDeltaSelectionSpreadsheetDeltaFetcherWatcher.java
@@ -17,11 +17,9 @@
 
 package walkingkooka.spreadsheet.dominokit.net;
 
-import walkingkooka.spreadsheet.SpreadsheetViewportWindows;
 import walkingkooka.spreadsheet.dominokit.AppContext;
 import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
 import walkingkooka.spreadsheet.dominokit.history.SpreadsheetSelectionHistoryToken;
-import walkingkooka.spreadsheet.dominokit.ui.viewport.SpreadsheetViewportCache;
 import walkingkooka.spreadsheet.engine.SpreadsheetDelta;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewport;
 
@@ -60,16 +58,6 @@ final class PushHistoryTokenResponseSpreadsheetDeltaSelectionSpreadsheetDeltaFet
                     context.pushHistoryToken(withSelection);
                 }
             }
-        }
-
-        final SpreadsheetViewportCache viewportCache = context.viewportCache();
-        final SpreadsheetViewportWindows previousWindow = viewportCache.windows();
-        final SpreadsheetViewportWindows window = delta.window();
-
-        if (false == previousWindow.equals(window)) {
-            context.debug("PushHistoryTokenResponseSpreadsheetDeltaSelectionSpreadsheetDeltaFetcherWatcher.onSpreadsheetDelta window changed from " + previousWindow + " to " + window);
-
-            viewportCache.setWindows(window);
         }
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/viewport/SpreadsheetViewportCache.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/viewport/SpreadsheetViewportCache.java
@@ -113,6 +113,8 @@ public final class SpreadsheetViewportCache implements NopFetcherWatcher,
     @Override
     public void onSpreadsheetDelta(final SpreadsheetDelta delta,
                                    final AppContext context) {
+        this.setWindows(delta.window());
+
         final Map<SpreadsheetCellReference, SpreadsheetCell> cells = this.cells;
 
         final Map<SpreadsheetCellReference, Set<SpreadsheetLabelName>> cellToLabels = this.cellToLabels;
@@ -367,7 +369,7 @@ public final class SpreadsheetViewportCache implements NopFetcherWatcher,
     public void setWindows(final SpreadsheetViewportWindows windows) {
         Objects.requireNonNull(windows, "windows");
 
-        if (windows.isEmpty()) {
+        if (false == windows.isEmpty()) {
             if (false == this.windows.equals(windows)) {
                 // no window clear caches
                 this.cells.clear();
@@ -382,9 +384,9 @@ public final class SpreadsheetViewportCache implements NopFetcherWatcher,
                 this.columnWidths.clear();
                 this.rowHeights.clear();
             }
-        }
 
-        this.windows = windows;
+            this.windows = windows;
+        }
     }
 
     /**


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/1481
- SpreadsheetViewportComponent grid becomes broken/empty during find cells

- Problem was caused by setWindows with empty windows causing SpreadsheetViewportComponent.refresh then render to become broken.