### PR TITLE
SpreadsheetCellFind set until EMPTY fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/SpreadsheetCellFind.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/SpreadsheetCellFind.java
@@ -160,13 +160,18 @@ public final class SpreadsheetCellFind implements HasUrlFragment {
                                         final OptionalInt max,
                                         final Optional<String> valueType,
                                         final Optional<String> query) {
-        return new SpreadsheetCellFind(
-                path,
-                offset,
-                max,
-                valueType,
-                query
-        );
+        return path.isPresent() ||
+                offset.isPresent() ||
+                max.isPresent() ||
+                valueType.isPresent() ||
+                query.isPresent() ?
+                new SpreadsheetCellFind(
+                        path,
+                        offset,
+                        max,
+                        valueType,
+                        query
+                ) : EMPTY;
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/ui/SpreadsheetCellFindTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/ui/SpreadsheetCellFindTest.java
@@ -257,6 +257,21 @@ public final class SpreadsheetCellFindTest implements HasUrlFragmentTesting,
         );
     }
 
+    // set then empty...................................................................................................
+
+    @Test
+    public void testSetUntilEmpty() {
+        assertSame(
+                SpreadsheetCellFind.empty(),
+                this.createObject()
+                        .setPath(Optional.empty())
+                        .setOffset(OptionalInt.empty())
+                        .setMax(OptionalInt.empty())
+                        .setValueType(Optional.empty())
+                        .setQuery(Optional.empty())
+        );
+    }
+
     // Object...........................................................................................................
 
     @Test


### PR DESCRIPTION
- After any set, if all props are empty return Spreadshee #EMPTY.