### PR TITLE
Broken link to themes css removed

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/public/index.html
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/public/index.html
@@ -19,8 +19,6 @@
 <head>
     <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
     <link type="text/css" rel="stylesheet" href="css/domino-ui/domino-ui.css">
-    <link type="text/css" rel="stylesheet" href="css/themes/all-themes.css">
-
     <script language="javascript" src="walkingkooka.spreadsheet.dominokit.App.nocache.js"></script>
     <iframe src="javascript:''" id="__gwt_historyFrame" style="width:0;height:0;border:0"></iframe>
     <style>


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/1548
- 404 when loading http://localhost:12345/css/themes/all-themes.css at startup