### PR TITLE
SpreadsheetViewportFormulaComponent cell with error empty tooltip tex…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/viewport/SpreadsheetViewportComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/viewport/SpreadsheetViewportComponent.java
@@ -1834,9 +1834,15 @@ public final class SpreadsheetViewportComponent implements Component<HTMLDivElem
         final HTMLTableCellElement element = td.element();
 
         if (maybeError.isPresent()) {
+            final SpreadsheetError error = maybeError.get();
+            final String message = error.message();
+
+            // if theres no message show SpreadsheetError#toString
             Tooltip.create(
                     element,
-                    maybeError.get().message()
+                    message.isEmpty() ?
+                            error.toString() :
+                            message
             ).setPosition(DropDirection.BOTTOM_MIDDLE);
         }
 


### PR DESCRIPTION
…t FIX

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/1781
- SpreadsheetViewportComponent viewport cell tooltip is empty when formula has error