### PR TITLE
SpreadsheetName click opens name editor

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/App.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/App.java
@@ -28,6 +28,7 @@ import org.dominokit.domino.ui.events.EventType;
 import org.dominokit.domino.ui.icons.Icon;
 import org.dominokit.domino.ui.icons.lib.Icons;
 import org.dominokit.domino.ui.layout.AppLayout;
+import org.dominokit.domino.ui.layout.NavBar;
 import org.dominokit.domino.ui.layout.RightDrawerSize;
 import org.dominokit.domino.ui.notifications.Notification;
 import org.dominokit.domino.ui.notifications.Notification.Position;
@@ -69,6 +70,7 @@ import walkingkooka.spreadsheet.dominokit.ui.meta.SpreadsheetMetadataPanelCompon
 import walkingkooka.spreadsheet.dominokit.ui.meta.SpreadsheetMetadataPanelComponentContexts;
 import walkingkooka.spreadsheet.dominokit.ui.pattern.SpreadsheetPatternComponent;
 import walkingkooka.spreadsheet.dominokit.ui.pattern.SpreadsheetPatternComponentContexts;
+import walkingkooka.spreadsheet.dominokit.ui.spreadsheetnameanchor.SpreadsheetNameAnchorComponent;
 import walkingkooka.spreadsheet.dominokit.ui.toolbar.SpreadsheetToolbarComponent;
 import walkingkooka.spreadsheet.dominokit.ui.viewport.SpreadsheetViewportCache;
 import walkingkooka.spreadsheet.dominokit.ui.viewport.SpreadsheetViewportComponent;
@@ -194,8 +196,17 @@ public class App implements EntryPoint,
                 .setOverFlowY("hidden") // stop scrollbars on the cell viewport
                 .appendChild(this.viewportComponent);
 
-        layout.getNavBar()
-                .getBody()
+        final SpreadsheetNameAnchorComponent spreadsheetNameAnchor = SpreadsheetNameAnchorComponent.empty();
+        this.addHistoryTokenWatcher(spreadsheetNameAnchor);
+
+        final NavBar navBar = layout.getNavBar();
+        navBar.withTitle(
+                (n, header) -> {
+                    header.appendChild(spreadsheetNameAnchor.element());
+                }
+        );
+
+        navBar.getBody()
                 .appendChild(
                         SpreadsheetToolbarComponent.with(this)
                 );
@@ -386,8 +397,6 @@ public class App implements EntryPoint,
             final SpreadsheetId id = maybeId.get();
             final SpreadsheetName name = maybeName.get();
 
-            this.setSpreadsheetName(name.text());
-
             final HistoryToken historyToken = context.historyToken();
             final Optional<SpreadsheetViewport> viewport = metadata.get(SpreadsheetMetadataPropertyName.VIEWPORT);
 
@@ -427,13 +436,6 @@ public class App implements EntryPoint,
     }
 
     private SpreadsheetMetadata spreadsheetMetadata;
-
-    // misc..........................................................................................................
-
-    public void setSpreadsheetName(final String name) {
-        this.layout.getNavBar()
-                .setTitle(name);
-    }
 
     // json.............................................................................................................
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/spreadsheetnameanchor/SpreadsheetNameAnchorComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/spreadsheetnameanchor/SpreadsheetNameAnchorComponent.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.dominokit.ui.spreadsheetnameanchor;
+
+import elemental2.dom.HTMLAnchorElement;
+import walkingkooka.spreadsheet.SpreadsheetName;
+import walkingkooka.spreadsheet.dominokit.AppContext;
+import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
+import walkingkooka.spreadsheet.dominokit.history.HistoryTokenWatcher;
+import walkingkooka.spreadsheet.dominokit.history.SpreadsheetNameHistoryToken;
+import walkingkooka.spreadsheet.dominokit.ui.Anchor;
+import walkingkooka.spreadsheet.dominokit.ui.Component;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
+
+import java.util.Optional;
+
+public final class SpreadsheetNameAnchorComponent implements Component<HTMLAnchorElement>,
+        HistoryTokenWatcher {
+
+    public static SpreadsheetNameAnchorComponent empty() {
+        return new SpreadsheetNameAnchorComponent();
+    }
+
+    private SpreadsheetNameAnchorComponent() {
+        this.anchor = Anchor.empty();
+    }
+
+    @Override
+    public HTMLAnchorElement element() {
+        return this.anchor.element();
+    }
+
+    @Override
+    public void onHistoryTokenChange(final HistoryToken previous,
+                                     final AppContext context) {
+        HistoryToken spreadsheetNameAnchor = null;
+
+        final HistoryToken historyToken = context.historyToken();
+        String nameText = "";
+
+        if (historyToken instanceof SpreadsheetNameHistoryToken) {
+            final SpreadsheetNameHistoryToken nameHistoryToken = historyToken.cast(SpreadsheetNameHistoryToken.class);
+            final SpreadsheetName name = nameHistoryToken.name();
+
+            spreadsheetNameAnchor = HistoryToken.metadataPropertySelect(
+                    nameHistoryToken.id(),
+                    name,
+                    SpreadsheetMetadataPropertyName.SPREADSHEET_NAME
+            );
+            nameText = name.text();
+        }
+
+        this.anchor.setHistoryToken(
+                Optional.ofNullable(
+                        spreadsheetNameAnchor
+                )
+        );
+        this.anchor.setTextContent(nameText);
+    }
+
+    private final Anchor anchor;
+}


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/507
- Clicking on spreadsheet name should bring up modal text field allowing edit

- TODO Fix SpreadsheetMetadataPanel to give focus to components within it, especially SpreadsheetName.