### PR TITLE
SpreadsheetToolbarComponentItemButtonPattern focus history token FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/toolbar/SpreadsheetToolbarComponentItemButtonPattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/toolbar/SpreadsheetToolbarComponentItemButtonPattern.java
@@ -86,7 +86,13 @@ abstract class SpreadsheetToolbarComponentItemButtonPattern<T extends Spreadshee
 
         context.historyToken()
                 .anchoredSelectionHistoryTokenOrEmpty()
-                .map(HistoryToken::clearPatternKind)
+                .map(
+                        t -> t.setPatternKind(
+                                Optional.of(
+                                        this.spreadsheetPatternKind()
+                                )
+                        ).clearPatternKind()
+                )
                 .ifPresent(context::pushHistoryToken);
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/1804
- toolbar tab to pattern format icon revert back to just cell selection, toolbar icon loses focus