### PR TITLE
SpreadsheetCellSaveHistoryToken optional polyorphic marshalling/unmar…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSaveFormulaHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSaveFormulaHistoryToken.java
@@ -26,6 +26,7 @@ import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * This {@link HistoryToken} is used by to paste a formula over a {@link walkingkooka.spreadsheet.reference.SpreadsheetCellRange}.
@@ -57,8 +58,8 @@ public final class SpreadsheetCellSaveFormulaHistoryToken extends SpreadsheetCel
     }
 
     @Override
-    Class<String> valueType() {
-        return String.class;
+    Optional<Class<String>> valueType() {
+        return Optional.of(String.class);
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSaveStyleHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSaveStyleHistoryToken.java
@@ -27,6 +27,7 @@ import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.tree.text.TextStyle;
 
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * This {@link HistoryToken} is used by to paste a styles for many cells over another range.
@@ -58,8 +59,8 @@ public final class SpreadsheetCellSaveStyleHistoryToken extends SpreadsheetCellS
     }
 
     @Override
-    Class<TextStyle> valueType() {
-        return TextStyle.class;
+    Optional<Class<TextStyle>> valueType() {
+        return Optional.of(TextStyle.class);
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSelectHistoryToken.java
@@ -146,7 +146,7 @@ public final class SpreadsheetCellSelectHistoryToken extends SpreadsheetCellHist
                             this.id(),
                             this.name(),
                             this.anchoredSelection(),
-                            SpreadsheetCellSaveHistoryToken.parseJson(
+                            SpreadsheetCellSaveHistoryToken.parseMap(
                                     cursor,
                                     String.class
                             )
@@ -157,7 +157,7 @@ public final class SpreadsheetCellSelectHistoryToken extends SpreadsheetCellHist
                             this.id(),
                             this.name(),
                             this.anchoredSelection(),
-                            SpreadsheetCellSaveHistoryToken.parseJson(
+                            SpreadsheetCellSaveHistoryToken.parseMap(
                                     cursor,
                                     TextStyle.class
                             )


### PR DESCRIPTION
…shalling of map

- This change is necessary because some Map values are constant eg formulas are always *String*, while SpreadsheetFormatPattern are polymorphic, eg there are several possible sub-classes of SpreadsheetFormatPattern.