### PR TITLE
SpreadsheetViewportComponent register SpreadsheetLabelMappingWatcher FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/viewport/SpreadsheetViewportComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/viewport/SpreadsheetViewportComponent.java
@@ -165,6 +165,7 @@ public final class SpreadsheetViewportComponent implements Component<HTMLDivElem
         this.root = this.root();
 
         context.addHistoryTokenWatcher(this);
+        context.addSpreadsheetLabelMappingWatcher(this);
         context.addSpreadsheetMetadataWatcher(this);
         context.addSpreadsheetDeltaWatcher(this);
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/1944
- SpreadsheetCell context menu "Label" not updated after label create.