### PR TITLE
SpreadsheetContextMenuNative extracted

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/contextmenu/SpreadsheetContextMenu.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/contextmenu/SpreadsheetContextMenu.java
@@ -18,21 +18,12 @@
 package walkingkooka.spreadsheet.dominokit.ui.contextmenu;
 
 import org.dominokit.domino.ui.IsElement;
-import org.dominokit.domino.ui.badges.Badge;
 import org.dominokit.domino.ui.icons.Icon;
 import org.dominokit.domino.ui.icons.MdiIcon;
-import org.dominokit.domino.ui.menu.AbstractMenuItem;
 import org.dominokit.domino.ui.menu.Menu;
-import org.dominokit.domino.ui.menu.MenuItem;
-import org.dominokit.domino.ui.menu.direction.MouseBestFitDirection;
-import org.dominokit.domino.ui.utils.DominoElement;
-import org.dominokit.domino.ui.utils.PostfixAddOn;
-import org.dominokit.domino.ui.utils.PrefixAddOn;
-import org.dominokit.domino.ui.utils.Separator;
 import walkingkooka.spreadsheet.dominokit.AppContext;
 import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
 import walkingkooka.spreadsheet.dominokit.history.HistoryTokenContext;
-import walkingkooka.spreadsheet.dominokit.ui.SpreadsheetIcons;
 import walkingkooka.spreadsheet.dominokit.ui.selectionmenu.SpreadsheetSelectionMenuContext;
 import walkingkooka.text.CharSequences;
 import walkingkooka.tree.text.TextStylePropertyName;
@@ -40,26 +31,13 @@ import walkingkooka.tree.text.TextStylePropertyName;
 import java.util.Objects;
 import java.util.Optional;
 
-import static org.dominokit.domino.ui.style.ColorsCss.dui_bg_orange;
-import static org.dominokit.domino.ui.style.SpacingCss.dui_font_size_5;
-import static org.dominokit.domino.ui.style.SpacingCss.dui_rounded_full;
-
 /**
  * Abstraction for building a context menu.
  */
-public class SpreadsheetContextMenu {
+public final class SpreadsheetContextMenu {
 
-    public static SpreadsheetContextMenu empty(final DominoElement<?> element,
-                                               final HistoryTokenContext context) {
-        Objects.requireNonNull(element, "element");
-        Objects.requireNonNull(context, "context");
-
-        final Menu<Void> menu = Menu.<Void>create()
-                .setContextMenu(true)
-                .setDropDirection(new MouseBestFitDirection())
-                .setTargetElement(element);
-        element.setDropMenu(menu);
-
+    static SpreadsheetContextMenu with(final Menu<Void> menu,
+                                       final HistoryTokenContext context) {
         return new SpreadsheetContextMenu(
                 menu,
                 context
@@ -135,34 +113,12 @@ public class SpreadsheetContextMenu {
 
         this.addSeparatorIfNecessary();
 
-        final Menu<Void> subMenu = Menu.create();
-
-        AbstractMenuItem<Void> menuItem = MenuItem.<Void>create(text)
-                .setId(id);
-        if (icon.isPresent()) {
-            menuItem = menuItem.appendChild(
-                    PrefixAddOn.of(
-                            icon.get()
-                                    .addCss(dui_font_size_5)
-                    )
-            );
-        }
-
-        if (badge.isPresent()) {
-            menuItem.appendChild(
-                    PostfixAddOn.of(
-                            Badge.create(
-                                    badge.get()
-                            ).addCss(
-                                    dui_bg_orange,
-                                    dui_rounded_full
-                            )
-                    )
-            );
-        }
-
-        this.menu.appendChild(
-                menuItem.setMenu(subMenu)
+        final Menu<Void> subMenu = SpreadsheetContextMenuNative.addSubMenu(
+                id,
+                text,
+                icon,
+                badge,
+                this
         );
         this.allowSeparator = true;
 
@@ -212,39 +168,10 @@ public class SpreadsheetContextMenu {
 
         this.addSeparatorIfNecessary();
 
-        AbstractMenuItem<Void> menuItem = this.context.menuItem(
-                item.id,
-                item.text,
-                item.historyToken
+        SpreadsheetContextMenuNative.menuAppendChildSpreadsheetContextMenuItem(
+                item,
+                this
         );
-        if (item.icon.isPresent()) {
-            menuItem = menuItem.appendChild(
-                    PrefixAddOn.of(
-                            item.icon.get()
-                                    .addCss(dui_font_size_5)
-                    )
-            );
-        }
-
-        if (item.badge.isPresent()) {
-            menuItem.appendChild(
-                    PostfixAddOn.of(
-                            Badge.create(
-                                    item.badge.get()
-                            )
-                    )
-            );
-        }
-
-        if (item.checked) {
-            menuItem.appendChild(
-                    PostfixAddOn.of(
-                            SpreadsheetIcons.checked()
-                    )
-            );
-        }
-
-        this.menu.appendChild(menuItem);
         this.allowSeparator = true;
 
         return this;
@@ -258,9 +185,11 @@ public class SpreadsheetContextMenu {
 
         this.addSeparatorIfNecessary();
 
-        this.menu.appendChild(
-                component.element()
+        SpreadsheetContextMenuNative.menuAppendChildIsElement(
+                component,
+                this
         );
+
         this.allowSeparator = true;
         return this;
     }
@@ -275,7 +204,7 @@ public class SpreadsheetContextMenu {
      */
     private void addSeparatorIfNecessary() {
         if (this.addSeparator) {
-            this.menu.appendChild(new Separator());
+            SpreadsheetContextMenuNative.menuAppendChildSeparator(this);
             this.addSeparator = false;
             this.allowSeparator = false;
         }
@@ -318,9 +247,9 @@ public class SpreadsheetContextMenu {
         this.menu.close();
     }
 
-    private final Menu<Void> menu;
+    final Menu<Void> menu;
 
-    private final HistoryTokenContext context;
+    final HistoryTokenContext context;
 
     @Override
     public String toString() {

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/contextmenu/SpreadsheetContextMenuNative.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/contextmenu/SpreadsheetContextMenuNative.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.dominokit.ui.contextmenu;
+
+import org.dominokit.domino.ui.IsElement;
+import org.dominokit.domino.ui.badges.Badge;
+import org.dominokit.domino.ui.icons.MdiIcon;
+import org.dominokit.domino.ui.menu.AbstractMenuItem;
+import org.dominokit.domino.ui.menu.Menu;
+import org.dominokit.domino.ui.menu.MenuItem;
+import org.dominokit.domino.ui.menu.direction.MouseBestFitDirection;
+import org.dominokit.domino.ui.utils.DominoElement;
+import org.dominokit.domino.ui.utils.PostfixAddOn;
+import org.dominokit.domino.ui.utils.PrefixAddOn;
+import org.dominokit.domino.ui.utils.Separator;
+import walkingkooka.spreadsheet.dominokit.history.HistoryTokenContext;
+import walkingkooka.spreadsheet.dominokit.ui.SpreadsheetIcons;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.dominokit.domino.ui.style.ColorsCss.dui_bg_orange;
+import static org.dominokit.domino.ui.style.SpacingCss.dui_font_size_5;
+import static org.dominokit.domino.ui.style.SpacingCss.dui_rounded_full;
+
+/**
+ * This is a bridge that performs actual real operations to create or add items to a domino {@link Menu}.
+ * Note the test source also contains a Menu class which is basically empty and only aggregates all added items.
+ * This should allow writing of unit tests to verify a menu without browser native objects failing to function.
+ */
+public final class SpreadsheetContextMenuNative {
+
+    /**
+     * Factory that builds a {@link SpreadsheetContextMenu}.
+     */
+    public static SpreadsheetContextMenu empty(final DominoElement<?> element,
+                                               final HistoryTokenContext context) {
+        Objects.requireNonNull(element, "element");
+        Objects.requireNonNull(context, "context");
+
+        final Menu<Void> menu = Menu.<Void>create()
+                .setContextMenu(true)
+                .setDropDirection(new MouseBestFitDirection())
+                .setTargetElement(element);
+        element.setDropMenu(menu);
+
+        return SpreadsheetContextMenu.with(
+                menu,
+                context
+        );
+    }
+
+    static Menu<Void> addSubMenu(final String id,
+                                 final String text,
+                                 final Optional<MdiIcon> icon,
+                                 final Optional<String> badge,
+                                 final SpreadsheetContextMenu menu) {
+        final Menu<Void> subMenu = Menu.create();
+
+        AbstractMenuItem<Void> menuItem = MenuItem.<Void>create(text)
+                .setId(id);
+        if (icon.isPresent()) {
+            menuItem = menuItem.appendChild(
+                    PrefixAddOn.of(
+                            icon.get()
+                                    .addCss(dui_font_size_5)
+                    )
+            );
+        }
+
+        if (badge.isPresent()) {
+            menuItem.appendChild(
+                    PostfixAddOn.of(
+                            Badge.create(
+                                    badge.get()
+                            ).addCss(
+                                    dui_bg_orange,
+                                    dui_rounded_full
+                            )
+                    )
+            );
+        }
+
+        menu.menu.appendChild(
+                menuItem.setMenu(subMenu)
+        );
+
+        return subMenu;
+    }
+
+    static void menuAppendChildSpreadsheetContextMenuItem(final SpreadsheetContextMenuItem item,
+                                                          final SpreadsheetContextMenu menu) {
+        AbstractMenuItem<Void> menuItem = menu.context.menuItem(
+                item.id,
+                item.text,
+                item.historyToken
+        );
+        if (item.icon.isPresent()) {
+            menuItem = menuItem.appendChild(
+                    PrefixAddOn.of(
+                            item.icon.get()
+                                    .addCss(dui_font_size_5)
+                    )
+            );
+        }
+
+        if (item.badge.isPresent()) {
+            menuItem.appendChild(
+                    PostfixAddOn.of(
+                            Badge.create(
+                                    item.badge.get()
+                            )
+                    )
+            );
+        }
+
+        if (item.checked) {
+            menuItem.appendChild(
+                    PostfixAddOn.of(
+                            SpreadsheetIcons.checked()
+                    )
+            );
+        }
+
+        menu.menu.appendChild(menuItem);
+    }
+
+    static void menuAppendChildIsElement(final IsElement<?> isElement,
+                                         final SpreadsheetContextMenu menu) {
+        menu.menu.appendChild(
+                isElement.element()
+        );
+    }
+
+    static void menuAppendChildSeparator(final SpreadsheetContextMenu menu) {
+        menu.menu.appendChild(new Separator());
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/pattern/SpreadsheetPatternComponentChipsComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/pattern/SpreadsheetPatternComponentChipsComponent.java
@@ -27,6 +27,7 @@ import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
 import walkingkooka.spreadsheet.dominokit.ui.Component;
 import walkingkooka.spreadsheet.dominokit.ui.SpreadsheetIds;
 import walkingkooka.spreadsheet.dominokit.ui.contextmenu.SpreadsheetContextMenu;
+import walkingkooka.spreadsheet.dominokit.ui.contextmenu.SpreadsheetContextMenuNative;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParserTokenKind;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
 import walkingkooka.text.CharSequences;
@@ -111,7 +112,7 @@ final class SpreadsheetPatternComponentChipsComponent implements Component<HTMLD
 
                 if (false == alternatives.isEmpty()) {
                     final HistoryToken historyToken = context.historyToken();
-                    SpreadsheetContextMenu contextMenu = SpreadsheetContextMenu.empty(
+                    SpreadsheetContextMenu contextMenu = SpreadsheetContextMenuNative.empty(
                             new DominoElement<Element>(chip.element()),
                             context
                     );

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/selectionmenu/SpreadsheetSelectionMenu.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/selectionmenu/SpreadsheetSelectionMenu.java
@@ -25,6 +25,7 @@ import walkingkooka.spreadsheet.dominokit.ui.SpreadsheetIcons;
 import walkingkooka.spreadsheet.dominokit.ui.SpreadsheetIds;
 import walkingkooka.spreadsheet.dominokit.ui.contextmenu.SpreadsheetContextMenu;
 import walkingkooka.spreadsheet.dominokit.ui.contextmenu.SpreadsheetContextMenuItem;
+import walkingkooka.spreadsheet.dominokit.ui.contextmenu.SpreadsheetContextMenuNative;
 import walkingkooka.spreadsheet.dominokit.ui.hidezerovalues.HideZeroValues;
 import walkingkooka.spreadsheet.dominokit.ui.metadatacolorpicker.SpreadsheetMetadataColorPickerComponent;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetFormatPattern;
@@ -80,7 +81,7 @@ public class SpreadsheetSelectionMenu {
         // UNFREEZE
         // -------
         // LABELS
-        final SpreadsheetContextMenu menu = SpreadsheetContextMenu.empty(
+        final SpreadsheetContextMenu menu = SpreadsheetContextMenuNative.empty(
                 element,
                 context
         );

--- a/src/test/java/org/dominokit/domino/ui/menu/Menu.java
+++ b/src/test/java/org/dominokit/domino/ui/menu/Menu.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.dominokit.domino.ui.menu;
+
+import org.gwtproject.core.shared.GwtIncompatible;
+import walkingkooka.collect.list.Lists;
+
+import java.util.List;
+
+@GwtIncompatible
+public class Menu<V> {
+
+    public static <V> Menu<V> create() {
+        return new Menu<>();
+    }
+
+    public Menu<V> appendChild(final Object child) {
+        this.children.add(child);
+        return this;
+    }
+
+    private final List<Object> children = Lists.array();
+}

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/ui/contextmenu/SpreadsheetContextMenuNative.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/ui/contextmenu/SpreadsheetContextMenuNative.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.dominokit.ui.contextmenu;
+
+import org.dominokit.domino.ui.IsElement;
+import org.dominokit.domino.ui.icons.MdiIcon;
+import org.dominokit.domino.ui.menu.Menu;
+import org.gwtproject.core.shared.GwtIncompatible;
+
+import java.util.Optional;
+
+/**
+ * This will implement TreePrintable allowing junit tests to validate menu builders.
+ */
+@GwtIncompatible
+public class SpreadsheetContextMenuNative {
+    static Menu<Void> addSubMenu(final String id,
+                                 final String text,
+                                 final Optional<MdiIcon> icon,
+                                 final Optional<String> badge,
+                                 final SpreadsheetContextMenu menu) {
+        // nop
+        return new Menu<>();
+    }
+
+    static void menuAppendChildSpreadsheetContextMenuItem(final SpreadsheetContextMenuItem item,
+                                                          final SpreadsheetContextMenu menu) {
+        menu.menu.appendChild(item);
+    }
+
+    static void menuAppendChildIsElement(final IsElement<?> isElement,
+                                         final SpreadsheetContextMenu menu) {
+        menu.menu.appendChild(isElement);
+    }
+
+    static void menuAppendChildSeparator(final SpreadsheetContextMenu menu) {
+        menu.menu.appendChild("-----");
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/ui/contextmenu/SpreadsheetContextMenuTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/ui/contextmenu/SpreadsheetContextMenuTest.java
@@ -17,22 +17,124 @@
 
 package walkingkooka.spreadsheet.dominokit.ui.contextmenu;
 
+import elemental2.dom.Element;
+import org.dominokit.domino.ui.IsElement;
+import org.dominokit.domino.ui.icons.MdiIcon;
+import org.dominokit.domino.ui.menu.Menu;
 import org.junit.jupiter.api.Test;
 import walkingkooka.reflect.ClassTesting;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.spreadsheet.dominokit.history.HistoryTokenContexts;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.util.Optional;
 
 public final class SpreadsheetContextMenuTest implements ClassTesting<SpreadsheetContextMenu> {
 
     @Test
-    public void testEmptyWithNullElementFails() {
-        assertThrows(
-                NullPointerException.class,
-                () -> SpreadsheetContextMenu.empty(
-                        null,
+    public void testItemSpreadsheetContextMenuItem() {
+        SpreadsheetContextMenu.with(
+                new Menu<>(),
+                HistoryTokenContexts.fake()
+        ).item(
+                SpreadsheetContextMenuItem.with(
+                        "id-MenuItem",
+                        "SubMenuText"
+                )
+        );
+    }
+
+    @Test
+    public void testItemIsElement() {
+        SpreadsheetContextMenu.with(
+                        new Menu<>(),
                         HistoryTokenContexts.fake()
+                ).separator()
+                .item(
+                        new IsElement<Element>() {
+                            @Override
+                            public Element element() {
+                                throw new UnsupportedOperationException();
+                            }
+                        }
+                );
+    }
+
+    @Test
+    public void testSeparatorThenItem() {
+        SpreadsheetContextMenu.with(
+                        new Menu<>(),
+                        HistoryTokenContexts.fake()
+                ).separator()
+                .item(
+                        SpreadsheetContextMenuItem.with(
+                                "id-MenuItem",
+                                "SubMenuText"
+                        )
+                );
+    }
+
+    @Test
+    public void testSubMenuIdText() {
+        SpreadsheetContextMenu.with(
+                new Menu<>(),
+                HistoryTokenContexts.fake()
+        ).subMenu(
+                "id-SubMenu",
+                "SubMenu"
+        );
+    }
+
+    @Test
+    public void testSubMenuIdTextBadge() {
+        SpreadsheetContextMenu.with(
+                new Menu<>(),
+                HistoryTokenContexts.fake()
+        ).subMenu(
+                "id-SubMenu",
+                "SubMenu",
+                "Badge-text-123"
+        );
+    }
+
+    @Test
+    public void testSubMenuIdTextIcon() {
+        SpreadsheetContextMenu.with(
+                new Menu<>(),
+                HistoryTokenContexts.fake()
+        ).subMenu(
+                "id-SubMenu",
+                "SubMenu",
+                MdiIcon.create("Icon-123")
+        );
+    }
+
+    @Test
+    public void testSubMenuIdTextIconBadge() {
+        SpreadsheetContextMenu.with(
+                new Menu<>(),
+                HistoryTokenContexts.fake()
+        ).subMenu(
+                "id-SubMenu",
+                "SubMenu",
+                Optional.of(
+                        MdiIcon.create("Icon-123")
+                ),
+                Optional.of("Badge-text-123")
+        );
+    }
+
+    @Test
+    public void testSubMenuIdTextThenItem() {
+        SpreadsheetContextMenu.with(
+                new Menu<>(),
+                HistoryTokenContexts.fake()
+        ).subMenu(
+                "id-SubMenu",
+                "SubMenu"
+        ).item(
+                SpreadsheetContextMenuItem.with(
+                        "id-MenuItem",
+                        "item-text-123"
                 )
         );
     }


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/1948
- SpreadsheetContextMenu should receive an abstraction not DominoElement

- Two forms of Native exist, a real implementation that works with real Domino components, and a barebones for junit tests.