### PR TITLE
SpreadsheetViewportComponentTableContext.mustRefresh replaces impleme…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/viewport/BasicSpreadsheetViewportComponentTableContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/viewport/BasicSpreadsheetViewportComponentTableContext.java
@@ -21,7 +21,6 @@ import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
 import walkingkooka.spreadsheet.dominokit.history.HistoryTokenContext;
 import walkingkooka.spreadsheet.dominokit.history.HistoryTokenWatcher;
 import walkingkooka.spreadsheet.dominokit.log.LoggingContext;
-import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.tree.text.TextStyle;
 
 final class BasicSpreadsheetViewportComponentTableContext implements SpreadsheetViewportComponentTableContext {
@@ -31,14 +30,14 @@ final class BasicSpreadsheetViewportComponentTableContext implements Spreadsheet
                                                               final SpreadsheetViewportCache viewportCache,
                                                               final boolean hideZeroValues,
                                                               final TextStyle defaultCellStyle,
-                                                              final SpreadsheetMetadata spreadsheetMetadata,
+                                                              final boolean mustRefresh,
                                                               final LoggingContext loggingContext) {
         return new BasicSpreadsheetViewportComponentTableContext(
                 historyTokenContext,
                 viewportCache,
                 hideZeroValues,
                 defaultCellStyle,
-                spreadsheetMetadata,
+                mustRefresh,
                 loggingContext
         );
     }
@@ -47,13 +46,13 @@ final class BasicSpreadsheetViewportComponentTableContext implements Spreadsheet
                                                           final SpreadsheetViewportCache viewportCache,
                                                           final boolean hideZeroValues,
                                                           final TextStyle defaultCellStyle,
-                                                          final SpreadsheetMetadata spreadsheetMetadata,
+                                                          final boolean mustRefresh,
                                                           final LoggingContext loggingContext) {
         this.historyTokenContext = historyTokenContext;
         this.viewportCache = viewportCache;
         this.hideZeroValues = hideZeroValues;
         this.defaultCellStyle = defaultCellStyle;
-        this.spreadsheetMetadata = spreadsheetMetadata;
+        this.mustRefresh = mustRefresh;
         this.loggingContext = loggingContext;
     }
 
@@ -106,11 +105,11 @@ final class BasicSpreadsheetViewportComponentTableContext implements Spreadsheet
     private final TextStyle defaultCellStyle;
 
     @Override
-    public SpreadsheetMetadata spreadsheetMetadata() {
-        return this.spreadsheetMetadata;
+    public boolean mustRefresh() {
+        return this.mustRefresh;
     }
 
-    private SpreadsheetMetadata spreadsheetMetadata;
+    private final boolean mustRefresh;
 
     @Override
     public void debug(final Object... values) {

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/viewport/SpreadsheetViewportComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/viewport/SpreadsheetViewportComponent.java
@@ -129,6 +129,7 @@ public final class SpreadsheetViewportComponent implements Component<HTMLDivElem
         this.verticalScrollbar = this.verticalScrollbar();
 
         this.tableContainer = this.tableContainer();
+        this.refreshMetadata = SpreadsheetMetadata.EMPTY;
 
         this.root = this.root();
 
@@ -1011,7 +1012,7 @@ public final class SpreadsheetViewportComponent implements Component<HTMLDivElem
                             metadata.getOrFail(SpreadsheetMetadataPropertyName.HIDE_ZERO_VALUES),
                             metadata.effectiveStyle()
                                     .merge(SpreadsheetViewportComponentTableCell.CELL_STYLE),
-                            metadata,
+                            metadata.shouldViewRefresh(this.refreshMetadata),
                             context
                     )
             );
@@ -1037,6 +1038,8 @@ public final class SpreadsheetViewportComponent implements Component<HTMLDivElem
             this.scrollbarsRefresh();
         }
     }
+
+    private SpreadsheetMetadata refreshMetadata;
 
     @Override
     public void openGiveFocus(final AppContext context) {

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/viewport/SpreadsheetViewportComponentTableCellSpreadsheetCell.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/viewport/SpreadsheetViewportComponentTableCellSpreadsheetCell.java
@@ -29,7 +29,6 @@ import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.spreadsheet.SpreadsheetError;
 import walkingkooka.spreadsheet.dominokit.dom.Doms;
 import walkingkooka.spreadsheet.dominokit.ui.SpreadsheetDominoKitColor;
-import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.tree.expression.ExpressionNumber;
@@ -75,7 +74,6 @@ final class SpreadsheetViewportComponentTableCellSpreadsheetCell extends Spreads
                         )
                 );
         this.cellReference = cellReference;
-        this.metadata = SpreadsheetMetadata.EMPTY;
         this.tooltipMessage = "";
     }
 
@@ -83,7 +81,6 @@ final class SpreadsheetViewportComponentTableCellSpreadsheetCell extends Spreads
     void refresh(final Predicate<SpreadsheetSelection> selected,
                  final SpreadsheetViewportComponentTableContext context) {
 
-        final SpreadsheetMetadata metadata = context.spreadsheetMetadata();
         final SpreadsheetViewportCache cache = context.viewportCache();
         final SpreadsheetCellReference cellReference = this.cellReference;
 
@@ -116,14 +113,14 @@ final class SpreadsheetViewportComponentTableCellSpreadsheetCell extends Spreads
             }
         }
 
-        if (false == maybeCell.equals(this.cell) ||
+        if (context.mustRefresh() ||
+                false == maybeCell.equals(this.cell) ||
                 this.selected != isSelected ||
-                this.hideZeroValues != hideZeroValues ||
-                metadata.shouldViewRefresh(this.metadata)) {
+                this.hideZeroValues != hideZeroValues
+        ) {
             this.cell = maybeCell;
             this.selected = isSelected;
             this.hideZeroValues = hideZeroValues;
-            this.metadata = metadata;
 
             final TDElement td = this.element;
             td.clearElement();
@@ -193,12 +190,6 @@ final class SpreadsheetViewportComponentTableCellSpreadsheetCell extends Spreads
     private boolean selected;
 
     private boolean hideZeroValues;
-
-    /**
-     * Some properties used to format the cell come from the {@link SpreadsheetMetadata} therefore if it changes
-     * render the cell again.
-     */
-    private SpreadsheetMetadata metadata;
 
     private void tooltipRefresh(final Optional<SpreadsheetError> error) {
         final String newTooltipMessage = error.map(

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/viewport/SpreadsheetViewportComponentTableContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/viewport/SpreadsheetViewportComponentTableContext.java
@@ -19,11 +19,9 @@ package walkingkooka.spreadsheet.dominokit.ui.viewport;
 
 import walkingkooka.spreadsheet.dominokit.history.HistoryTokenContext;
 import walkingkooka.spreadsheet.dominokit.log.LoggingContext;
-import walkingkooka.spreadsheet.meta.HasSpreadsheetMetadata;
 import walkingkooka.tree.text.TextStyle;
 
 interface SpreadsheetViewportComponentTableContext extends HistoryTokenContext,
-        HasSpreadsheetMetadata,
         LoggingContext {
 
     SpreadsheetViewportCache viewportCache();
@@ -34,4 +32,9 @@ interface SpreadsheetViewportComponentTableContext extends HistoryTokenContext,
      * The default {@link TextStyle} for a cell.
      */
     TextStyle defaultCellStyle();
+
+    /**
+     * When true a {@link SpreadsheetViewportComponentTableCell} must refresh.
+     */
+    boolean mustRefresh();
 }


### PR DESCRIPTION
…nts HasSpreadsheetMetadata

- Significant performance improvements, SpreadsheetViewportComponentTableCellSpreadsheetCell.refresh calls SpreadsheetMetadata.shouldViewRefresh cost 10m, resulting in 1000ms viewport refreshes.