### PR TITLE
SpreadsheetDeleteHistoryToken.onHistoryTokenChange0 reloads previous

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetDeleteHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetDeleteHistoryToken.java
@@ -156,6 +156,10 @@ public final class SpreadsheetDeleteHistoryToken extends SpreadsheetNameHistoryT
     @Override
     public void onHistoryTokenChange0(final HistoryToken previous,
                                      final AppContext context) {
+        context.pushHistoryToken(
+                previous.clearAction()
+        );
+
         context.addSpreadsheetMetadataWatcherOnce(
                 new SpreadsheetMetadataFetcherWatcher() {
                     @Override


### PR DESCRIPTION
- TODO SpreadsheetListComponent table not reloaded.