### PR TITLE
SpreadsheetViewportComponent create list reload remains closed FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/viewport/SpreadsheetViewportComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/viewport/SpreadsheetViewportComponent.java
@@ -1005,6 +1005,10 @@ public final class SpreadsheetViewportComponent implements HtmlElementComponent<
     public void close(final AppContext context) {
         this.setVisibility(false);
         this.open = false;
+
+        // need to "clear" cached metadata this will force loadViewportCells to happen when a new SpreadsheetMetadata.id appears
+        this.metadata = SpreadsheetMetadata.EMPTY;
+        this.refreshMetadata = SpreadsheetMetadata.EMPTY;
     }
 
     private boolean open;


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/2431
- Create Spreadsheet, List Spreadsheets, Load Spreadsheet again SpreadsheetViewportComponent remains closed