### PR TITLE
Hide AppLayout when browsing files

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/App.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/App.java
@@ -28,7 +28,6 @@ import org.dominokit.domino.ui.cards.Card;
 import org.dominokit.domino.ui.events.EventType;
 import org.dominokit.domino.ui.icons.Icon;
 import org.dominokit.domino.ui.icons.lib.Icons;
-import org.dominokit.domino.ui.layout.AppLayout;
 import org.dominokit.domino.ui.layout.NavBar;
 import org.dominokit.domino.ui.layout.RightDrawerSize;
 import org.dominokit.domino.ui.notifications.Notification;
@@ -71,6 +70,7 @@ import walkingkooka.spreadsheet.dominokit.net.SpreadsheetMetadataFetcher;
 import walkingkooka.spreadsheet.dominokit.net.SpreadsheetMetadataFetcherWatcher;
 import walkingkooka.spreadsheet.dominokit.net.SpreadsheetMetadataFetcherWatchers;
 import walkingkooka.spreadsheet.dominokit.ui.SpreadsheetCellFind;
+import walkingkooka.spreadsheet.dominokit.ui.applayout.SpreadsheetAppLayout;
 import walkingkooka.spreadsheet.dominokit.ui.applayoutrightdrawer.AppLayoutRightDrawerComponent;
 import walkingkooka.spreadsheet.dominokit.ui.columnrowinsert.SpreadsheetColumnRowInsertCountDialogComponent;
 import walkingkooka.spreadsheet.dominokit.ui.columnrowinsert.SpreadsheetColumnRowInsertCountDialogComponentContexts;
@@ -213,15 +213,16 @@ public class App implements EntryPoint,
         this.layout = this.prepareLayout();
     }
 
-    private final AppLayout layout;
+    private final SpreadsheetAppLayout layout;
 
     // header = metadata toggle | clickable(editable) spreadsheet name
     // right = editable metadata properties
     // content = toolbar
     //   formula,
     //   table holding spreadsheet cells
-    private AppLayout prepareLayout() {
-        final AppLayout layout = AppLayout.create();
+    private SpreadsheetAppLayout prepareLayout() {
+        final SpreadsheetAppLayout layout = SpreadsheetAppLayout.empty();
+        this.addHistoryTokenWatcher(layout);
 
         layout.setOverFlowX("hidden")
                 .setOverFlowY("hidden");
@@ -357,7 +358,7 @@ public class App implements EntryPoint,
 
     private void onResize(final int width,
                           final int height) {
-        final AppLayout layout = this.layout;
+        final SpreadsheetAppLayout layout = this.layout;
         final int navigationBarHeight = layout.getNavBar()
                 .element()
                 .offsetHeight;

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/applayout/SpreadsheetAppLayout.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/applayout/SpreadsheetAppLayout.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.dominokit.ui.applayout;
+
+import elemental2.dom.HTMLDivElement;
+import org.dominokit.domino.ui.layout.AppLayout;
+import walkingkooka.spreadsheet.dominokit.AppContext;
+import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
+import walkingkooka.spreadsheet.dominokit.history.SpreadsheetNameHistoryToken;
+import walkingkooka.spreadsheet.dominokit.ui.VisibleComponentLifecycle;
+
+public final class SpreadsheetAppLayout extends AppLayout implements VisibleComponentLifecycle<HTMLDivElement, SpreadsheetAppLayout> {
+
+    public static SpreadsheetAppLayout empty() {
+        return new SpreadsheetAppLayout();
+    }
+
+    private SpreadsheetAppLayout() {
+        super();
+    }
+
+    @Override
+    public boolean shouldIgnore(final HistoryToken token) {
+        return false;
+    }
+
+    @Override
+    public boolean isMatch(final HistoryToken token) {
+        return token instanceof SpreadsheetNameHistoryToken;
+    }
+
+    @Override
+    public void refresh(final AppContext context) {
+        // do nothing only want AppLayout to be hidden when not SpreadsheetNameHistoryToken
+    }
+
+    @Override
+    public void openGiveFocus(final AppContext context) {
+        // do nothing
+    }
+
+    @Override
+    public boolean shouldLogLifecycleChanges() {
+        return false;
+    }
+}


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/2457
- SpreadsheetAppLayout implements VisibleComponentLifecycle

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/2456
- SpreadsheetMetadataPanelComponent burger should be hidden when SpreadsheetViewportComponent is "hidden".