### PR TITLE
SpreadsheetPatternComponentAppender.refreshLinks removed debug for ea…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/pattern/SpreadsheetPatternComponentAppender.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/pattern/SpreadsheetPatternComponentAppender.java
@@ -167,7 +167,6 @@ final class SpreadsheetPatternComponentAppender implements HtmlElementComponent<
                 }
             }
 
-            context.debug(this.getClass().getSimpleName() + ".linksHrefRefresh: " + link.pattern + "=" + save);
             link.anchor.setHistoryToken(
                     Optional.ofNullable(save)
             );


### PR DESCRIPTION
…ch link

- Unnecessary now due to SpreadsheetPatternComponentAppenderTest rendering tests.