### PR TITLE
AppContext.loadSpreadsheetMetadataAndPushPreviousIfFails

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLoadHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLoadHistoryToken.java
@@ -17,21 +17,12 @@
 
 package walkingkooka.spreadsheet.dominokit.history;
 
-import elemental2.dom.Headers;
-import walkingkooka.net.AbsoluteOrRelativeUrl;
-import walkingkooka.net.Url;
 import walkingkooka.net.UrlFragment;
-import walkingkooka.net.http.HttpMethod;
-import walkingkooka.net.http.HttpStatus;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.dominokit.AppContext;
-import walkingkooka.spreadsheet.dominokit.net.SpreadsheetMetadataFetcherWatcher;
-import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.text.cursor.TextCursor;
 
-import java.util.List;
-import java.util.Optional;
 import java.util.OptionalInt;
 
 public final class SpreadsheetLoadHistoryToken extends SpreadsheetIdHistoryToken {
@@ -90,56 +81,9 @@ public final class SpreadsheetLoadHistoryToken extends SpreadsheetIdHistoryToken
     @Override
     public void onHistoryTokenChange(final HistoryToken previous,
                                      final AppContext context) {
-        context.addSpreadsheetMetadataWatcherOnce(
-                new SpreadsheetMetadataFetcherWatcher() {
-
-                    @Override
-                    public void onNoResponse(final AppContext context) {
-                        // nop
-                    }
-
-                    @Override
-                    public void onSpreadsheetMetadata(final SpreadsheetMetadata metadata,
-                                                      final AppContext context) {
-                        // nop
-                    }
-
-                    @Override
-                    public void onSpreadsheetMetadataList(final List<SpreadsheetMetadata> metadatas,
-                                                          final AppContext context) {
-                        // ignore
-                    }
-
-                    @Override
-                    public void onBegin(final HttpMethod method,
-                                        final Url url,
-                                        final Optional<String> body,
-                                        final AppContext context) {
-                        // nop
-                    }
-
-                    @Override
-                    public void onFailure(final HttpMethod method,
-                                          final AbsoluteOrRelativeUrl url,
-                                          final HttpStatus status,
-                                          final Headers headers,
-                                          final String body,
-                                          final AppContext context) {
-                        context.pushHistoryToken(
-                                previous.clearAction()
-                        );
-                    }
-
-                    @Override
-                    public void onError(final Object cause,
-                                        final AppContext context) {
-                        context.pushHistoryToken(
-                                previous.clearAction()
-                        );
-                    }
-                }
+        context.loadSpreadsheetMetadataAndPushPreviousIfFails(
+                this.id(),
+                previous
         );
-        context.spreadsheetMetadataFetcher()
-                .loadSpreadsheetMetadata(this.id());
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNameHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNameHistoryToken.java
@@ -266,8 +266,10 @@ public abstract class SpreadsheetNameHistoryToken extends SpreadsheetIdHistoryTo
                             previousId +
                             " have different ids, load SpreadsheetId and then fire current history token"
             );
-            context.spreadsheetMetadataFetcher()
-                    .loadSpreadsheetMetadata(id);
+            context.loadSpreadsheetMetadataAndPushPreviousIfFails(
+                    this.id(),
+                    previous
+            );
         } else {
             this.onHistoryTokenChange0(
                     previous,

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectHistoryToken.java
@@ -331,10 +331,10 @@ public final class SpreadsheetSelectHistoryToken extends SpreadsheetNameHistoryT
         }
 
         if (load) {
-            context.spreadsheetMetadataFetcher()
-                    .loadSpreadsheetMetadata(
-                            id
-                    );
+            context.loadSpreadsheetMetadataAndPushPreviousIfFails(
+                    id,
+                    previous
+            );
         }
     }
 }


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/2560
- Loading unknown spreadsheet id when no previous history should display "/" not remain stuck on /bad-spreadsheet-id/