### PR TITLE
SpreadsheetViewportCache implements SpreadsheetLabelNameResolver

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellClipboardCopyHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellClipboardCopyHistoryToken.java
@@ -76,9 +76,11 @@ public final class SpreadsheetCellClipboardCopyHistoryToken extends SpreadsheetC
     @Override
     void onHistoryTokenChangeClipboard(final AppContext context) {
         final SpreadsheetCellClipboardKind kind = this.kind();
-        final SpreadsheetCellRangeReference range = this.anchoredSelection()
-                .selection()
-                .toCellRange();
+        final SpreadsheetCellRangeReference range = context.spreadsheetViewportCache()
+                .resolveIfLabel(
+                        this.anchoredSelection()
+                                .selection()
+                ).toCellRange();
 
         final ClipboardTextItem clipboardTextItem = ClipboardTextItem.toJson(
                 context.spreadsheetViewportCache()

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellClipboardCutHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellClipboardCutHistoryToken.java
@@ -83,9 +83,11 @@ public final class SpreadsheetCellClipboardCutHistoryToken extends SpreadsheetCe
     @Override
     void onHistoryTokenChangeClipboard(final AppContext context) {
         final SpreadsheetCellClipboardKind kind = this.kind();
-        final SpreadsheetCellRangeReference range = this.anchoredSelection()
-                .selection()
-                .toCellRange();
+        final SpreadsheetCellRangeReference range = context.spreadsheetViewportCache()
+                .resolveIfLabel(
+                        this.anchoredSelection()
+                                .selection()
+                ).toCellRange();
 
         final ClipboardTextItem clipboardTextItem = ClipboardTextItem.toJson(
                 context.spreadsheetViewportCache()

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectionHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectionHistoryToken.java
@@ -24,6 +24,7 @@ import walkingkooka.spreadsheet.compare.SpreadsheetColumnOrRowSpreadsheetCompara
 import walkingkooka.spreadsheet.dominokit.clipboard.SpreadsheetCellClipboardKind;
 import walkingkooka.spreadsheet.dominokit.ui.SpreadsheetCellFind;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellRangeReferencePath;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolvers;
 import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.text.cursor.TextCursorSavePoint;
 
@@ -95,7 +96,10 @@ abstract public class SpreadsheetSelectionHistoryToken extends SpreadsheetNameHi
                 );
                 break;
             case "menu":
-                result = this.setMenu(Optional.empty());
+                result = this.setMenu(
+                        Optional.empty(), // no selection
+                        SpreadsheetLabelNameResolvers.fake()
+                );
                 break;
             case "parse-pattern":
                 result = this.parseParsePattern(cursor);

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTest.java
@@ -41,6 +41,7 @@ import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnRangeReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolvers;
 import walkingkooka.spreadsheet.reference.SpreadsheetRowRangeReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetRowReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
@@ -143,17 +144,17 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>, Parse
     }
 
     @Test
-    public void testNonLabelSelectionUnknownLabel() {
+    public void testNonLabelSelectionUnknownLabelFails() {
         final SpreadsheetViewportCache cache = this.appContext()
                 .spreadsheetViewportCache();
 
-        this.nonLabelSelectionAndCheck(
-                HistoryToken.cell(
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> HistoryToken.cell(
                         ID,
                         NAME,
                         LABEL.setDefaultAnchor()
-                ),
-                cache
+                ).nonLabelSelection(cache)
         );
     }
 
@@ -1166,11 +1167,26 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>, Parse
     // setMenu..........................................................................................................
 
     @Test
-    public void testSetMenuWithNullFails() {
+    public void testSetMenuWithNullSelectionFails() {
         assertThrows(
                 NullPointerException.class,
                 () -> HistoryToken.unknown(UrlFragment.EMPTY)
-                        .setMenu(null)
+                        .setMenu(
+                                null,
+                                SpreadsheetLabelNameResolvers.fake()
+                        )
+        );
+    }
+
+    @Test
+    public void testSetMenuWithNullLabelNameResolverFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> HistoryToken.unknown(UrlFragment.EMPTY)
+                        .setMenu(
+                                Optional.of(SpreadsheetSelection.A1),
+                                null
+                        )
         );
     }
 
@@ -1726,7 +1742,10 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>, Parse
                                  final HistoryToken expected) {
         this.checkEquals(
                 expected,
-                token.setMenu(selection),
+                token.setMenu(
+                        selection,
+                        SpreadsheetLabelNameResolvers.fake()
+                ),
                 () -> token + " setMenu " + selection
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/ui/viewport/SpreadsheetViewportCacheTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/ui/viewport/SpreadsheetViewportCacheTest.java
@@ -51,6 +51,8 @@ import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelMapping;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolver;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolverTesting;
 import walkingkooka.spreadsheet.reference.SpreadsheetRowReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.tree.text.Length;
@@ -66,6 +68,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class SpreadsheetViewportCacheTest implements IteratorTesting,
+        SpreadsheetLabelNameResolverTesting,
         ClassTesting<SpreadsheetViewportCache> {
 
     private final static SpreadsheetCellReference A1 = SpreadsheetCellReference.A1;
@@ -677,7 +680,7 @@ public final class SpreadsheetViewportCacheTest implements IteratorTesting,
                 false
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 A1,
                 A1
@@ -837,7 +840,7 @@ public final class SpreadsheetViewportCacheTest implements IteratorTesting,
                 LABEL_MAPPINGA1B
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 LABEL_MAPPINGA1B.label(),
                 LABEL_MAPPINGA1B.target()
@@ -1900,7 +1903,7 @@ public final class SpreadsheetViewportCacheTest implements IteratorTesting,
                 CONTEXT
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelFails(
                 cache,
                 LABEL999
         );
@@ -1934,13 +1937,13 @@ public final class SpreadsheetViewportCacheTest implements IteratorTesting,
                 CONTEXT
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 A1,
                 A1
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 A2,
                 A2
@@ -2012,7 +2015,7 @@ public final class SpreadsheetViewportCacheTest implements IteratorTesting,
                 CONTEXT
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 nonLabel,
                 nonLabel
@@ -2050,7 +2053,7 @@ public final class SpreadsheetViewportCacheTest implements IteratorTesting,
                 CONTEXT
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 LABEL3,
                 B3
@@ -2095,13 +2098,13 @@ public final class SpreadsheetViewportCacheTest implements IteratorTesting,
                 LABEL_MAPPINGA1B
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 LABEL1,
                 A1
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 LABEL2,
                 A1
@@ -2156,13 +2159,13 @@ public final class SpreadsheetViewportCacheTest implements IteratorTesting,
                 )
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 LABEL999,
                 b3b4
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 B3,
                 B3
@@ -2207,13 +2210,13 @@ public final class SpreadsheetViewportCacheTest implements IteratorTesting,
                 )
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 LABEL999,
                 B3
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 LABEL3,
                 B3
@@ -2265,13 +2268,13 @@ public final class SpreadsheetViewportCacheTest implements IteratorTesting,
                 )
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 LABEL999,
                 b3b4
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 LABEL3,
                 b3b4
@@ -2316,13 +2319,13 @@ public final class SpreadsheetViewportCacheTest implements IteratorTesting,
                 )
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 LABEL3,
                 B3
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 LABEL999,
                 B3
@@ -2379,25 +2382,25 @@ public final class SpreadsheetViewportCacheTest implements IteratorTesting,
                 )
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 LABEL1,
                 A1
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 LABEL2,
                 A1
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 LABEL3,
                 B3
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 LABEL999,
                 B3
@@ -2458,31 +2461,31 @@ public final class SpreadsheetViewportCacheTest implements IteratorTesting,
                 )
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 LABEL1,
                 A1
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 LABEL2,
                 A1
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 LABEL3,
                 B3
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 LABEL999,
                 B3
         );
 
-        this.checkNonLabelSelection(
+        this.resolveIfLabelAndCheck(
                 cache,
                 third,
                 B3
@@ -3777,35 +3780,6 @@ public final class SpreadsheetViewportCacheTest implements IteratorTesting,
         }
     }
 
-    private void checkNonLabelSelection(final SpreadsheetViewportCache cache,
-                                        final SpreadsheetSelection selection) {
-        this.checkNonLabelSelection(
-                cache,
-                selection,
-                Optional.empty()
-        );
-    }
-
-    private void checkNonLabelSelection(final SpreadsheetViewportCache cache,
-                                        final SpreadsheetSelection selection,
-                                        final SpreadsheetSelection nonLabel) {
-        this.checkNonLabelSelection(
-                cache,
-                selection,
-                Optional.of(nonLabel)
-        );
-    }
-
-    private void checkNonLabelSelection(final SpreadsheetViewportCache cache,
-                                        final SpreadsheetSelection selection,
-                                        final Optional<SpreadsheetSelection> nonLabel) {
-        this.checkEquals(
-                nonLabel,
-                cache.nonLabelSelection(selection),
-                "nonLabelSelection " + selection
-        );
-    }
-
     // isColumnHidden...................................................................................................
 
     @Test
@@ -3914,6 +3888,13 @@ public final class SpreadsheetViewportCacheTest implements IteratorTesting,
                 cache.isRowHidden(row),
                 () -> "isHidden " + row
         );
+    }
+
+    // SpreadsheetLabelNameResolver.....................................................................................
+
+    @Override
+    public SpreadsheetLabelNameResolver spreadsheetLabelNameResolver() {
+        return this.viewportCache();
     }
 
     // ClassTesting.....................................................................................................


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/2571
- SpreadsheetViewportCache needs to implement SpreadsheetLabelNameResolver

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/2569
- SpreadsheetViewportCache.nonLabelSelection should not return Optional - it should fail if it cant resolve the given label
- SpreadsheetLabelNameResolve.resolveXXX do not return Optional.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/2565
- context menu is broken for cell selection using label
- The rendered TABLE only maps columns/rows/cells to TABLE CELLS, labels would never work, added intermediate translation of label to cell(s)