### PR TITLE
HistoryToken setCell/setColumn/SetRow removed

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryToken.java
@@ -1355,26 +1355,6 @@ public abstract class HistoryToken implements HasUrlFragment,
     }
 
     /**
-     * Sets or replaces the current {@link SpreadsheetSelection} otherwise returns this.
-     */
-    public final HistoryToken setCell(final SpreadsheetSelection selection) {
-        Objects.requireNonNull(selection, "selection");
-        HistoryToken token = this;
-
-        if (this instanceof SpreadsheetNameHistoryToken) {
-            final SpreadsheetNameHistoryToken spreadsheetNameHistoryToken = this.cast(SpreadsheetNameHistoryToken.class);
-            token = cell(
-                    spreadsheetNameHistoryToken.id(),
-                    spreadsheetNameHistoryToken.name(),
-                    selection.setDefaultAnchor()
-            );
-        }
-
-        return token;
-    }
-
-
-    /**
      * If possible creates a {@link SpreadsheetCellClipboardCopyHistoryToken} token.
      */
     public final HistoryToken setCellCopy(final SpreadsheetCellClipboardKind kind) {
@@ -1472,25 +1452,6 @@ public abstract class HistoryToken implements HasUrlFragment,
         return this.setIfSpreadsheetNameHistoryToken(
                 SpreadsheetNameHistoryToken::setClear0
         );
-    }
-
-    /**
-     * Sets or replaces the current {@link SpreadsheetSelection} otherwise returns this.
-     */
-    public final HistoryToken setColumn(final SpreadsheetSelection selection) {
-        Objects.requireNonNull(selection, "selection");
-        HistoryToken token = this;
-
-        if (this instanceof SpreadsheetNameHistoryToken) {
-            final SpreadsheetNameHistoryToken spreadsheetNameHistoryToken = this.cast(SpreadsheetNameHistoryToken.class);
-            token = column(
-                    spreadsheetNameHistoryToken.id(),
-                    spreadsheetNameHistoryToken.name(),
-                    selection.setDefaultAnchor()
-            );
-        }
-
-        return token;
     }
 
     public final OptionalInt count() {
@@ -2028,25 +1989,6 @@ public abstract class HistoryToken implements HasUrlFragment,
             token = spreadsheetRenameSelect(
                     spreadsheetNameHistoryToken.id(),
                     spreadsheetNameHistoryToken.name()
-            );
-        }
-
-        return token;
-    }
-
-    /**
-     * Sets or replaces the current {@link SpreadsheetSelection} otherwise returns this.
-     */
-    public final HistoryToken setRow(final SpreadsheetSelection selection) {
-        Objects.requireNonNull(selection, "selection");
-        HistoryToken token = this;
-
-        if (this instanceof SpreadsheetNameHistoryToken) {
-            final SpreadsheetNameHistoryToken spreadsheetNameHistoryToken = this.cast(SpreadsheetNameHistoryToken.class);
-            token = row(
-                    spreadsheetNameHistoryToken.id(),
-                    spreadsheetNameHistoryToken.name(),
-                    selection.setDefaultAnchor()
             );
         }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenSelectionSpreadsheetSelectionVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenSelectionSpreadsheetSelectionVisitor.java
@@ -17,6 +17,8 @@
 
 package walkingkooka.spreadsheet.dominokit.history;
 
+import walkingkooka.spreadsheet.SpreadsheetId;
+import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellRangeReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
@@ -29,102 +31,112 @@ import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelectionVisitor;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportAnchor;
 
-import java.util.function.Function;
-
 /**
  * This visitor is used to create a {@link SpreadsheetHistoryToken} that selects the given {@link SpreadsheetSelection}.
  */
 final class HistoryTokenSelectionSpreadsheetSelectionVisitor extends SpreadsheetSelectionVisitor {
 
-    static HistoryToken selectionToken(final SpreadsheetHistoryToken token,
+    static HistoryToken selectionToken(final SpreadsheetNameHistoryToken historyToken,
                                        final AnchoredSpreadsheetSelection anchoredSelection) {
         final HistoryTokenSelectionSpreadsheetSelectionVisitor visitor = new HistoryTokenSelectionSpreadsheetSelectionVisitor(
-                token,
+                historyToken.id(),
+                historyToken.name(),
                 anchoredSelection.anchor()
         );
         visitor.accept(
                 anchoredSelection.selection()
         );
-        return visitor.selectionToken;
+        return visitor.historyToken;
     }
 
-    HistoryTokenSelectionSpreadsheetSelectionVisitor(final SpreadsheetHistoryToken token,
+    HistoryTokenSelectionSpreadsheetSelectionVisitor(final SpreadsheetId id,
+                                                     final SpreadsheetName name,
                                                      final SpreadsheetViewportAnchor anchor) {
         super();
-        this.token = token;
+        this.id = id;
+        this.name = name;
         this.anchor = anchor;
     }
 
     @Override
     protected void visit(final SpreadsheetCellRangeReference cell) {
-        this.setSelectionToken(
-                cell,
-                this.token::setCell
-        );
+        this.setCell(cell);
     }
 
     @Override
     protected void visit(final SpreadsheetCellReference cell) {
-        this.setSelectionToken(
-                cell,
-                this.token::setCell
-        );
+        this.setCell(cell);
     }
 
     @Override
     protected void visit(final SpreadsheetColumnReference column) {
-        this.setSelectionToken(
-                column,
-                this.token::setColumn
-        );
+        this.setColumn(column);
     }
 
     @Override
     protected void visit(final SpreadsheetColumnRangeReference column) {
+        this.setColumn(column);
+    }
+
+    private void setColumn(final SpreadsheetSelection selection) {
         this.setSelectionToken(
-                column,
-                this.token::setColumn
+                HistoryToken.column(
+                        this.id,
+                        this.name,
+                        selection.setAnchor(this.anchor)
+                )
         );
     }
 
     @Override
     protected void visit(final SpreadsheetLabelName label) {
+        this.setCell(label);
+    }
+
+    private void setCell(final SpreadsheetSelection selection) {
         this.setSelectionToken(
-                label,
-                this.token::setCell
+                HistoryToken.cell(
+                        this.id,
+                        this.name,
+                        selection.setAnchor(this.anchor)
+                )
         );
     }
 
     @Override
     protected void visit(final SpreadsheetRowReference row) {
-        this.setSelectionToken(
-                row,
-                this.token::setRow
-        );
+        this.setRow(row);
     }
 
     @Override
     protected void visit(final SpreadsheetRowRangeReference range) {
+        this.setRow(range);
+    }
+
+    private void setRow(final SpreadsheetSelection selection) {
         this.setSelectionToken(
-                range,
-                this.token::setRow
+                HistoryToken.row(
+                        this.id,
+                        this.name,
+                        selection.setAnchor(this.anchor)
+                )
         );
     }
 
-    private final HistoryToken token;
+    private final SpreadsheetId id;
 
-    private void setSelectionToken(final SpreadsheetSelection selection,
-                                   final Function<SpreadsheetSelection, HistoryToken> factory) {
-        this.selectionToken = factory.apply(selection)
-                .setAnchor(this.anchor);
+    private final SpreadsheetName name;
+
+    private void setSelectionToken(final HistoryToken selection) {
+        this.historyToken = selection;
     }
 
-    private HistoryToken selectionToken;
+    private HistoryToken historyToken;
 
     private final SpreadsheetViewportAnchor anchor;
 
     @Override
     public String toString() {
-        return this.token.toString();
+        return this.historyToken.toString();
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectHistoryToken.java
@@ -64,14 +64,10 @@ public final class SpreadsheetSelectHistoryToken extends SpreadsheetNameHistoryT
 
         switch(component) {
             case "cell":
-                result = this.parseCell(
-                        cursor
-                );
+                result = this.parseCell(cursor);
                 break;
             case "column":
-                result = this.parseColumn(
-                        cursor
-                );
+                result = this.parseColumn(cursor);
                 break;
             case "delete":
                 result = this.parseDelete(cursor);
@@ -89,9 +85,7 @@ public final class SpreadsheetSelectHistoryToken extends SpreadsheetNameHistoryT
                 result = this.parseRename(cursor);
                 break;
             case "row":
-                result = this.parseRow(
-                        cursor
-                );
+                result = this.parseRow(cursor);
                 break;
             default:
                 cursor.end();
@@ -104,36 +98,38 @@ public final class SpreadsheetSelectHistoryToken extends SpreadsheetNameHistoryT
     private HistoryToken parseCell(final TextCursor cursor) {
         return parseCellColumnOrRow(
                 cursor,
-                SpreadsheetSelection::parseExpressionReference,
-                this::setCell
+                SpreadsheetSelection::parseExpressionReference
         );
     }
 
     private HistoryToken parseColumn(final TextCursor cursor) {
         return parseCellColumnOrRow(
                 cursor,
-                SpreadsheetSelection::parseColumnOrColumnRange,
-                this::setColumn
+                SpreadsheetSelection::parseColumnOrColumnRange
         );
     }
 
     private HistoryToken parseRow(final TextCursor cursor) {
         return parseCellColumnOrRow(
                 cursor,
-                SpreadsheetSelection::parseRowOrRowRange,
-                this::setRow
+                SpreadsheetSelection::parseRowOrRowRange
         );
     }
 
     private HistoryToken parseCellColumnOrRow(final TextCursor cursor,
-                                              final Function<String, SpreadsheetSelection> parser,
-                                              final Function<SpreadsheetSelection, HistoryToken> historyTokenFactory) {
+                                              final Function<String, SpreadsheetSelection> parser) {
         HistoryToken result = this;
 
         final Optional<String> maybeSelection = parseComponent(cursor);
         if (maybeSelection.isPresent()) {
-            result = historyTokenFactory.apply(
-                    parser.apply(maybeSelection.get())
+            final SpreadsheetSelection selection = parser.apply(
+                    maybeSelection.get()
+            );
+
+            result = this.setAnchoredSelection(
+                    Optional.of(
+                            selection.setDefaultAnchor()
+                    )
             );
 
             final TextCursorSavePoint beforeAnchor = cursor.save();

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/find/SpreadsheetFindDialogComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/find/SpreadsheetFindDialogComponent.java
@@ -203,7 +203,12 @@ public final class SpreadsheetFindDialogComponent implements SpreadsheetDialogCo
                 .setHistoryToken(
                         Optional.of(
                                 historyToken.clearSelection()
-                                        .setCell(cell.reference())
+                                        .setAnchoredSelection(
+                                                Optional.of(
+                                                        cell.reference()
+                                                                .setDefaultAnchor()
+                                                )
+                                        )
                         )
                 ).element();
     }
@@ -217,8 +222,12 @@ public final class SpreadsheetFindDialogComponent implements SpreadsheetDialogCo
                 .setHistoryToken(
                         Optional.of(
                                 historyToken.clearSelection()
-                                        .setCell(cell.reference())
-                                        .setFormula()
+                                        .setAnchoredSelection(
+                                                Optional.of(
+                                                        cell.reference()
+                                                                .setDefaultAnchor()
+                                                )
+                                        ).setFormula()
                         )
                 ).element();
     }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/selectionmenu/SpreadsheetSelectionMenu.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/selectionmenu/SpreadsheetSelectionMenu.java
@@ -902,8 +902,11 @@ public final class SpreadsheetSelectionMenu implements PublicStaticHelper {
                                       final SpreadsheetContextMenu menu,
                                       final SpreadsheetSelectionMenuContext context) {
         if (selection.isColumnReference() | selection.isColumnRangeReference() | selection.isCellReference() || selection.isCellRangeReference()) {
-            final HistoryToken columnHistoryToken = historyToken.setColumn(
-                    selection.toColumnOrColumnRange()
+            final HistoryToken columnHistoryToken = historyToken.setAnchoredSelection(
+                    Optional.of(
+                            selection.toColumnOrColumnRange()
+                                    .setDefaultAnchor()
+                    )
             );
 
             final String beforeIdPrefix = context.idPrefix() + "column-insert-before";
@@ -937,8 +940,11 @@ public final class SpreadsheetSelectionMenu implements PublicStaticHelper {
                                    final SpreadsheetContextMenu menu,
                                    final SpreadsheetSelectionMenuContext context) {
         if (selection.isRowReference() | selection.isRowRangeReference() | selection.isCellReference() || selection.isCellRangeReference()) {
-            final HistoryToken rowHistoryToken = historyToken.setRow(
-                    selection.toRowOrRowRange()
+            final HistoryToken rowHistoryToken = historyToken.setAnchoredSelection(
+                    Optional.of(
+                            selection.toRowOrRowRange()
+                                    .setDefaultAnchor()
+                    )
             );
 
             final String beforeIdPrefix = context.idPrefix() + "row-insert-before";

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenSelectionSpreadsheetSelectionVisitorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenSelectionSpreadsheetSelectionVisitorTest.java
@@ -23,7 +23,11 @@ import walkingkooka.spreadsheet.reference.SpreadsheetSelectionVisitorTesting;
 public final class HistoryTokenSelectionSpreadsheetSelectionVisitorTest implements SpreadsheetSelectionVisitorTesting<HistoryTokenSelectionSpreadsheetSelectionVisitor> {
     @Override
     public HistoryTokenSelectionSpreadsheetSelectionVisitor createVisitor() {
-        return new HistoryTokenSelectionSpreadsheetSelectionVisitor(null, null);
+        return new HistoryTokenSelectionSpreadsheetSelectionVisitor(
+                null,
+                null,
+                null
+        );
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTest.java
@@ -119,40 +119,6 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>, Parse
         );
     }
 
-    // setCell..........................................................................................................
-
-    @Test
-    public void testSetCellWithNotSpreadsheetNameHistoryTokenSubclass() {
-        final HistoryToken historyToken = HistoryToken.unknown(UrlFragment.parse("/something else"));
-
-        assertSame(
-                historyToken.setCell(CELL),
-                historyToken
-        );
-    }
-
-    @Test
-    public void testSetCellWithColumnFails() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> HistoryToken.spreadsheetSelect(ID, NAME).setCell(COLUMN)
-        );
-    }
-
-    @Test
-    public void testSetCell() {
-        final HistoryToken historyToken = HistoryToken.spreadsheetSelect(ID, NAME);
-
-        this.checkEquals(
-                historyToken.setCell(CELL),
-                HistoryToken.cell(
-                        ID,
-                        NAME,
-                        CELL.setDefaultAnchor()
-                )
-        );
-    }
-
     // setCount.........................................................................................................
 
     @Test
@@ -563,40 +529,6 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>, Parse
                         ID,
                         NAME,
                         selection
-                )
-        );
-    }
-
-    // setColumn........................................................................................................
-
-    @Test
-    public void testSetColumnWithNotSpreadsheetNameHistoryTokenSubclass() {
-        final HistoryToken historyToken = HistoryToken.unknown(UrlFragment.parse("/something else"));
-
-        assertSame(
-                historyToken.setColumn(COLUMN),
-                historyToken
-        );
-    }
-
-    @Test
-    public void testSetColumnWithCellFails() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> HistoryToken.spreadsheetSelect(ID, NAME).setColumn(CELL)
-        );
-    }
-
-    @Test
-    public void testSetColumn() {
-        final HistoryToken historyToken = HistoryToken.spreadsheetSelect(ID, NAME);
-
-        this.checkEquals(
-                historyToken.setColumn(COLUMN),
-                HistoryToken.column(
-                        ID,
-                        NAME,
-                        COLUMN.setDefaultAnchor()
                 )
         );
     }


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/2605
- HistoryToken.setRow is forcing default anchor, resulting in any anchors being lost

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/2604
- HistoryToken.setColumn is forcing default anchor, resulting in any anchors being lost

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/2603
- HistoryToken.setCell is forcing default anchor, resulting in any anchors being lost