### PR TITLE
BasicSpreadsheetViewportComponentTableContext.isShiftKeyDown()

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/viewport/BasicSpreadsheetViewportComponentTableContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/viewport/BasicSpreadsheetViewportComponentTableContext.java
@@ -31,6 +31,7 @@ final class BasicSpreadsheetViewportComponentTableContext implements Spreadsheet
                                                               final boolean hideZeroValues,
                                                               final TextStyle defaultCellStyle,
                                                               final boolean mustRefresh,
+                                                              final boolean shiftKeyDown,
                                                               final LoggingContext loggingContext) {
         return new BasicSpreadsheetViewportComponentTableContext(
                 historyTokenContext,
@@ -38,6 +39,7 @@ final class BasicSpreadsheetViewportComponentTableContext implements Spreadsheet
                 hideZeroValues,
                 defaultCellStyle,
                 mustRefresh,
+                shiftKeyDown,
                 loggingContext
         );
     }
@@ -47,12 +49,14 @@ final class BasicSpreadsheetViewportComponentTableContext implements Spreadsheet
                                                           final boolean hideZeroValues,
                                                           final TextStyle defaultCellStyle,
                                                           final boolean mustRefresh,
+                                                          final boolean shiftKeyDown,
                                                           final LoggingContext loggingContext) {
         this.historyTokenContext = historyTokenContext;
         this.viewportCache = viewportCache;
         this.hideZeroValues = hideZeroValues;
         this.defaultCellStyle = defaultCellStyle;
         this.mustRefresh = mustRefresh;
+        this.shiftKeyDown = shiftKeyDown;
         this.loggingContext = loggingContext;
     }
 
@@ -110,6 +114,13 @@ final class BasicSpreadsheetViewportComponentTableContext implements Spreadsheet
     }
 
     private final boolean mustRefresh;
+
+    @Override
+    public boolean isShiftKeyDown() {
+        return this.shiftKeyDown;
+    }
+
+    private final boolean shiftKeyDown;
 
     @Override
     public void debug(final Object... values) {

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/viewport/SpreadsheetViewportComponentTableContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/viewport/SpreadsheetViewportComponentTableContext.java
@@ -37,4 +37,11 @@ interface SpreadsheetViewportComponentTableContext extends HistoryTokenContext,
      * When true a {@link SpreadsheetViewportComponentTableCell} must refresh.
      */
     boolean mustRefresh();
+
+
+    /**
+     * When true indicates that the SHIFT key is currently DOWN.
+     * This will be useful to update the links within the COLUMN and ROW headers.
+     */
+    boolean isShiftKeyDown();
 }


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/2638
- SpreadsheetViewportComponent ROW click with SHIFT extends range

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/2637
- SpreadsheetViewportComponent COLUMN click with SHIFT extends range

- Need to update SpreadsheetViewportComponentTableCellHeaderSpreadsheetColumn/SpreadsheetViewportComponentTableCellHeaderSpreadsheetRow refresh to read Context.shiftKeyDown and refresh link.