### PR TITLE
ElementHistory.pushHistoryToken trace replaces debug

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/ElementalHistory.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/ElementalHistory.java
@@ -50,8 +50,7 @@ final class ElementalHistory implements History {
                             final String newHash = "#" + token.urlFragment();
                             final String current = DomGlobal.location.hash;
                             if (false == current.equals(newHash)) {
-                                this.context.debug("ElementalHistory.pushHistoryToken from " + CharSequences.quoteAndEscape(current) + " to " + CharSequences.quoteAndEscape(newHash));
-
+                                DomGlobal.console.trace("ElementalHistory.pushHistoryToken from " + CharSequences.quoteAndEscape(current) + " to " + CharSequences.quoteAndEscape(newHash));
                                 DomGlobal.location.hash = newHash;
                             }
                         }


### PR DESCRIPTION
- This should be helpful as it includes the full stacktrace allowing the original pusher to be seen in the console.