### PR TITLE
SpreadsheetTextBox.validator InvalidCharacterException#getShortMessag…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/textbox/SpreadsheetTextBoxStringParserValidator.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/textbox/SpreadsheetTextBoxStringParserValidator.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.dominokit.ui.textbox;
 
 import org.dominokit.domino.ui.forms.validations.ValidationResult;
 import org.dominokit.domino.ui.utils.HasValidation.Validator;
+import walkingkooka.InvalidCharacterException;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -52,6 +53,8 @@ final class SpreadsheetTextBoxStringParserValidator implements Validator<Optiona
                     value.orElse("")
             );
             result = ValidationResult.valid();
+        } catch (final InvalidCharacterException fail) {
+            result = ValidationResult.invalid(fail.getShortMessage());
         } catch (final Exception fail) {
             result = ValidationResult.invalid(fail.getMessage());
         }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/ui/parsertextbox/ParserSpreadsheetTextBoxTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/ui/parsertextbox/ParserSpreadsheetTextBoxTest.java
@@ -53,6 +53,24 @@ public final class ParserSpreadsheetTextBoxTest implements ValueComponentTesting
     }
 
     @Test
+    public void testPrintTreeSetStringValueInvalidCharacter() {
+        this.treePrintAndCheck(
+                ParserSpreadsheetTextBox.with(SpreadsheetSelection::parseCell)
+                        .setId("id123")
+                        .setStringValue(
+                                Optional.of(
+                                        "AB!12"
+                                )
+                        ),
+                "ParserSpreadsheetTextBox\n" +
+                        "  SpreadsheetTextBox\n" +
+                        "    [AB!12] id=id123\n" +
+                        "    Errors\n" +
+                        "      Invalid character '!' at 2\n"
+        );
+    }
+
+    @Test
     public void testTreePrint() {
         this.treePrintAndCheck(
                 ParserSpreadsheetTextBox.with(SpreadsheetSelection::parseCell)

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/ui/textbox/SpreadsheetTextBoxTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/ui/textbox/SpreadsheetTextBoxTest.java
@@ -21,6 +21,7 @@ import elemental2.dom.HTMLFieldSetElement;
 import org.dominokit.domino.ui.forms.validations.ValidationResult;
 import org.dominokit.domino.ui.utils.HasValidation.Validator;
 import org.junit.jupiter.api.Test;
+import walkingkooka.InvalidCharacterException;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.spreadsheet.dominokit.ui.viewport.ValueComponentTesting;
 
@@ -43,6 +44,25 @@ public final class SpreadsheetTextBoxTest implements ValueComponentTesting<HTMLF
                         ).setValue(Optional.of("Value456")),
                 "SpreadsheetTextBox\n" +
                         "  Label123 [Value456]\n"
+        );
+    }
+
+    @Test
+    public void testValidationFailureInvalidCharacterException() {
+        this.treePrintAndCheck(
+                SpreadsheetTextBox.empty()
+                        .setLabel("Label123")
+                        .setValidator(
+                                SpreadsheetTextBoxValidators.parser(
+                                        (s) -> {
+                                            throw new InvalidCharacterException(s, 2);
+                                        }
+                                )
+                        ).setValue(Optional.of("Value456")),
+                "SpreadsheetTextBox\n" +
+                        "  Label123 [Value456]\n" +
+                        "  Errors\n" +
+                        "    Invalid character 'l' at 2\n"
         );
     }
 


### PR DESCRIPTION
…e FIX

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/2914
- ParserSpreadsheetTextBox catch InvalidCharacterException without "in $text"