### PR TITLE
SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetCompar…

### DIFF
--- a/src/test/java/walkingkooka/spreadsheet/dominokit/ui/sort/SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/ui/sort/SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponentTest.java
@@ -27,11 +27,14 @@ import walkingkooka.spreadsheet.compare.SpreadsheetColumnOrRowSpreadsheetCompara
 import walkingkooka.spreadsheet.compare.SpreadsheetComparatorInfo;
 import walkingkooka.spreadsheet.compare.SpreadsheetComparatorName;
 import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
+import walkingkooka.spreadsheet.dominokit.history.HistoryTokenContexts;
 import walkingkooka.text.printer.TreePrintableTesting;
 
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -40,15 +43,28 @@ public final class SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadshe
 
     private final static String ID = SpreadsheetSortDialogComponent.ID_PREFIX + "comparator-1-";
 
+    private final static Function<Optional<SpreadsheetColumnOrRowSpreadsheetComparatorNames>, Optional<HistoryToken>> MOVE_UP = (names) -> {
+        throw new UnsupportedOperationException();
+    };
+
+    private final static Function<Optional<SpreadsheetColumnOrRowSpreadsheetComparatorNames>, Optional<HistoryToken>> MOVE_DOWN = MOVE_UP;
+
+    private final static Function<Optional<SpreadsheetColumnOrRowSpreadsheetComparatorNames>, HistoryToken> SETTER = (names) -> {
+        throw new UnsupportedOperationException();
+    };
+
+    private final static String HISTORY_TOKEN = "/1/SpreadsheetName123/cell/A1:C3/top-right/sort/edit/";
+
     @Test
     public void testWithNullIdFails() {
         assertThrows(
                 NullPointerException.class,
                 () -> SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent.with(
                         null,
-                        (names) -> {
-                            throw new UnsupportedOperationException();
-                        }
+                        MOVE_UP,
+                        MOVE_DOWN,
+                        SETTER,
+                        HistoryTokenContexts.fake()
                 )
         );
     }
@@ -59,9 +75,38 @@ public final class SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadshe
                 IllegalArgumentException.class,
                 () -> SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent.with(
                         "",
-                        (names) -> {
-                            throw new UnsupportedOperationException();
-                        }
+                        MOVE_UP,
+                        MOVE_DOWN,
+                        SETTER,
+                        HistoryTokenContexts.fake()
+                )
+        );
+    }
+
+    @Test
+    public void testWithNullMoveUpFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent.with(
+                        ID,
+                        null,
+                        MOVE_DOWN,
+                        SETTER,
+                        HistoryTokenContexts.fake()
+                )
+        );
+    }
+
+    @Test
+    public void testWithNullMoveDownFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent.with(
+                        ID,
+                        MOVE_UP,
+                        null,
+                        SETTER,
+                        HistoryTokenContexts.fake()
                 )
         );
     }
@@ -72,7 +117,10 @@ public final class SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadshe
                 NullPointerException.class,
                 () -> SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent.with(
                         ID,
-                        null
+                        MOVE_UP,
+                        MOVE_DOWN,
+                        null,
+                        HistoryTokenContexts.fake()
                 )
         );
     }
@@ -83,12 +131,15 @@ public final class SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadshe
                 "",
                 "SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "  SpreadsheetFlexLayout\n" +
-                        "    SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "      ParserSpreadsheetTextBox\n" +
-                        "        SpreadsheetTextBox\n" +
-                        "          [] id=sort-comparator-1-TextBox\n" +
-                        "          Errors\n" +
-                        "            text is empty\n"
+                        "    SpreadsheetFlexLayout\n" +
+                        "      SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "        ParserSpreadsheetTextBox\n" +
+                        "          SpreadsheetTextBox\n" +
+                        "            [] id=sort-comparator-1-TextBox\n" +
+                        "            Errors\n" +
+                        "              text is empty\n" +
+                        "      \"Move Up\" DISABLED id=sort-comparator-1-moveUp-Link\n" +
+                        "      \"Move Down\" DISABLED id=sort-comparator-1-moveDown-Link\n"
         );
     }
 
@@ -98,12 +149,15 @@ public final class SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadshe
                 "A",
                 "SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "  SpreadsheetFlexLayout\n" +
-                        "    SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "      ParserSpreadsheetTextBox\n" +
-                        "        SpreadsheetTextBox\n" +
-                        "          [A] id=sort-comparator-1-TextBox\n" +
-                        "          Errors\n" +
-                        "            Missing '='\n" +
+                        "    SpreadsheetFlexLayout\n" +
+                        "      SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "        ParserSpreadsheetTextBox\n" +
+                        "          SpreadsheetTextBox\n" +
+                        "            [A] id=sort-comparator-1-TextBox\n" +
+                        "            Errors\n" +
+                        "              Missing '='\n" +
+                        "      \"Move Up\" DISABLED id=sort-comparator-1-moveUp-Link\n" +
+                        "      \"Move Down\" DISABLED id=sort-comparator-1-moveDown-Link\n" +
                         "    SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "      SpreadsheetCard\n" +
                         "        Card\n" +
@@ -120,12 +174,15 @@ public final class SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadshe
                 "A=",
                 "SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "  SpreadsheetFlexLayout\n" +
-                        "    SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "      ParserSpreadsheetTextBox\n" +
-                        "        SpreadsheetTextBox\n" +
-                        "          [A=] id=sort-comparator-1-TextBox\n" +
-                        "          Errors\n" +
-                        "            Missing comparator name\n" +
+                        "    SpreadsheetFlexLayout\n" +
+                        "      SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "        ParserSpreadsheetTextBox\n" +
+                        "          SpreadsheetTextBox\n" +
+                        "            [A=] id=sort-comparator-1-TextBox\n" +
+                        "            Errors\n" +
+                        "              Missing comparator name\n" +
+                        "      \"Move Up\" DISABLED id=sort-comparator-1-moveUp-Link\n" +
+                        "      \"Move Down\" DISABLED id=sort-comparator-1-moveDown-Link\n" +
                         "    SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "      SpreadsheetCard\n" +
                         "        Card\n" +
@@ -142,12 +199,15 @@ public final class SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadshe
                 "12=",
                 "SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "  SpreadsheetFlexLayout\n" +
-                        "    SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "      ParserSpreadsheetTextBox\n" +
-                        "        SpreadsheetTextBox\n" +
-                        "          [12=] id=sort-comparator-1-TextBox\n" +
-                        "          Errors\n" +
-                        "            Missing comparator name\n" +
+                        "    SpreadsheetFlexLayout\n" +
+                        "      SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "        ParserSpreadsheetTextBox\n" +
+                        "          SpreadsheetTextBox\n" +
+                        "            [12=] id=sort-comparator-1-TextBox\n" +
+                        "            Errors\n" +
+                        "              Missing comparator name\n" +
+                        "      \"Move Up\" DISABLED id=sort-comparator-1-moveUp-Link\n" +
+                        "      \"Move Down\" DISABLED id=sort-comparator-1-moveDown-Link\n" +
                         "    SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "      SpreadsheetCard\n" +
                         "        Card\n" +
@@ -164,10 +224,13 @@ public final class SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadshe
                 "A=comparator-1",
                 "SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "  SpreadsheetFlexLayout\n" +
-                        "    SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "      ParserSpreadsheetTextBox\n" +
-                        "        SpreadsheetTextBox\n" +
-                        "          [A=comparator-1] id=sort-comparator-1-TextBox\n" +
+                        "    SpreadsheetFlexLayout\n" +
+                        "      SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "        ParserSpreadsheetTextBox\n" +
+                        "          SpreadsheetTextBox\n" +
+                        "            [A=comparator-1] id=sort-comparator-1-TextBox\n" +
+                        "      \"Move Up\" DISABLED id=sort-comparator-1-moveUp-Link\n" +
+                        "      \"Move Down\" DISABLED id=sort-comparator-1-moveDown-Link\n" +
                         "    SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "      SpreadsheetCard\n" +
                         "        Card\n" +
@@ -188,10 +251,13 @@ public final class SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadshe
                 "A=comparator-1,comparator-2",
                 "SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "  SpreadsheetFlexLayout\n" +
-                        "    SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "      ParserSpreadsheetTextBox\n" +
-                        "        SpreadsheetTextBox\n" +
-                        "          [A=comparator-1,comparator-2] id=sort-comparator-1-TextBox\n" +
+                        "    SpreadsheetFlexLayout\n" +
+                        "      SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "        ParserSpreadsheetTextBox\n" +
+                        "          SpreadsheetTextBox\n" +
+                        "            [A=comparator-1,comparator-2] id=sort-comparator-1-TextBox\n" +
+                        "      \"Move Up\" DISABLED id=sort-comparator-1-moveUp-Link\n" +
+                        "      \"Move Down\" DISABLED id=sort-comparator-1-moveDown-Link\n" +
                         "    SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "      SpreadsheetCard\n" +
                         "        Card\n" +
@@ -212,10 +278,13 @@ public final class SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadshe
                 "A=comparator-1,comparator-2,comparator-3",
                 "SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "  SpreadsheetFlexLayout\n" +
-                        "    SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "      ParserSpreadsheetTextBox\n" +
-                        "        SpreadsheetTextBox\n" +
-                        "          [A=comparator-1,comparator-2,comparator-3] id=sort-comparator-1-TextBox\n" +
+                        "    SpreadsheetFlexLayout\n" +
+                        "      SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "        ParserSpreadsheetTextBox\n" +
+                        "          SpreadsheetTextBox\n" +
+                        "            [A=comparator-1,comparator-2,comparator-3] id=sort-comparator-1-TextBox\n" +
+                        "      \"Move Up\" DISABLED id=sort-comparator-1-moveUp-Link\n" +
+                        "      \"Move Down\" DISABLED id=sort-comparator-1-moveDown-Link\n" +
                         "    SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionRemover\n" +
                         "      SpreadsheetCard\n" +
                         "        Card\n" +
@@ -226,18 +295,187 @@ public final class SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadshe
         );
     }
 
-    void refreshAndCheck(final String columnOrRowSpreadsheetComparatorNames,
-                         final String expected) {
-        final String historyToken = "/1/SpreadsheetName123/cell/A1:C3/top-right/sort/edit/";
-
+    @Test
+    public void testCellAllComparatorNamesFirst() {
         this.refreshAndCheck(
-                columnOrRowSpreadsheetComparatorNames,
-                historyToken,
+                "A=comparator-1",
+                (names) -> Optional.empty(), // first CANT move-up
+                (names) -> Optional.of(
+                        HistoryToken.parse(
+                                UrlFragment.parse(
+                                        HISTORY_TOKEN +
+                                                concat(
+                                                        "B=comparator-2",
+                                                        names.map(SpreadsheetColumnOrRowSpreadsheetComparatorNames::text)
+                                                                .orElse(""),
+                                                        "C=comparator-3"
+                                                )
+                                )
+                        )
+                ), // move-down
                 (names) -> HistoryToken.parse(
                         UrlFragment.parse(
-                                historyToken +
-                                        names.map(SpreadsheetColumnOrRowSpreadsheetComparatorNames::text)
-                                                .orElse("")
+                                HISTORY_TOKEN +
+                                        concat(
+                                                names.map(SpreadsheetColumnOrRowSpreadsheetComparatorNames::text)
+                                                        .orElse(""),
+                                                "B=comparator-2",
+                                                "C=comparator-3"
+                                        )
+                        )
+                ), // setter
+                "SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "  SpreadsheetFlexLayout\n" +
+                        "    SpreadsheetFlexLayout\n" +
+                        "      SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "        ParserSpreadsheetTextBox\n" +
+                        "          SpreadsheetTextBox\n" +
+                        "            [A=comparator-1] id=sort-comparator-1-TextBox\n" +
+                        "      \"Move Up\" DISABLED id=sort-comparator-1-moveUp-Link\n" +
+                        "      \"Move Down\" [#/1/SpreadsheetName123/cell/A1:C3/top-right/sort/edit/B=comparator-2;A=comparator-1;C=comparator-3] id=sort-comparator-1-moveDown-Link\n" +
+                        "    SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
+                        "      SpreadsheetCard\n" +
+                        "        Card\n" +
+                        "          Append comparator(s)\n" +
+                        "            \"comparator-2\" [#/1/SpreadsheetName123/cell/A1:C3/top-right/sort/edit/A=comparator-1,comparator-2;B=comparator-2;C=comparator-3] id=sort-comparator-1-append-0-Link\n" +
+                        "            \"comparator-3\" [#/1/SpreadsheetName123/cell/A1:C3/top-right/sort/edit/A=comparator-1,comparator-3;B=comparator-2;C=comparator-3] id=sort-comparator-1-append-1-Link\n" +
+                        "    SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionRemover\n" +
+                        "      SpreadsheetCard\n" +
+                        "        Card\n" +
+                        "          Remove comparator(s)\n" +
+                        "            \"comparator-1\" [#/1/SpreadsheetName123/cell/A1:C3/top-right/sort/edit/B=comparator-2;C=comparator-3] id=sort-comparator-1-remove-0-Link\n"
+        );
+    }
+
+    @Test
+    public void testCellAllComparatorNamesMiddle() {
+        this.refreshAndCheck(
+                "B=comparator-2",
+                (names) -> Optional.of(
+                        HistoryToken.parse(
+                                UrlFragment.parse(
+                                        HISTORY_TOKEN +
+                                                concat(
+                                                        names.map(SpreadsheetColumnOrRowSpreadsheetComparatorNames::text)
+                                                                .orElse(""),
+                                                        "A=comparator-1",
+                                                        "C=comparator-3"
+                                                )
+                                )
+                        )
+                ), // move-up
+                (names) -> Optional.of(
+                        HistoryToken.parse(
+                                UrlFragment.parse(
+                                        HISTORY_TOKEN +
+                                                concat(
+                                                        "A=comparator-1",
+                                                        "C=comparator-3",
+                                                        names.map(SpreadsheetColumnOrRowSpreadsheetComparatorNames::text)
+                                                                .orElse("")
+                                                )
+                                )
+                        )
+                ), // move-down
+                (names) -> HistoryToken.parse(
+                        UrlFragment.parse(
+                                HISTORY_TOKEN +
+                                        concat(
+                                                "A=comparator-1",
+                                                names.map(SpreadsheetColumnOrRowSpreadsheetComparatorNames::text)
+                                                        .orElse(""),
+                                                "C=comparator-3"
+                                        )
+                        )
+                ), // setter
+                "SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "  SpreadsheetFlexLayout\n" +
+                        "    SpreadsheetFlexLayout\n" +
+                        "      SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "        ParserSpreadsheetTextBox\n" +
+                        "          SpreadsheetTextBox\n" +
+                        "            [B=comparator-2] id=sort-comparator-1-TextBox\n" +
+                        "      \"Move Up\" [#/1/SpreadsheetName123/cell/A1:C3/top-right/sort/edit/B=comparator-2;A=comparator-1;C=comparator-3] id=sort-comparator-1-moveUp-Link\n" +
+                        "      \"Move Down\" [#/1/SpreadsheetName123/cell/A1:C3/top-right/sort/edit/A=comparator-1;C=comparator-3;B=comparator-2] id=sort-comparator-1-moveDown-Link\n" +
+                        "    SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
+                        "      SpreadsheetCard\n" +
+                        "        Card\n" +
+                        "          Append comparator(s)\n" +
+                        "            \"comparator-1\" [#/1/SpreadsheetName123/cell/A1:C3/top-right/sort/edit/A=comparator-1;B=comparator-2,comparator-1;C=comparator-3] id=sort-comparator-1-append-0-Link\n" +
+                        "            \"comparator-3\" [#/1/SpreadsheetName123/cell/A1:C3/top-right/sort/edit/A=comparator-1;B=comparator-2,comparator-3;C=comparator-3] id=sort-comparator-1-append-1-Link\n" +
+                        "    SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionRemover\n" +
+                        "      SpreadsheetCard\n" +
+                        "        Card\n" +
+                        "          Remove comparator(s)\n" +
+                        "            \"comparator-2\" [#/1/SpreadsheetName123/cell/A1:C3/top-right/sort/edit/A=comparator-1;C=comparator-3] id=sort-comparator-1-remove-0-Link\n"
+        );
+    }
+
+    @Test
+    public void testCellAllComparatorNamesLast() {
+        this.refreshAndCheck(
+                "C=comparator-3",
+                (names) -> Optional.of(
+                        HistoryToken.parse(
+                                UrlFragment.parse(
+                                        HISTORY_TOKEN +
+                                                concat(
+                                                        "A=comparator-1",
+                                                        names.map(SpreadsheetColumnOrRowSpreadsheetComparatorNames::text)
+                                                                .orElse(""),
+                                                        "B=comparator-2"
+                                                )
+                                )
+                        )
+                ), // move-up
+                (names) -> Optional.empty(), // LAST CANT move-down
+                (names) -> HistoryToken.parse(
+                        UrlFragment.parse(
+                                HISTORY_TOKEN +
+                                        concat(
+                                                "A=comparator-1",
+                                                "B=comparator-2",
+                                                names.map(SpreadsheetColumnOrRowSpreadsheetComparatorNames::text)
+                                                        .orElse("")
+                                        )
+                        )
+                ), // setter
+                "SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "  SpreadsheetFlexLayout\n" +
+                        "    SpreadsheetFlexLayout\n" +
+                        "      SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "        ParserSpreadsheetTextBox\n" +
+                        "          SpreadsheetTextBox\n" +
+                        "            [C=comparator-3] id=sort-comparator-1-TextBox\n" +
+                        "      \"Move Up\" [#/1/SpreadsheetName123/cell/A1:C3/top-right/sort/edit/A=comparator-1;C=comparator-3;B=comparator-2] id=sort-comparator-1-moveUp-Link\n" +
+                        "      \"Move Down\" DISABLED id=sort-comparator-1-moveDown-Link\n" +
+                        "    SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
+                        "      SpreadsheetCard\n" +
+                        "        Card\n" +
+                        "          Append comparator(s)\n" +
+                        "            \"comparator-1\" [#/1/SpreadsheetName123/cell/A1:C3/top-right/sort/edit/A=comparator-1;B=comparator-2;C=comparator-3,comparator-1] id=sort-comparator-1-append-0-Link\n" +
+                        "            \"comparator-2\" [#/1/SpreadsheetName123/cell/A1:C3/top-right/sort/edit/A=comparator-1;B=comparator-2;C=comparator-3,comparator-2] id=sort-comparator-1-append-1-Link\n" +
+                        "    SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionRemover\n" +
+                        "      SpreadsheetCard\n" +
+                        "        Card\n" +
+                        "          Remove comparator(s)\n" +
+                        "            \"comparator-3\" [#/1/SpreadsheetName123/cell/A1:C3/top-right/sort/edit/A=comparator-1;B=comparator-2] id=sort-comparator-1-remove-0-Link\n"
+        );
+    }
+
+    void refreshAndCheck(final String columnOrRowSpreadsheetComparatorNames,
+                         final String expected) {
+        this.refreshAndCheck(
+                columnOrRowSpreadsheetComparatorNames,
+                (names) -> Optional.empty(),
+                (names) -> Optional.empty(),
+                (names) -> HistoryToken.parse(
+                        UrlFragment.parse(
+                                HISTORY_TOKEN +
+                                        concat(
+                                                names.map(SpreadsheetColumnOrRowSpreadsheetComparatorNames::text)
+                                                        .orElse("")
+                                        )
                         )
                 ),
                 expected
@@ -245,11 +483,30 @@ public final class SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadshe
     }
 
     void refreshAndCheck(final String columnOrRowSpreadsheetComparatorNames,
-                         final String historyToken,
+                         final Function<Optional<SpreadsheetColumnOrRowSpreadsheetComparatorNames>, Optional<HistoryToken>> moveUp,
+                         final Function<Optional<SpreadsheetColumnOrRowSpreadsheetComparatorNames>, Optional<HistoryToken>> moveDown,
                          final Function<Optional<SpreadsheetColumnOrRowSpreadsheetComparatorNames>, HistoryToken> setter,
                          final String expected) {
         this.refreshAndCheck(
                 columnOrRowSpreadsheetComparatorNames,
+                HISTORY_TOKEN,
+                moveUp,
+                moveDown,
+                setter,
+                expected
+        );
+    }
+
+    void refreshAndCheck(final String columnOrRowSpreadsheetComparatorNames,
+                         final String historyToken,
+                         final Function<Optional<SpreadsheetColumnOrRowSpreadsheetComparatorNames>, Optional<HistoryToken>> moveUp,
+                         final Function<Optional<SpreadsheetColumnOrRowSpreadsheetComparatorNames>, Optional<HistoryToken>> moveDown,
+                         final Function<Optional<SpreadsheetColumnOrRowSpreadsheetComparatorNames>, HistoryToken> setter,
+                         final String expected) {
+        this.refreshAndCheck(
+                columnOrRowSpreadsheetComparatorNames,
+                moveUp,
+                moveDown,
                 setter,
                 new FakeSpreadsheetSortDialogComponentContext() {
                     @Override
@@ -282,12 +539,17 @@ public final class SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadshe
     }
 
     void refreshAndCheck(final String columnOrRowSpreadsheetComparatorNames,
+                         final Function<Optional<SpreadsheetColumnOrRowSpreadsheetComparatorNames>, Optional<HistoryToken>> moveUp,
+                         final Function<Optional<SpreadsheetColumnOrRowSpreadsheetComparatorNames>, Optional<HistoryToken>> moveDown,
                          final Function<Optional<SpreadsheetColumnOrRowSpreadsheetComparatorNames>, HistoryToken> setter,
                          final SpreadsheetSortDialogComponentContext context,
                          final String expected) {
         final SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent component = SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent.with(
                 ID,
-                setter
+                moveUp,
+                moveDown,
+                setter,
+                context
         );
         component.refresh(
                 columnOrRowSpreadsheetComparatorNames,
@@ -297,6 +559,12 @@ public final class SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadshe
                 component,
                 expected
         );
+    }
+
+    private static String concat(final String... names) {
+        return Arrays.stream(names)
+                .filter(s -> false == s.isEmpty())
+                .collect(Collectors.joining(";"));
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/ui/sort/SpreadsheetSortDialogComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/ui/sort/SpreadsheetSortDialogComponentTest.java
@@ -65,12 +65,15 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "      SpreadsheetFlexLayout\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [] id=sort-comparatorNames-0-TextBox\n" +
-                        "                  Errors\n" +
-                        "                    text is empty\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [] id=sort-comparatorNames-0-TextBox\n" +
+                        "                    Errors\n" +
+                        "                      text is empty\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-0-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-0-moveDown-Link\n" +
                         "      SpreadsheetFlexLayout\n" +
                         "        \"Sort\" DISABLED id=sort-sort-Link\n" +
                         "        \"Close\" [#/1/spreadsheetName123/cell/B2:C3/bottom-right] id=sort-close-Link\n"
@@ -98,12 +101,15 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "      SpreadsheetFlexLayout\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [Z=text] id=sort-comparatorNames-0-TextBox\n" +
-                        "                  Errors\n" +
-                        "                    Invalid Column Z is not within B2:C3\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [Z=text] id=sort-comparatorNames-0-TextBox\n" +
+                        "                    Errors\n" +
+                        "                      Invalid Column Z is not within B2:C3\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-0-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-0-moveDown-Link\n" +
                         "            SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "              SpreadsheetCard\n" +
                         "                Card\n" +
@@ -129,12 +135,15 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "                    \"text\" [#/1/spreadsheetName123/cell/B2:C3/bottom-right/sort/edit] id=sort-comparatorNames-0-remove-0-Link\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [] id=sort-comparatorNames-1-TextBox\n" +
-                        "                  Errors\n" +
-                        "                    text is empty\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [] id=sort-comparatorNames-1-TextBox\n" +
+                        "                    Errors\n" +
+                        "                      text is empty\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-1-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-1-moveDown-Link\n" +
                         "      SpreadsheetFlexLayout\n" +
                         "        \"Sort\" DISABLED id=sort-sort-Link\n" +
                         "        \"Close\" [#/1/spreadsheetName123/cell/B2:C3/bottom-right] id=sort-close-Link\n"
@@ -162,12 +171,15 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "      SpreadsheetFlexLayout\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [99=text] id=sort-comparatorNames-0-TextBox\n" +
-                        "                  Errors\n" +
-                        "                    Invalid Row 99 is not within B2:C3\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [99=text] id=sort-comparatorNames-0-TextBox\n" +
+                        "                    Errors\n" +
+                        "                      Invalid Row 99 is not within B2:C3\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-0-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-0-moveDown-Link\n" +
                         "            SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "              SpreadsheetCard\n" +
                         "                Card\n" +
@@ -193,12 +205,15 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "                    \"text\" [#/1/spreadsheetName123/cell/B2:C3/bottom-right/sort/edit] id=sort-comparatorNames-0-remove-0-Link\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [] id=sort-comparatorNames-1-TextBox\n" +
-                        "                  Errors\n" +
-                        "                    text is empty\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [] id=sort-comparatorNames-1-TextBox\n" +
+                        "                    Errors\n" +
+                        "                      text is empty\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-1-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-1-moveDown-Link\n" +
                         "      SpreadsheetFlexLayout\n" +
                         "        \"Sort\" DISABLED id=sort-sort-Link\n" +
                         "        \"Close\" [#/1/spreadsheetName123/cell/B2:C3/bottom-right] id=sort-close-Link\n"
@@ -227,12 +242,15 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "      SpreadsheetFlexLayout\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [B] id=sort-comparatorNames-0-TextBox\n" +
-                        "                  Errors\n" +
-                        "                    Missing '='\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [B] id=sort-comparatorNames-0-TextBox\n" +
+                        "                    Errors\n" +
+                        "                      Missing '='\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-0-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-0-moveDown-Link\n" +
                         "            SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "              SpreadsheetCard\n" +
                         "                Card\n" +
@@ -254,12 +272,15 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "                    \"year\" [#/1/spreadsheetName123/cell/B2:C3/bottom-right/sort/edit/B=year] id=sort-comparatorNames-0-append-14-Link\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [] id=sort-comparatorNames-1-TextBox\n" +
-                        "                  Errors\n" +
-                        "                    text is empty\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [] id=sort-comparatorNames-1-TextBox\n" +
+                        "                    Errors\n" +
+                        "                      text is empty\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-1-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-1-moveDown-Link\n" +
                         "      SpreadsheetFlexLayout\n" +
                         "        \"Sort\" DISABLED id=sort-sort-Link\n" +
                         "        \"Close\" [#/1/spreadsheetName123/cell/B2:C3/bottom-right] id=sort-close-Link\n"
@@ -286,12 +307,15 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "      SpreadsheetFlexLayout\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [B=] id=sort-comparatorNames-0-TextBox\n" +
-                        "                  Errors\n" +
-                        "                    Missing comparator name\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [B=] id=sort-comparatorNames-0-TextBox\n" +
+                        "                    Errors\n" +
+                        "                      Missing comparator name\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-0-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-0-moveDown-Link\n" +
                         "            SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "              SpreadsheetCard\n" +
                         "                Card\n" +
@@ -313,12 +337,15 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "                    \"year\" [#/1/spreadsheetName123/cell/B2:C3/bottom-right/sort/edit/B=year] id=sort-comparatorNames-0-append-14-Link\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [] id=sort-comparatorNames-1-TextBox\n" +
-                        "                  Errors\n" +
-                        "                    text is empty\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [] id=sort-comparatorNames-1-TextBox\n" +
+                        "                    Errors\n" +
+                        "                      text is empty\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-1-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-1-moveDown-Link\n" +
                         "      SpreadsheetFlexLayout\n" +
                         "        \"Sort\" DISABLED id=sort-sort-Link\n" +
                         "        \"Close\" [#/1/spreadsheetName123/cell/B2:C3/bottom-right] id=sort-close-Link\n"
@@ -345,10 +372,13 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "      SpreadsheetFlexLayout\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [B=text] id=sort-comparatorNames-0-TextBox\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [B=text] id=sort-comparatorNames-0-TextBox\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-0-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-0-moveDown-Link\n" +
                         "            SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "              SpreadsheetCard\n" +
                         "                Card\n" +
@@ -374,12 +404,15 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "                    \"text\" [#/1/spreadsheetName123/cell/B2:C3/bottom-right/sort/edit] id=sort-comparatorNames-0-remove-0-Link\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [] id=sort-comparatorNames-1-TextBox\n" +
-                        "                  Errors\n" +
-                        "                    text is empty\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [] id=sort-comparatorNames-1-TextBox\n" +
+                        "                    Errors\n" +
+                        "                      text is empty\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-1-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-1-moveDown-Link\n" +
                         "      SpreadsheetFlexLayout\n" +
                         "        \"Sort\" [#/1/spreadsheetName123/cell/B2:C3/bottom-right/sort/save/B=text] id=sort-sort-Link\n" +
                         "        \"Close\" [#/1/spreadsheetName123/cell/B2:C3/bottom-right] id=sort-close-Link\n"
@@ -404,10 +437,13 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "      SpreadsheetFlexLayout\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [B=text,text2] id=sort-comparatorNames-0-TextBox\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [B=text,text2] id=sort-comparatorNames-0-TextBox\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-0-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-0-moveDown-Link\n" +
                         "            SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "              SpreadsheetCard\n" +
                         "                Card\n" +
@@ -434,12 +470,15 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "                    \"text2\" [#/1/spreadsheetName123/cell/B2:C3/bottom-right/sort/edit/B=text] id=sort-comparatorNames-0-remove-1-Link\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [] id=sort-comparatorNames-1-TextBox\n" +
-                        "                  Errors\n" +
-                        "                    text is empty\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [] id=sort-comparatorNames-1-TextBox\n" +
+                        "                    Errors\n" +
+                        "                      text is empty\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-1-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-1-moveDown-Link\n" +
                         "      SpreadsheetFlexLayout\n" +
                         "        \"Sort\" [#/1/spreadsheetName123/cell/B2:C3/bottom-right/sort/save/B=text,text2] id=sort-sort-Link\n" +
                         "        \"Close\" [#/1/spreadsheetName123/cell/B2:C3/bottom-right] id=sort-close-Link\n"
@@ -464,10 +503,13 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "      SpreadsheetFlexLayout\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [B=text] id=sort-comparatorNames-0-TextBox\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [B=text] id=sort-comparatorNames-0-TextBox\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-0-moveUp-Link\n" +
+                        "              \"Move Down\" [#/1/spreadsheetName123/cell/B2:C3/bottom-right/sort/edit/C=text2;B=text] id=sort-comparatorNames-0-moveDown-Link\n" +
                         "            SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "              SpreadsheetCard\n" +
                         "                Card\n" +
@@ -493,10 +535,13 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "                    \"text\" [#/1/spreadsheetName123/cell/B2:C3/bottom-right/sort/edit/C=text2] id=sort-comparatorNames-0-remove-0-Link\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [C=text2] id=sort-comparatorNames-1-TextBox\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [C=text2] id=sort-comparatorNames-1-TextBox\n" +
+                        "              \"Move Up\" [#/1/spreadsheetName123/cell/B2:C3/bottom-right/sort/edit/C=text2;B=text] id=sort-comparatorNames-1-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-1-moveDown-Link\n" +
                         "            SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "              SpreadsheetCard\n" +
                         "                Card\n" +
@@ -549,10 +594,13 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "      SpreadsheetFlexLayout\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [B=text] id=sort-comparatorNames-0-TextBox\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [B=text] id=sort-comparatorNames-0-TextBox\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-0-moveUp-Link\n" +
+                        "              \"Move Down\" [#/1/spreadsheetName123/cell/B2:C3/bottom-right/sort/edit/B=text2;B=text] id=sort-comparatorNames-0-moveDown-Link\n" +
                         "            SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "              SpreadsheetCard\n" +
                         "                Card\n" +
@@ -578,12 +626,15 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "                    \"text\" [#/1/spreadsheetName123/cell/B2:C3/bottom-right/sort/edit/B=text2] id=sort-comparatorNames-0-remove-0-Link\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [B=text2] id=sort-comparatorNames-1-TextBox\n" +
-                        "                  Errors\n" +
-                        "                    Duplicate Column B\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [B=text2] id=sort-comparatorNames-1-TextBox\n" +
+                        "                    Errors\n" +
+                        "                      Duplicate Column B\n" +
+                        "              \"Move Up\" [#/1/spreadsheetName123/cell/B2:C3/bottom-right/sort/edit/B=text2;B=text] id=sort-comparatorNames-1-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-1-moveDown-Link\n" +
                         "            SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "              SpreadsheetCard\n" +
                         "                Card\n" +
@@ -633,10 +684,13 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "      SpreadsheetFlexLayout\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [B=text] id=sort-comparatorNames-0-TextBox\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [B=text] id=sort-comparatorNames-0-TextBox\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-0-moveUp-Link\n" +
+                        "              \"Move Down\" [#/1/spreadsheetName123/cell/B2:D4/bottom-right/sort/edit/C=text2;B=text] id=sort-comparatorNames-0-moveDown-Link\n" +
                         "            SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "              SpreadsheetCard\n" +
                         "                Card\n" +
@@ -662,10 +716,13 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "                    \"text\" [#/1/spreadsheetName123/cell/B2:D4/bottom-right/sort/edit/C=text2] id=sort-comparatorNames-0-remove-0-Link\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [C=text2] id=sort-comparatorNames-1-TextBox\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [C=text2] id=sort-comparatorNames-1-TextBox\n" +
+                        "              \"Move Up\" [#/1/spreadsheetName123/cell/B2:D4/bottom-right/sort/edit/C=text2;B=text] id=sort-comparatorNames-1-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-1-moveDown-Link\n" +
                         "            SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "              SpreadsheetCard\n" +
                         "                Card\n" +
@@ -692,12 +749,15 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "                    \"text2\" [#/1/spreadsheetName123/cell/B2:D4/bottom-right/sort/edit/B=text] id=sort-comparatorNames-1-remove-0-Link\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [] id=sort-comparatorNames-2-TextBox\n" +
-                        "                  Errors\n" +
-                        "                    text is empty\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [] id=sort-comparatorNames-2-TextBox\n" +
+                        "                    Errors\n" +
+                        "                      text is empty\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-2-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-2-moveDown-Link\n" +
                         "      SpreadsheetFlexLayout\n" +
                         "        \"Sort\" [#/1/spreadsheetName123/cell/B2:D4/bottom-right/sort/save/B=text;C=text2] id=sort-sort-Link\n" +
                         "        \"Close\" [#/1/spreadsheetName123/cell/B2:D4/bottom-right] id=sort-close-Link\n"
@@ -727,10 +787,13 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "      SpreadsheetFlexLayout\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [B=text] id=sort-comparatorNames-0-TextBox\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [B=text] id=sort-comparatorNames-0-TextBox\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-0-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-0-moveDown-Link\n" +
                         "            SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "              SpreadsheetCard\n" +
                         "                Card\n" +
@@ -756,12 +819,15 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "                    \"text\" [#/1/spreadsheetName123/column/B:C/right/sort/edit] id=sort-comparatorNames-0-remove-0-Link\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [] id=sort-comparatorNames-1-TextBox\n" +
-                        "                  Errors\n" +
-                        "                    text is empty\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [] id=sort-comparatorNames-1-TextBox\n" +
+                        "                    Errors\n" +
+                        "                      text is empty\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-1-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-1-moveDown-Link\n" +
                         "      SpreadsheetFlexLayout\n" +
                         "        \"Sort\" [#/1/spreadsheetName123/column/B:C/right/sort/save/B=text] id=sort-sort-Link\n" +
                         "        \"Close\" [#/1/spreadsheetName123/column/B:C/right] id=sort-close-Link\n"
@@ -794,10 +860,13 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "      SpreadsheetFlexLayout\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [B=text] id=sort-comparatorNames-0-TextBox\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [B=text] id=sort-comparatorNames-0-TextBox\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-0-moveUp-Link\n" +
+                        "              \"Move Down\" [#/1/spreadsheetName123/column/B:C/right/sort/edit/B=text-case-insensitive;B=text] id=sort-comparatorNames-0-moveDown-Link\n" +
                         "            SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "              SpreadsheetCard\n" +
                         "                Card\n" +
@@ -823,12 +892,15 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "                    \"text\" [#/1/spreadsheetName123/column/B:C/right/sort/edit/B=text-case-insensitive] id=sort-comparatorNames-0-remove-0-Link\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [B=text-case-insensitive] id=sort-comparatorNames-1-TextBox\n" +
-                        "                  Errors\n" +
-                        "                    Duplicate Column B\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [B=text-case-insensitive] id=sort-comparatorNames-1-TextBox\n" +
+                        "                    Errors\n" +
+                        "                      Duplicate Column B\n" +
+                        "              \"Move Up\" [#/1/spreadsheetName123/column/B:C/right/sort/edit/B=text-case-insensitive;B=text] id=sort-comparatorNames-1-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-1-moveDown-Link\n" +
                         "            SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "              SpreadsheetCard\n" +
                         "                Card\n" +
@@ -883,10 +955,13 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "      SpreadsheetFlexLayout\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [B=text] id=sort-comparatorNames-0-TextBox\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [B=text] id=sort-comparatorNames-0-TextBox\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-0-moveUp-Link\n" +
+                        "              \"Move Down\" [#/1/spreadsheetName123/column/B:C/right/sort/edit/2=text-case-insensitive;B=text] id=sort-comparatorNames-0-moveDown-Link\n" +
                         "            SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "              SpreadsheetCard\n" +
                         "                Card\n" +
@@ -912,12 +987,15 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "                    \"text\" [#/1/spreadsheetName123/column/B:C/right/sort/edit/2=text-case-insensitive] id=sort-comparatorNames-0-remove-0-Link\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [2=text-case-insensitive] id=sort-comparatorNames-1-TextBox\n" +
-                        "                  Errors\n" +
-                        "                    Got Row 2 expected Column\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [2=text-case-insensitive] id=sort-comparatorNames-1-TextBox\n" +
+                        "                    Errors\n" +
+                        "                      Got Row 2 expected Column\n" +
+                        "              \"Move Up\" [#/1/spreadsheetName123/column/B:C/right/sort/edit/2=text-case-insensitive;B=text] id=sort-comparatorNames-1-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-1-moveDown-Link\n" +
                         "            SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "              SpreadsheetCard\n" +
                         "                Card\n" +
@@ -970,10 +1048,13 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "      SpreadsheetFlexLayout\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [3=text] id=sort-comparatorNames-0-TextBox\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [3=text] id=sort-comparatorNames-0-TextBox\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-0-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-0-moveDown-Link\n" +
                         "            SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "              SpreadsheetCard\n" +
                         "                Card\n" +
@@ -999,12 +1080,15 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "                    \"text\" [#/1/spreadsheetName123/row/3:4/bottom/sort/edit] id=sort-comparatorNames-0-remove-0-Link\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [] id=sort-comparatorNames-1-TextBox\n" +
-                        "                  Errors\n" +
-                        "                    text is empty\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [] id=sort-comparatorNames-1-TextBox\n" +
+                        "                    Errors\n" +
+                        "                      text is empty\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-1-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-1-moveDown-Link\n" +
                         "      SpreadsheetFlexLayout\n" +
                         "        \"Sort\" [#/1/spreadsheetName123/row/3:4/bottom/sort/save/3=text] id=sort-sort-Link\n" +
                         "        \"Close\" [#/1/spreadsheetName123/row/3:4/bottom] id=sort-close-Link\n"
@@ -1037,10 +1121,13 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "      SpreadsheetFlexLayout\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [3=text] id=sort-comparatorNames-0-TextBox\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [3=text] id=sort-comparatorNames-0-TextBox\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-0-moveUp-Link\n" +
+                        "              \"Move Down\" [#/1/spreadsheetName123/row/3:5/bottom/sort/edit/4=text;3=text;3=text-case-insensitive] id=sort-comparatorNames-0-moveDown-Link\n" +
                         "            SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "              SpreadsheetCard\n" +
                         "                Card\n" +
@@ -1066,10 +1153,13 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "                    \"text\" [#/1/spreadsheetName123/row/3:5/bottom/sort/edit/4=text;3=text-case-insensitive] id=sort-comparatorNames-0-remove-0-Link\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [4=text] id=sort-comparatorNames-1-TextBox\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [4=text] id=sort-comparatorNames-1-TextBox\n" +
+                        "              \"Move Up\" [#/1/spreadsheetName123/row/3:5/bottom/sort/edit/4=text;3=text;3=text-case-insensitive] id=sort-comparatorNames-1-moveUp-Link\n" +
+                        "              \"Move Down\" [#/1/spreadsheetName123/row/3:5/bottom/sort/edit/3=text;3=text-case-insensitive;4=text] id=sort-comparatorNames-1-moveDown-Link\n" +
                         "            SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "              SpreadsheetCard\n" +
                         "                Card\n" +
@@ -1095,12 +1185,15 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "                    \"text\" [#/1/spreadsheetName123/row/3:5/bottom/sort/edit/3=text;3=text-case-insensitive] id=sort-comparatorNames-1-remove-0-Link\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [3=text-case-insensitive] id=sort-comparatorNames-2-TextBox\n" +
-                        "                  Errors\n" +
-                        "                    Duplicate Row 3\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [3=text-case-insensitive] id=sort-comparatorNames-2-TextBox\n" +
+                        "                    Errors\n" +
+                        "                      Duplicate Row 3\n" +
+                        "              \"Move Up\" [#/1/spreadsheetName123/row/3:5/bottom/sort/edit/3=text;3=text-case-insensitive;4=text] id=sort-comparatorNames-2-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-2-moveDown-Link\n" +
                         "            SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "              SpreadsheetCard\n" +
                         "                Card\n" +
@@ -1155,10 +1248,13 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "      SpreadsheetFlexLayout\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [3=text] id=sort-comparatorNames-0-TextBox\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [3=text] id=sort-comparatorNames-0-TextBox\n" +
+                        "              \"Move Up\" DISABLED id=sort-comparatorNames-0-moveUp-Link\n" +
+                        "              \"Move Down\" [#/1/spreadsheetName123/row/3:4/bottom/sort/edit/A=text;3=text] id=sort-comparatorNames-0-moveDown-Link\n" +
                         "            SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "              SpreadsheetCard\n" +
                         "                Card\n" +
@@ -1184,12 +1280,15 @@ public final class SpreadsheetSortDialogComponentTest implements SpreadsheetDial
                         "                    \"text\" [#/1/spreadsheetName123/row/3:4/bottom/sort/edit/A=text] id=sort-comparatorNames-0-remove-0-Link\n" +
                         "        SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
                         "          SpreadsheetFlexLayout\n" +
-                        "            SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
-                        "              ParserSpreadsheetTextBox\n" +
-                        "                SpreadsheetTextBox\n" +
-                        "                  [A=text] id=sort-comparatorNames-1-TextBox\n" +
-                        "                  Errors\n" +
-                        "                    Got Column A expected Row\n" +
+                        "            SpreadsheetFlexLayout\n" +
+                        "              SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent\n" +
+                        "                ParserSpreadsheetTextBox\n" +
+                        "                  SpreadsheetTextBox\n" +
+                        "                    [A=text] id=sort-comparatorNames-1-TextBox\n" +
+                        "                    Errors\n" +
+                        "                      Got Column A expected Row\n" +
+                        "              \"Move Up\" [#/1/spreadsheetName123/row/3:4/bottom/sort/edit/A=text;3=text] id=sort-comparatorNames-1-moveUp-Link\n" +
+                        "              \"Move Down\" DISABLED id=sort-comparatorNames-1-moveDown-Link\n" +
                         "            SpreadsheetSortDialogComponentSpreadsheetComparatorNameAndDirectionAppender\n" +
                         "              SpreadsheetCard\n" +
                         "                Card\n" +


### PR DESCRIPTION
…atorNamesComponent moveUp/moveDown

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/2920
- SpreadsheetSortDialogComponent: each SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent should have a "move up" and "move down" links