### PR TITLE
SpreadsheetSortDialogComponent.onSpreadsheetColumnOrRowSpreadsheetCom…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/sort/SpreadsheetSortDialogComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/sort/SpreadsheetSortDialogComponent.java
@@ -364,8 +364,8 @@ public final class SpreadsheetSortDialogComponent implements SpreadsheetDialogCo
                     context
             );
 
-            names.addKeyupListener((e) -> this.refreshColumnOrRowComparatorNames(names))
-                    .addChangeListener((o, n) -> this.refreshColumnOrRowComparatorNames(names));
+            names.addKeyupListener((e) -> this.onSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent(names))
+                    .addChangeListener((o, n) -> this.onSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent(names));
             parent.appendChild(names);
         }
 
@@ -499,9 +499,11 @@ public final class SpreadsheetSortDialogComponent implements SpreadsheetDialogCo
                         .orElse("");
             }
 
-            return this.setEdit(
+            final HistoryToken h = this.setEdit(
                     this.mergeSpreadsheetColumnOrRowSpreadsheetComparatorNames(tokens)
             );
+            //DomGlobal.console.error("@setter " + index + " " + names.toString() + " " + h);
+            return h;
         };
     }
 
@@ -520,10 +522,11 @@ public final class SpreadsheetSortDialogComponent implements SpreadsheetDialogCo
                 .setSortEdit(sortEdit);
     }
 
+
     /**
      * Concatenate the string value of all {@link SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent} and update {@link #columnOrRowComparatorNamesList}.
      */
-    private void refreshColumnOrRowComparatorNames(final SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent component) {
+    private void onSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent(final SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent component) {
         component.validate();
 
         String columnOrRowSpreadsheetComparatorNames = this.columnOrRowComparatorNamesParent.children()
@@ -545,7 +548,8 @@ public final class SpreadsheetSortDialogComponent implements SpreadsheetDialogCo
         }
 
         component.refresh(
-                columnOrRowSpreadsheetComparatorNames,
+                component.stringValue()
+                        .orElse(""),
                 this.context
         );
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/sort/SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/sort/SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent.java
@@ -123,7 +123,7 @@ final class SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetCompa
 
     void refresh(final String columnOrRowSpreadsheetComparatorNames,
                  final SpreadsheetSortDialogComponentContext context) {
-
+        // DomGlobal.console.error("@refresh " + this.names.id() + " " + CharSequences.quoteAndEscape(columnOrRowSpreadsheetComparatorNames));
         final SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent names = this.names;
         names.setStringValue(
                 Optional.ofNullable(


### PR DESCRIPTION
…paratorNamesComponent change FIX

- Previously typing in the 2nd SpreadsheetSortDialogComponentSpreadsheetColumnOrRowSpreadsheetComparatorNamesComponent would cause it to be updated with the entire SpreadsheetColumnOrRowSpreadsheetComparatorNamesComponentList value and not just itself.