### PR TITLE
SpreadsheetCard removed auto hide

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/card/SpreadsheetCard.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/card/SpreadsheetCard.java
@@ -43,7 +43,6 @@ public final class SpreadsheetCard implements HtmlElementComponent<HTMLDivElemen
     private SpreadsheetCard() {
         this.card = Card.create();
         this.children = Lists.array();
-        this.updateShowOrHide();
     }
 
     public SpreadsheetCard setTitle(final String title) {
@@ -57,7 +56,6 @@ public final class SpreadsheetCard implements HtmlElementComponent<HTMLDivElemen
     public SpreadsheetCard appendChild(final IsElement<?> child) {
         this.card.appendChild(child);
         this.children.add(child);
-        this.updateShowOrHide();
         return this;
     }
 
@@ -69,16 +67,7 @@ public final class SpreadsheetCard implements HtmlElementComponent<HTMLDivElemen
         final IsElement<?> child = this.children.remove(index);
         this.card.getAppendTarget()
                 .removeChild(child.element());
-        this.updateShowOrHide();
         return this;
-    }
-
-    private void updateShowOrHide() {
-        if (this.isEmpty()) {
-            this.card.hide();
-        } else {
-            this.card.show();
-        }
     }
 
     /**


### PR DESCRIPTION
- Was causing problems where adding an empty component like SpreadsheetFlexLayout would keep the card hidden and future SpreadsheetFlexLayout.appendChild would make that unempty but the wrapping SpreadsheetCard would never know this happened and would remain hidden.