### PR TITLE
SpreadsheetFlexLayout: row-display=flex flex-wrap=wrap FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/flexlayout/SpreadsheetFlexLayout.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/flexlayout/SpreadsheetFlexLayout.java
@@ -43,6 +43,8 @@ public class SpreadsheetFlexLayout implements SpreadsheetFlexLayoutLike {
 
     public static SpreadsheetFlexLayout row() {
         final SpreadsheetFlexLayout flex = new SpreadsheetFlexLayout(false);
+        flex.div.style()
+                .cssText("display:flex; flex-wrap: wrap;");
         flex.div.addCss(
                 SpacingCss.dui_flex_row,
                 SpacingCss.dui_h_full,

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/toolbar/SpreadsheetToolbarComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/toolbar/SpreadsheetToolbarComponent.java
@@ -86,6 +86,9 @@ public final class SpreadsheetToolbarComponent implements HtmlElementComponent<H
      */
     private SpreadsheetFlexLayout createFlexLayout() {
         final SpreadsheetFlexLayout flexLayout = SpreadsheetFlexLayout.row();
+        flexLayout.element()
+                .style
+                .display = "block"; // without this the toolbar rows have a undesirable line "height" instead of meeting.
 
         for (final SpreadsheetToolbarComponentItem<?> component : this.components) {
             flexLayout.appendChild(component);


### PR DESCRIPTION
- Items within a SpreadsheetFlexLayout now wrap instead of overflowing if they grow greater than the width of the container.