### PR TITLE
SpreadsheetDataTable.isEmpty() never true FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/ComponentWithChildren.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/ComponentWithChildren.java
@@ -67,7 +67,7 @@ public interface ComponentWithChildren<C extends Component<E>, E extends Element
     /**
      * Returns true if this component is empty (has no children).
      */
-    default boolean isEmpty() {
+    default boolean isEmptyIfChildrenAreEmpty() {
         boolean hide = true;
         
         for (final IsElement<?> child : this.children()) {

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/card/SpreadsheetCard.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/card/SpreadsheetCard.java
@@ -109,6 +109,13 @@ public final class SpreadsheetCard implements HtmlElementComponent<HTMLDivElemen
      */
     private List<IsElement<?>> children;
 
+    // CanBeEmpty.......................................................................................................
+
+    @Override
+    public boolean isEmpty() {
+        return this.isEmptyIfChildrenAreEmpty();
+    }
+
     // Component........................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/datatable/SpreadsheetDataTableComponentLike.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/datatable/SpreadsheetDataTableComponentLike.java
@@ -179,6 +179,16 @@ public interface SpreadsheetDataTableComponentLike<T> extends ValueComponent<HTM
         return "EmptyStatePlugin (" + icon.getName() + ") " + CharSequences.quoteAndEscape(title);
     }
 
+    // CanBeEmpty.......................................................................................................
+
+    /**
+     * A table is never empty, best to show columns or any empty state plugin etc even when there are no rows.
+     */
+    @Override
+    default boolean isEmpty() {
+        return false;
+    }
+
     // TreePrintable....................................................................................................
 
     default void printTreeTable(final List<ColumnConfig<T>> columnConfigs,

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/flexlayout/SpreadsheetFlexLayoutLike.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/flexlayout/SpreadsheetFlexLayoutLike.java
@@ -41,6 +41,13 @@ public interface SpreadsheetFlexLayoutLike extends HtmlElementComponent<HTMLDivE
      */
     boolean isColumn();
 
+    // CanBeEmpty.......................................................................................................
+
+    @Override
+    default boolean isEmpty() {
+        return this.isEmptyIfChildrenAreEmpty();
+    }
+
     // TreePrintable....................................................................................................
 
     // SpreadsheetFlexLayout


### PR DESCRIPTION
- Previously SpreadsheetDataTable.isEmpty() defaulted to ComponentWithChildren.isEmpty() which would return true if the table had no values.
- ComponentWithChildren.isEmptyIfChildrenAreEmpty() was isEmpty().