### PR TITLE
SpreadsheetToolbarComponent: SpreadsheetFlexLayout.displayBlock

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/toolbar/SpreadsheetToolbarComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/toolbar/SpreadsheetToolbarComponent.java
@@ -101,10 +101,8 @@ public final class SpreadsheetToolbarComponent implements HtmlElementComponent<H
      * Creates a {@link SpreadsheetFlexLayout} and populates it with the toolbar icons etc.
      */
     private SpreadsheetFlexLayout createFlexLayout() {
-        final SpreadsheetFlexLayout flexLayout = SpreadsheetFlexLayout.row();
-        flexLayout.element()
-                .style
-                .display = "block"; // without this the toolbar rows have a undesirable line "height" instead of meeting.
+        final SpreadsheetFlexLayout flexLayout = SpreadsheetFlexLayout.row()
+                .displayBlock(); // without this the toolbar rows have a undesirable line "height" instead of meeting.
 
         for (final SpreadsheetToolbarComponentItem<?> component : this.components) {
             flexLayout.appendChild(component);


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/3089
- SpreadsheetToolbarComponent.createFlexLayout style.display=block