### PR TITLE
SpreadsheetToolbarComponentItemAnchor.toString anchor.toString

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/ui/toolbar/SpreadsheetToolbarComponentItemAnchor.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/ui/toolbar/SpreadsheetToolbarComponentItemAnchor.java
@@ -90,6 +90,6 @@ abstract class SpreadsheetToolbarComponentItemAnchor<C extends SpreadsheetToolba
 
     @Override
     public final String toString() {
-        return this.element().id;
+        return this.anchor.toString();
     }
 }


### PR DESCRIPTION
- Previously used element.toString which will cause problems in a JVM test.