### PR TITLE
https://github.com/mP1/walkingkooka-spreadsheet/pull/4200-4208 Spread…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSaveFormatPatternHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSaveFormatPatternHistoryToken.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.dominokit.history;
+
+import walkingkooka.collect.map.Maps;
+import walkingkooka.net.UrlFragment;
+import walkingkooka.spreadsheet.SpreadsheetId;
+import walkingkooka.spreadsheet.SpreadsheetName;
+import walkingkooka.spreadsheet.dominokit.AppContext;
+import walkingkooka.spreadsheet.format.pattern.SpreadsheetFormatPattern;
+import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
+import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * This {@link HistoryToken} is used by to paste a {@link SpreadsheetFormatPattern} for many cells over another range.
+ */
+public final class SpreadsheetCellSaveFormatPatternHistoryToken extends SpreadsheetCellSaveMapHistoryToken<Optional<SpreadsheetFormatPattern>> {
+
+    static SpreadsheetCellSaveFormatPatternHistoryToken with(final SpreadsheetId id,
+                                                             final SpreadsheetName name,
+                                                             final AnchoredSpreadsheetSelection anchoredSelection,
+                                                             final Map<SpreadsheetCellReference, Optional<SpreadsheetFormatPattern>> value) {
+        return new SpreadsheetCellSaveFormatPatternHistoryToken(
+                id,
+                name,
+                anchoredSelection,
+                Maps.immutable(value)
+        );
+    }
+
+    private SpreadsheetCellSaveFormatPatternHistoryToken(final SpreadsheetId id,
+                                                         final SpreadsheetName name,
+                                                         final AnchoredSpreadsheetSelection anchoredSelection,
+                                                         final Map<SpreadsheetCellReference, Optional<SpreadsheetFormatPattern>> value) {
+        super(
+                id,
+                name,
+                anchoredSelection,
+                value
+        );
+    }
+
+    @Override //
+    Optional<Class<Optional<SpreadsheetFormatPattern>>> valueType() {
+        return Optional.empty(); // polumorphic not fixed
+    }
+
+    @Override //
+    SpreadsheetCellSaveFormatPatternHistoryToken replace(final SpreadsheetId id,
+                                                         final SpreadsheetName name,
+                                                         final AnchoredSpreadsheetSelection anchoredSelection,
+                                                         final Map<SpreadsheetCellReference, Optional<SpreadsheetFormatPattern>> value) {
+        return new SpreadsheetCellSaveFormatPatternHistoryToken(
+                id,
+                name,
+                anchoredSelection,
+                value
+        );
+    }
+
+    // HasUrlFragment..................................................................................................
+
+    @Override
+    UrlFragment saveEntityUrlFragment() {
+        return FORMAT_PATTERN;
+    }
+
+    private final static UrlFragment FORMAT_PATTERN = UrlFragment.parse("format-pattern");
+
+    // HistoryTokenWatcher..............................................................................................
+
+    @Override
+    void onHistoryTokenChange0(final HistoryToken previous,
+                               final AppContext context) {
+        context.spreadsheetDeltaFetcher()
+                .patchCellsFormatPattern(
+                        this.id(),
+                        this.anchoredSelection().selection(),
+                        this.value()
+                );
+        context.pushHistoryToken(previous);
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSaveFormatPatternHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSaveFormatPatternHistoryTokenTest.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.dominokit.history;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.collect.map.Maps;
+import walkingkooka.spreadsheet.SpreadsheetId;
+import walkingkooka.spreadsheet.SpreadsheetName;
+import walkingkooka.spreadsheet.format.pattern.SpreadsheetFormatPattern;
+import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
+import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
+import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public final class SpreadsheetCellSaveFormatPatternHistoryTokenTest extends SpreadsheetCellSaveMapHistoryTokenTestCase<SpreadsheetCellSaveFormatPatternHistoryToken> {
+
+    @Test
+    public void testWithSaveFormulasOutsideRangeFails() {
+        final IllegalArgumentException thrown = assertThrows(
+                IllegalArgumentException.class,
+                () -> SpreadsheetCellSaveFormatPatternHistoryToken.with(
+                        ID,
+                        NAME,
+                        SpreadsheetSelection.A1.setDefaultAnchor(),
+                        Maps.of(
+                                SpreadsheetSelection.parseCell("A2"),
+                                Optional.of(
+                                        SpreadsheetPattern.DEFAULT_TEXT_FORMAT_PATTERN
+                                )
+                        )
+                )
+        );
+
+        this.checkEquals(
+                "Save value includes cells A2 outside A1",
+                thrown.getMessage(),
+                "message"
+        );
+    }
+
+    @Test
+    public void testWithSaveFormulasOutsideRangeFails2() {
+        final IllegalArgumentException thrown = assertThrows(
+                IllegalArgumentException.class,
+                () -> SpreadsheetCellSaveFormatPatternHistoryToken.with(
+                        ID,
+                        NAME,
+                        SpreadsheetSelection.parseCellRange("A2:A3").setDefaultAnchor(),
+                        Maps.of(
+                                SpreadsheetSelection.A1,
+                                Optional.of(
+                                        SpreadsheetPattern.parseDateFormatPattern("dd/mm/yyyy")
+                                ),
+                                SpreadsheetSelection.parseCell("A3"),
+                                Optional.of(
+                                        SpreadsheetPattern.parseDateTimeFormatPattern("dd/mm/yyyy hh:mm")
+                                ),
+                                SpreadsheetSelection.parseCell("A4"),
+                                Optional.of(
+                                        SpreadsheetPattern.parseTimeFormatPattern("hh:mm")
+                                )
+                        )
+                )
+        );
+
+        this.checkEquals(
+                "Save value includes cells A1, A4 outside A2:A3",
+                thrown.getMessage(),
+                "message"
+        );
+    }
+
+    // parse............................................................................................................
+
+    @Test
+    public void testParseNoCellsFails() {
+        this.parseAndCheck(
+                "/123/SpreadsheetName456/cell/A1/save/format-pattern",
+                SpreadsheetCellSelectHistoryToken.with(
+                        ID,
+                        NAME,
+                        SpreadsheetSelection.A1.setDefaultAnchor()
+                )
+        );
+    }
+
+    // {
+    //   "A1": {
+    //     "type": "spreadsheet-text-format-pattern",
+    //     "value": "@"
+    //   }
+    // }
+    @Test
+    public void testParseOneCell() {
+        this.parseAndCheck(
+                "/123/SpreadsheetName456/cell/A1/save/format-pattern/{%20\"A1\":%20{%20\"type\":%20\"spreadsheet-text-format-pattern\",%20\"value\":%20\"@\"%20}%20}",
+                SpreadsheetCellSaveFormatPatternHistoryToken.with(
+                        ID,
+                        NAME,
+                        SpreadsheetSelection.A1.setDefaultAnchor(),
+                        Maps.of(
+                                SpreadsheetSelection.A1,
+                                Optional.of(
+                                        SpreadsheetPattern.DEFAULT_TEXT_FORMAT_PATTERN
+                                )
+                        )
+                )
+        );
+    }
+
+    // {
+    //   "A1": {
+    //     "type": "spreadsheet-date-format-pattern",
+    //     "value": "dd/mm/yyyy"
+    //   },
+    //   "A2": {
+    //     "type": "spreadsheet-time-format-pattern",
+    //     "value": "hh:mm"
+    //   }
+    // }
+    @Test
+    public void testParseSeveralCells() {
+        this.parseAndCheck(
+                "/123/SpreadsheetName456/cell/A1:A2/bottom-right/save/format-pattern/{%20%22A1%22:%20{%20%22type%22:%20%22spreadsheet-date-format-pattern%22,%20%22value%22:%20%22dd/mm/yyyy%22%20},%20%22A2%22:%20{%20%22type%22:%20%22spreadsheet-time-format-pattern%22,%20%22value%22:%20%22hh:mm%22%20}%20}",
+                SpreadsheetCellSaveFormatPatternHistoryToken.with(
+                        ID,
+                        NAME,
+                        SpreadsheetSelection.parseCellRange("A1:A2")
+                                .setDefaultAnchor(),
+                        Maps.of(
+                                SpreadsheetSelection.A1,
+                                Optional.of(
+                                        SpreadsheetPattern.parseDateFormatPattern("dd/mm/yyyy")
+                                ),
+                                SpreadsheetSelection.parseCell("A2"),
+                                Optional.of(
+                                        SpreadsheetPattern.parseTimeFormatPattern("hh:mm")
+                                )
+                        )
+                )
+        );
+    }
+
+    // {
+    //   "A1": null
+    // }
+    @Test
+    public void testParseOneCellWithoutPattern() {
+        this.parseAndCheck(
+                "/123/SpreadsheetName456/cell/A1/save/format-pattern/%7B%22A1%22%3Anull%7D",
+                SpreadsheetCellSaveFormatPatternHistoryToken.with(
+                        ID,
+                        NAME,
+                        SpreadsheetSelection.A1.setDefaultAnchor(),
+                        Maps.of(
+                                SpreadsheetSelection.A1,
+                                Optional.empty()
+                        )
+                )
+        );
+    }
+
+    // {
+    //   "A1": {
+    //     "type": "spreadsheet-number-format-pattern",
+    //     "value": "#.##"
+    //   }
+    // }
+    @Test
+    public void testUrlFragment() {
+        final Map<SpreadsheetCellReference, Optional<SpreadsheetFormatPattern>> cellToFormatPattern = Maps.of(
+                SpreadsheetSelection.A1,
+                Optional.of(
+                        SpreadsheetPattern.parseNumberFormatPattern("#.##")
+                )
+        );
+        this.urlFragmentAndCheck(
+                SpreadsheetCellSaveFormatPatternHistoryToken.with(
+                        ID,
+                        NAME,
+                        SELECTION,
+                        cellToFormatPattern
+                ),
+                "/123/SpreadsheetName456/cell/A1/save/format-pattern/" +
+                        marshallMapWithOptionalTypedValues(cellToFormatPattern)
+        );
+    }
+
+    @Test
+    public void testUrlFragment2() {
+        final Map<SpreadsheetCellReference, Optional<SpreadsheetFormatPattern>> cellToFormatPattern = Maps.of(
+                SpreadsheetSelection.A1,
+                Optional.of(
+                        SpreadsheetPattern.parseTextFormatPattern("@@")
+                )
+        );
+
+        this.urlFragmentAndCheck(
+                SpreadsheetCellSaveFormatPatternHistoryToken.with(
+                        ID,
+                        NAME,
+                        SELECTION,
+                        cellToFormatPattern
+                ),
+                "/123/SpreadsheetName456/cell/A1/save/format-pattern/" +
+                        marshallMapWithOptionalTypedValues(cellToFormatPattern)
+        );
+    }
+
+    @Test
+    public void testUrlFragmentWithMultipleCells() {
+        final Map<SpreadsheetCellReference, Optional<SpreadsheetFormatPattern>> cellToFormulaText = Maps.of(
+                SpreadsheetSelection.A1,
+                Optional.of(
+                        SpreadsheetPattern.parseDateFormatPattern("dd/mm/yyyy")
+                ),
+                SpreadsheetSelection.parseCell("A2"),
+                Optional.of(
+                        SpreadsheetPattern.parseDateTimeFormatPattern("dd/mm/yyyy hh:mm")
+                ),
+                SpreadsheetSelection.parseCell("A3"),
+                Optional.of(
+                        SpreadsheetPattern.parseTimeFormatPattern("hh:mm")
+                )
+        );
+
+        this.urlFragmentAndCheck(
+                SpreadsheetCellSaveFormatPatternHistoryToken.with(
+                        ID,
+                        NAME,
+                        SpreadsheetSelection.parseCellRange("A1:A3")
+                                .setDefaultAnchor(),
+                        cellToFormulaText
+                ),
+                "/123/SpreadsheetName456/cell/A1:A3/bottom-right/save/format-pattern/" +
+                        marshallMapWithOptionalTypedValues(cellToFormulaText)
+        );
+    }
+
+    @Test
+    public void testUrlFragmentWithNoPattern() {
+        final Map<SpreadsheetCellReference, Optional<SpreadsheetFormatPattern>> cellToFormulaText = Maps.of(
+                SpreadsheetSelection.A1,
+                Optional.empty()
+        );
+
+        this.urlFragmentAndCheck(
+                SpreadsheetCellSaveFormatPatternHistoryToken.with(
+                        ID,
+                        NAME,
+                        SpreadsheetSelection.parseCellRange("A1:A3")
+                                .setDefaultAnchor(),
+                        cellToFormulaText
+                ),
+                "/123/SpreadsheetName456/cell/A1:A3/bottom-right/save/format-pattern/" +
+                        marshallMapWithOptionalTypedValues(cellToFormulaText)
+        );
+    }
+
+    @Override
+    SpreadsheetCellSaveFormatPatternHistoryToken createHistoryToken(final SpreadsheetId id,
+                                                                    final SpreadsheetName name,
+                                                                    final AnchoredSpreadsheetSelection anchoredSelection) {
+        return SpreadsheetCellSaveFormatPatternHistoryToken.with(
+                id,
+                name,
+                anchoredSelection,
+                Maps.of(
+                        SpreadsheetSelection.A1,
+                        Optional.of(
+                                SpreadsheetPattern.DEFAULT_TEXT_FORMAT_PATTERN
+                        )
+                )
+        );
+    }
+
+    @Override
+    public Class<SpreadsheetCellSaveFormatPatternHistoryToken> type() {
+        return SpreadsheetCellSaveFormatPatternHistoryToken.class;
+    }
+}


### PR DESCRIPTION
…sheetMetadata.XXX_FORMATTER replaces XXX_FORMAT_PATTERN 2/2

- https://github.com/mP1/walkingkooka-spreadsheet/pull/4200
- SpreadsheetMetadata.XXX_FORMATTER replaces XXX_FORMAT_PATTERN

- https://github.com/mP1/walkingkooka-spreadsheet/pull/4201
- SpreadsheetPattern.DEFAULT_TEXT_FORMAT_PATTERN was DEFAULT_TEXT_FORMATTER

- https://github.com/mP1/walkingkooka-spreadsheet/pull/4202
- SpreadsheetCell.NO_FORMAT was NO_FORMATTER

- https://github.com/mP1/walkingkooka-spreadsheet/pull/4203
- SpreadsheetCell.NO_FORMAT_PATTERN was NO_FORMAT

- https://github.com/mP1/walkingkooka-spreadsheet/pull/4204
- SpreadsheetUrlFragments.FORMATTER was FORMAT_PATTERN

- https://github.com/mP1/walkingkooka-spreadsheet/pull/4208
- SpreadsheetCell.formatter SpreadsheetFormatterSelector was SpreadsheetFormatPattern

- SpreadsheetMetadataPanelComponent removed(commented out) formatter links
- TODO SpreadsheetCellPatternHistoryToken common parent for formatter & parse-patterns needs to be disconnected.
- Introduced SpreadsheetPatternDialogComponentContext.savePatternText to special case formatter / pattern text stuff.