### PR TITLE
SpreadsheetParserSelectorDialogComponent.onText calls refreshTitleTab…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/format/SpreadsheetFormatterTableComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/format/SpreadsheetFormatterTableComponent.java
@@ -110,6 +110,13 @@ public final class SpreadsheetFormatterTableComponent implements HtmlElementComp
         this.dataTable.setValue(
                 Optional.of(samples)
         );
+
+        // manually show/hide depending on samples. Card will never be empty because SpreadsheetDataTableComponent is never empty
+        if (samples.isEmpty()) {
+            this.card.hide();
+        } else {
+            this.card.show();
+        }
     }
 
     private final SpreadsheetDataTableComponent<SpreadsheetFormatterSample> dataTable;


### PR DESCRIPTION
…sClearClose

- Close https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/3343
- SpreadsheetFormatterSelectorDialogComponent: Card holding empty table shown should be hidden