### PR TITLE
SpreadsheetDialogComponent.fireClose pushes historyToken.close()

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/dialog/SpreadsheetDialogComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/dialog/SpreadsheetDialogComponent.java
@@ -127,8 +127,12 @@ public class SpreadsheetDialogComponent implements SpreadsheetDialogComponentLik
     }
 
     private void fireClose() {
-        this.context.historyToken()
-                .close();
+        final HistoryTokenContext context = this.context;
+
+        context.pushHistoryToken(
+                context.historyToken()
+                        .close()
+        );
     }
 
     private final HistoryTokenContext context;


### PR DESCRIPTION
- Previously closing cell/A1/sort/edit didnt remove "/sort/edit"