### PR TITLE
PluginInfoSetDialogComponent.onProviderInfoSet isOpen guard

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/pluginfoset/PluginInfoSetDialogComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/pluginfoset/PluginInfoSetDialogComponent.java
@@ -104,7 +104,9 @@ public final class PluginInfoSetDialogComponent<N extends Name & Comparable<N>, 
     }
 
     private void onProviderInfoSet(final S providerInfos) {
-        this.refreshNonResetLinks();
+        if (this.isOpen()) {
+            this.refreshNonResetLinks();
+        }
     }
 
     // ids..............................................................................................................


### PR DESCRIPTION
- Without the new guard, exceptions would be thrown by HistoryToken.setSave such as when the SpreadsheetMetadata property was a different/incompatible type.