### PR TITLE
PluginAliasSetLikeDialogComponent: find-functions & formula-functions…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/pluginaliassetlike/PluginAliasSetLikeDialogComponentContextBasic.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/pluginaliassetlike/PluginAliasSetLikeDialogComponentContextBasic.java
@@ -34,7 +34,6 @@ import walkingkooka.spreadsheet.dominokit.log.LoggingContext;
 import walkingkooka.spreadsheet.dominokit.log.LoggingContextDelegator;
 import walkingkooka.spreadsheet.dominokit.net.SpreadsheetMetadataFetcherWatcher;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
-import walkingkooka.spreadsheet.provider.SpreadsheetProvider;
 import walkingkooka.text.CaseKind;
 
 import java.util.Objects;
@@ -103,15 +102,6 @@ abstract class PluginAliasSetLikeDialogComponentContextBasic<N extends Name & Co
     }
 
     abstract SpreadsheetMetadataPropertyName<AS> metadataPropertyName();
-
-    @Override
-    public final AS providerAliasSetLike() {
-        return this.providerAliasSetLike0(
-                this.context.systemSpreadsheetProvider()
-        );
-    }
-
-    abstract AS providerAliasSetLike0(final SpreadsheetProvider spreadsheetProvider);
 
     // focus............................................................................................................
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/pluginaliassetlike/PluginAliasSetLikeDialogComponentContextBasicExpressionFunctionAliases.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/pluginaliassetlike/PluginAliasSetLikeDialogComponentContextBasicExpressionFunctionAliases.java
@@ -26,7 +26,7 @@ import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.dominokit.AppContext;
 import walkingkooka.spreadsheet.dominokit.function.ExpressionFunctionAliasSetComponent;
 import walkingkooka.spreadsheet.dominokit.net.ExpressionFunctionFetcherWatcher;
-import walkingkooka.spreadsheet.provider.SpreadsheetProvider;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.tree.expression.ExpressionFunctionName;
 import walkingkooka.tree.expression.function.provider.ExpressionFunctionAlias;
 import walkingkooka.tree.expression.function.provider.ExpressionFunctionAliasSet;
@@ -108,8 +108,20 @@ abstract class PluginAliasSetLikeDialogComponentContextBasicExpressionFunctionAl
         );
     }
 
-    @Override final ExpressionFunctionAliasSet providerAliasSetLike0(final SpreadsheetProvider spreadsheetProvider) {
-        return spreadsheetProvider.expressionFunctionInfos()
-                .aliasSet();
+    /**
+     * This takes the {@link ExpressionFunctionInfoSet} filtered by {@link SpreadsheetMetadataPropertyName#FUNCTIONS},
+     * providing a view of the effective {@link ExpressionFunctionAliasSet aliase}.
+     */
+    final ExpressionFunctionAliasSet providerAliasSetLikeAndFunctions() {
+        final AppContext context = this.context;
+
+        return context.spreadsheetMetadata()
+                .get(SpreadsheetMetadataPropertyName.FUNCTIONS)
+                .orElse(ExpressionFunctionAliasSet.EMPTY)
+                .keepAliasOrNameAll(
+                        context.systemSpreadsheetProvider()
+                                .expressionFunctionInfos()
+                                .names()
+                );
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/pluginaliassetlike/PluginAliasSetLikeDialogComponentContextBasicExpressionFunctionAliasesFindFunctions.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/pluginaliassetlike/PluginAliasSetLikeDialogComponentContextBasicExpressionFunctionAliasesFindFunctions.java
@@ -37,4 +37,9 @@ final class PluginAliasSetLikeDialogComponentContextBasicExpressionFunctionAlias
     SpreadsheetMetadataPropertyName<ExpressionFunctionAliasSet> metadataPropertyName() {
         return SpreadsheetMetadataPropertyName.FIND_FUNCTIONS;
     }
+
+    @Override
+    public ExpressionFunctionAliasSet providerAliasSetLike() {
+        return this.providerAliasSetLikeAndFunctions();
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/pluginaliassetlike/PluginAliasSetLikeDialogComponentContextBasicExpressionFunctionAliasesFormulaFunctions.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/pluginaliassetlike/PluginAliasSetLikeDialogComponentContextBasicExpressionFunctionAliasesFormulaFunctions.java
@@ -37,4 +37,9 @@ final class PluginAliasSetLikeDialogComponentContextBasicExpressionFunctionAlias
     SpreadsheetMetadataPropertyName<ExpressionFunctionAliasSet> metadataPropertyName() {
         return SpreadsheetMetadataPropertyName.FORMULA_FUNCTIONS;
     }
+
+    @Override
+    public ExpressionFunctionAliasSet providerAliasSetLike() {
+        return this.providerAliasSetLikeAndFunctions();
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/pluginaliassetlike/PluginAliasSetLikeDialogComponentContextBasicExpressionFunctionAliasesFunctions.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/pluginaliassetlike/PluginAliasSetLikeDialogComponentContextBasicExpressionFunctionAliasesFunctions.java
@@ -37,4 +37,11 @@ final class PluginAliasSetLikeDialogComponentContextBasicExpressionFunctionAlias
     SpreadsheetMetadataPropertyName<ExpressionFunctionAliasSet> metadataPropertyName() {
         return SpreadsheetMetadataPropertyName.FUNCTIONS;
     }
+
+    @Override
+    public ExpressionFunctionAliasSet providerAliasSetLike() {
+        return this.context.systemSpreadsheetProvider()
+                .expressionFunctionInfos()
+                .aliasSet();
+    }
 }


### PR DESCRIPTION
… FIX

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/3713
- PluginAliasSetLikeDialogComponent when editing "find-functions", function lists are not filtered by "functions"

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/3712
- PluginAliasSetLikeDialogComponent when editing "formula-functions", function lists are not filtered by "functions"