### PR TITLE
PluginAliasSetLikeDialogComponent add & remove filtering

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/card/SpreadsheetCard.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/card/SpreadsheetCard.java
@@ -21,15 +21,19 @@ import elemental2.dom.HTMLDivElement;
 import elemental2.dom.Node;
 import org.dominokit.domino.ui.IsElement;
 import org.dominokit.domino.ui.cards.Card;
+import org.dominokit.domino.ui.utils.HasChangeListeners.ChangeListener;
+import org.dominokit.domino.ui.utils.PostfixAddOn;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.spreadsheet.dominokit.ComponentWithChildren;
 import walkingkooka.spreadsheet.dominokit.HtmlElementComponent;
+import walkingkooka.spreadsheet.dominokit.value.SpreadsheetTextBox;
 import walkingkooka.text.CharSequences;
 import walkingkooka.text.printer.IndentingPrinter;
 import walkingkooka.text.printer.TreePrintable;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * A {@link Card} that auto hides when empty.
@@ -77,6 +81,35 @@ public final class SpreadsheetCard implements HtmlElementComponent<HTMLDivElemen
                 .cssText(css);
         return this;
     }
+
+    // filter...........................................................................................................
+
+    /**
+     * Adds a {@link ChangeListener}, automatically adding a filter text box lazily. The textbox will occupy the
+     * right third of the card header.
+     */
+    public SpreadsheetCard setFilterValueChangeListener(final ChangeListener<Optional<String>> changeListener) {
+        Objects.requireNonNull(changeListener, "changeListener");
+
+        SpreadsheetTextBox filter = this.filter;
+        if (null == filter) {
+            filter = SpreadsheetTextBox.empty()
+                    .magnifyingGlassIcon();
+            final SpreadsheetTextBox filter2 = filter;
+
+            this.card.withHeader(
+                    (card, header) -> header.appendChild(
+                            PostfixAddOn.of(
+                                    filter2.setCssText("display: inline-block; width: 33%;"))
+                    )
+            );
+        }
+        filter.addChangeListener(changeListener);
+
+        return this;
+    }
+
+    private SpreadsheetTextBox filter;
 
     // ComponentWithChildren............................................................................................
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/pluginaliassetlike/AddPluginAliasSetLikeComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/pluginaliassetlike/AddPluginAliasSetLikeComponent.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.dominokit.pluginaliassetlike;
 
 import elemental2.dom.HTMLDivElement;
 import elemental2.dom.Node;
+import org.dominokit.domino.ui.utils.HasChangeListeners.ChangeListener;
 import walkingkooka.naming.Name;
 import walkingkooka.plugin.PluginAliasLike;
 import walkingkooka.plugin.PluginAliasSetLike;
@@ -35,6 +36,8 @@ import walkingkooka.text.printer.IndentingPrinter;
 import walkingkooka.text.printer.TreePrintable;
 
 import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
 
 /**
  * A component that contains a panel holding links of for each present {@link PluginAliasLike}, adding when missing from a {@link PluginAliasSetLike}.
@@ -72,11 +75,27 @@ public final class AddPluginAliasSetLikeComponent<N extends Name & Comparable<N>
                 .appendChild(this.flex);
     }
 
+    AddPluginAliasSetLikeComponent setFilterValueChangeListener(final ChangeListener<Optional<String>> listener) {
+        this.root.setFilterValueChangeListener(listener);
+        return this;
+    }
+
+    AddPluginAliasSetLikeComponent setFilter(final Predicate<CharSequence> filter) {
+        this.filter = filter;
+        return this;
+    }
+
+    /**
+     * A {@link Predicate} which is used to filter links by testing the text against the given {@link Predicate}.
+     */
+    private Predicate<CharSequence> filter;
+
     public void refresh(final AS aliases, // value from SpreadsheetMetadata
                         final AS providerAliases, // list of available aliases from provider
                         final AddPluginAliasSetLikeComponentContext context) {
         this.root.hide();
         final SpreadsheetFlexLayout flex = this.flex.removeAllChildren();
+        final Predicate<CharSequence> filter = this.filter;
 
         int i = 0;
 
@@ -84,7 +103,7 @@ public final class AddPluginAliasSetLikeComponent<N extends Name & Comparable<N>
         for (final A providerAlias : providerAliases) {
             final N name = providerAlias.name();
 
-            if (false == aliases.containsAliasOrName(name)) {
+            if (false == aliases.containsAliasOrName(name) && (null == filter || filter.test(providerAlias.name().text()))) {
                 flex.appendChild(
                         this.anchor(
                                 providerAlias,

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/pluginaliassetlike/RemovePluginAliasSetLikeComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/pluginaliassetlike/RemovePluginAliasSetLikeComponent.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.dominokit.pluginaliassetlike;
 
 import elemental2.dom.HTMLDivElement;
 import elemental2.dom.Node;
+import org.dominokit.domino.ui.utils.HasChangeListeners.ChangeListener;
 import walkingkooka.naming.Name;
 import walkingkooka.plugin.PluginAliasLike;
 import walkingkooka.plugin.PluginAliasSetLike;
@@ -35,6 +36,8 @@ import walkingkooka.text.printer.IndentingPrinter;
 import walkingkooka.text.printer.TreePrintable;
 
 import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
 
 /**
  * A component that contains a panel holding links of for each present {@link PluginAliasLike}, removing each from a {@link PluginAliasSetLike}.
@@ -72,11 +75,28 @@ public final class RemovePluginAliasSetLikeComponent<N extends Name & Comparable
                 .appendChild(this.flex);
     }
 
+    RemovePluginAliasSetLikeComponent setFilterValueChangeListener(final ChangeListener<Optional<String>> listener) {
+        this.root.setFilterValueChangeListener(listener);
+        return this;
+    }
+
+    RemovePluginAliasSetLikeComponent setFilter(final Predicate<CharSequence> filter) {
+        this.filter = filter;
+        return this;
+    }
+
+    /**
+     * A {@link Predicate} which is used to filter links by testing the text against the given {@link Predicate}.
+     */
+    private Predicate<CharSequence> filter;
+    
     public void refresh(final AS aliases, // value from SpreadsheetMetadata
                         final AS providerAliases, // list of available aliases from provider
                         final RemovePluginAliasSetLikeComponentContext context) {
         this.root.hide();
+
         final SpreadsheetFlexLayout flex = this.flex.removeAllChildren();
+        final Predicate<CharSequence> filter = this.filter;
 
         int i = 0;
 
@@ -84,7 +104,7 @@ public final class RemovePluginAliasSetLikeComponent<N extends Name & Comparable
         for (final A providerAlias : providerAliases) {
             final N name = providerAlias.name();
 
-            if (aliases.containsAliasOrName(name)) {
+            if (aliases.containsAliasOrName(name) && (null == filter || filter.test(providerAlias.name().text()))) {
                 flex.appendChild(
                         this.anchor(
                                 providerAlias,

--- a/src/test/java/org/dominokit/domino/ui/cards/Card.java
+++ b/src/test/java/org/dominokit/domino/ui/cards/Card.java
@@ -20,6 +20,7 @@ package org.dominokit.domino.ui.cards;
 import com.google.gwt.thirdparty.guava.common.base.Strings;
 import elemental2.dom.Element;
 import org.dominokit.domino.ui.IsElement;
+import org.dominokit.domino.ui.utils.ChildHandler;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.printer.IndentingPrinter;
 import walkingkooka.text.printer.TreePrintable;
@@ -55,6 +56,12 @@ public class Card implements IsElement<Element>,
 
     public IsElement<?> appendChild(final IsElement<?> component) {
         this.components.add(component);
+        return this;
+    }
+
+    public Card withHeader(final ChildHandler<Card, CardHeader> handler) {
+        // nop
+
         return this;
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/pluginaliassetlike/AddPluginAliasSetLikeComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/pluginaliassetlike/AddPluginAliasSetLikeComponentTest.java
@@ -170,6 +170,30 @@ public final class AddPluginAliasSetLikeComponentTest implements ClassTesting<Ad
     }
 
     @Test
+    public void testRefreshAllAddedWithFilter() {
+        final AddPluginAliasSetLikeComponent<ExpressionFunctionName, ExpressionFunctionInfo, ExpressionFunctionInfoSet, ExpressionFunctionSelector, ExpressionFunctionAlias, ExpressionFunctionAliasSet> component = AddPluginAliasSetLikeComponent.empty("base-id-123-add-");
+        component.setFilter((t) -> t.toString().contains("name"));
+        component.refresh(
+                ExpressionFunctionAliasSet.parse(""), // present
+                ExpressionFunctionAliasSet.parse("name1, name2, hidden3"), // provider
+                CONTEXT
+        );
+
+        // name1 add link needed
+        this.treePrintAndCheck(
+                component,
+                "AddPluginAliasSetLikeComponent\n" +
+                        "  SpreadsheetCard\n" +
+                        "    Card\n" +
+                        "      Add\n" +
+                        "        SpreadsheetFlexLayout\n" +
+                        "          ROW\n" +
+                        "            \"Name1\" [#/1/SpreadsheetName123/metadata/formula-functions/save/name1] id=base-id-123-add-0-Link\n" +
+                        "            \"Name2\" [#/1/SpreadsheetName123/metadata/formula-functions/save/name2] id=base-id-123-add-1-Link\n"
+        );
+    }
+
+    @Test
     public void testRefreshSomeAddedIncludesAliases1() {
         final AddPluginAliasSetLikeComponent<ExpressionFunctionName, ExpressionFunctionInfo, ExpressionFunctionInfoSet, ExpressionFunctionSelector, ExpressionFunctionAlias, ExpressionFunctionAliasSet> component = AddPluginAliasSetLikeComponent.empty("base-id-123-add-");
         component.refresh(

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/pluginaliassetlike/RemovePluginAliasSetLikeComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/pluginaliassetlike/RemovePluginAliasSetLikeComponentTest.java
@@ -115,6 +115,30 @@ public final class RemovePluginAliasSetLikeComponentTest implements ClassTesting
     }
 
     @Test
+    public void testRefreshAllRemovableWithFilter() {
+        final RemovePluginAliasSetLikeComponent<ExpressionFunctionName, ExpressionFunctionInfo, ExpressionFunctionInfoSet, ExpressionFunctionSelector, ExpressionFunctionAlias, ExpressionFunctionAliasSet> component = RemovePluginAliasSetLikeComponent.empty("base-id-123-remove-");
+        component.setFilter((t) -> t.toString().contains("name"));
+        component.refresh(
+                ExpressionFunctionAliasSet.parse("name1, name2, missing3"), // present
+                ExpressionFunctionAliasSet.parse("name1, name2, missing3"), // provider
+                CONTEXT
+        );
+
+        // all disabled no need to create any enable links
+        this.treePrintAndCheck(
+                component,
+                "RemovePluginAliasSetLikeComponent\n" +
+                        "  SpreadsheetCard\n" +
+                        "    Card\n" +
+                        "      Remove\n" +
+                        "        SpreadsheetFlexLayout\n" +
+                        "          ROW\n" +
+                        "            \"Name1\" [#/1/SpreadsheetName123/metadata/formula-functions/save/missing3,%20name2] id=base-id-123-remove-0-Link\n" +
+                        "            \"Name2\" [#/1/SpreadsheetName123/metadata/formula-functions/save/missing3,%20name1] id=base-id-123-remove-1-Link\n"
+        );
+    }
+
+    @Test
     public void testRefreshAllRemovableIncludesAliases() {
         final RemovePluginAliasSetLikeComponent<ExpressionFunctionName, ExpressionFunctionInfo, ExpressionFunctionInfoSet, ExpressionFunctionSelector, ExpressionFunctionAlias, ExpressionFunctionAliasSet> component = RemovePluginAliasSetLikeComponent.empty("base-id-123-remove-");
         component.refresh(


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/3662
- SpreadsheetCard add support for filter textbox in header

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/3666
- SpreadsheetLinkListComponent.setFilter pattern is used to "filter" child elements.