### PR TITLE
ValueSpreadsheetTextBox.textBox.autocompleteOff()

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/value/ValueSpreadsheetTextBox.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/value/ValueSpreadsheetTextBox.java
@@ -49,6 +49,7 @@ public final class ValueSpreadsheetTextBox<T> implements ValueComponent<HTMLFiel
     private ValueSpreadsheetTextBox(final Function<String, T> parser,
                                     final Function<T, String> formatter) {
         this.textBox = SpreadsheetTextBox.empty()
+                .autocompleteOff()
                 .clearIcon()
                 .disableSpellcheck()
                 .enterFiresValueChange();


### PR DESCRIPTION
- Solve a problem when clicking on auto suggest item causes a ClassCastException within the SpreadsheetTextBox.enterFiresValueChange when the Event is cast to KeyboardEvent