### PR TITLE
SpreadsheetFindDialogComponent.query parser error message FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/find/SpreadsheetFindDialogComponentSpreadsheetFormulaComponentParserFunction.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/find/SpreadsheetFindDialogComponentSpreadsheetFormulaComponentParserFunction.java
@@ -47,12 +47,7 @@ final class SpreadsheetFindDialogComponentSpreadsheetFormulaComponentParserFunct
 
         return SpreadsheetFormula.parse(
                 TextCursors.charSequence(text),
-                SpreadsheetParsers.valueOrExpression(
-                        metadata.spreadsheetParser(
-                                context, // SpreadsheetParserProvider
-                                context // ProviderContext
-                        )
-                ),
+                SpreadsheetParsers.expression(),
                 metadata.spreadsheetParserContext(
                         context::now
                 )


### PR DESCRIPTION
- Was previously using SpreadsheetParsers.valueOrExpression() switched to SpreadsheetParsers.expression()