### PR TITLE
SpreadsheetDialogComponent.close disable Dialog CloseListener FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/dialog/SpreadsheetDialogComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/dialog/SpreadsheetDialogComponent.java
@@ -243,6 +243,7 @@ public class SpreadsheetDialogComponent implements SpreadsheetDialogComponentLik
         }
 
         this.open = false;
+        this.closeListenerEnabled = false; // dont want Dialog's CloseListener to fire and push HistoryToken.close
         this.dialog.close();
     }
 


### PR DESCRIPTION
- Need to disable DialogCloseListener before Dialog.close otherwise the install listener will fire HistoryToken.close which is wrong and breaks functionality such as:

  - list spreadsheets
  - click rename
  - list spreadsheet tries to close dialog, which eventually push HistoryToken.close which stops rename dialog from showing.