### PR TITLE
POM: walkingkooka-spreadsheet-gwt removed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,12 +157,6 @@
     <dependencies>
         <dependency>
             <groupId>walkingkooka</groupId>
-            <artifactId>walkingkooka-spreadsheet-gwt</artifactId>
-            <version>1.0-SNAPSHOT</version>
-        </dependency>
-
-        <dependency>
-            <groupId>walkingkooka</groupId>
             <artifactId>walkingkooka-spreadsheet-server-gwt</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>


### PR DESCRIPTION
- Unnecessary declaration already a transitive of walkingkooka-spreadsheet-server-gwt and walkingkooka-spreadsheet-expression-function-gwt