### PR TITLE
ValueSpreadsheetTextBox parse isEmpty test

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/value/ValueSpreadsheetTextBox.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/value/ValueSpreadsheetTextBox.java
@@ -22,6 +22,7 @@ import elemental2.dom.HTMLFieldSetElement;
 import elemental2.dom.Node;
 import org.dominokit.domino.ui.utils.HasChangeListeners.ChangeListener;
 import org.dominokit.domino.ui.utils.HasValidation.Validator;
+import walkingkooka.CanBeEmpty;
 import walkingkooka.text.printer.IndentingPrinter;
 
 import java.util.List;
@@ -286,7 +287,26 @@ public final class ValueSpreadsheetTextBox<T> implements ValueComponent<HTMLFiel
         } catch (final Exception ignore) {
             parsed = null;
         }
-        return Optional.ofNullable(parsed);
+        return Optional.ofNullable(
+                null == parsed ||
+                        "".equals(parsed) ||
+                        isEmpty(parsed) ?
+                        null :
+                        parsed
+        );
+    }
+
+    private static boolean isEmpty(final Object value) {
+        final boolean empty;
+
+        if (value instanceof CanBeEmpty) {
+            final CanBeEmpty canBeEmpty = (CanBeEmpty) value;
+            empty = canBeEmpty.isEmpty();
+        } else {
+            empty = false;
+        }
+
+        return empty;
     }
 
     /**

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/textmatch/TextMatchComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/textmatch/TextMatchComponentTest.java
@@ -19,14 +19,11 @@ package walkingkooka.spreadsheet.dominokit.textmatch;
 
 import elemental2.dom.HTMLFieldSetElement;
 import org.junit.jupiter.api.Test;
-import walkingkooka.predicate.Predicates;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.spreadsheet.dominokit.value.ValueComponentTesting;
 import walkingkooka.spreadsheet.expression.function.TextMatch;
-import walkingkooka.text.CaseSensitivity;
 
 import java.util.Optional;
-import java.util.function.Predicate;
 
 public final class TextMatchComponentTest implements ValueComponentTesting<HTMLFieldSetElement, TextMatch, TextMatchComponent> {
 
@@ -38,6 +35,20 @@ public final class TextMatchComponentTest implements ValueComponentTesting<HTMLF
                         "  ValueSpreadsheetTextBox\n" +
                         "    SpreadsheetTextBox\n" +
                         "      []\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintWithWhitespace() {
+        this.treePrintAndCheck(
+                TextMatchComponent.empty()
+                        .setStringValue(
+                                Optional.of("   ")
+                        ),
+                "TextMatchComponent\n" +
+                        "  ValueSpreadsheetTextBox\n" +
+                        "    SpreadsheetTextBox\n" +
+                        "      [   ]\n"
         );
     }
 


### PR DESCRIPTION
- This is necessary because TextMatchComponent.value() is not empty when it is empty (eg "" or "   ").