### PR TITLE
PluginSetDialogComponent delete plugin doesnt show spreadsheet list FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/PluginDeleteHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/PluginDeleteHistoryToken.java
@@ -64,7 +64,7 @@ public final class PluginDeleteHistoryToken extends PluginNameHistoryToken {
                                      final AppContext context) {
         context.pluginFetcher()
                 .deletePlugin(this.name());
-
+context.warn(this.toString() + " push prevuous " + previous.toString());
         context.pushHistoryToken(previous);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/plugin/PluginSetDialogComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/plugin/PluginSetDialogComponent.java
@@ -32,6 +32,7 @@ import walkingkooka.spreadsheet.dominokit.flex.SpreadsheetFlexLayout;
 import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
 import walkingkooka.spreadsheet.dominokit.history.HistoryTokenAnchorComponent;
 import walkingkooka.spreadsheet.dominokit.history.HistoryTokenContext;
+import walkingkooka.spreadsheet.dominokit.history.PluginDeleteHistoryToken;
 import walkingkooka.spreadsheet.dominokit.history.PluginListSelectHistoryToken;
 import walkingkooka.spreadsheet.server.plugin.JarEntryInfoList;
 import walkingkooka.spreadsheet.server.plugin.JarEntryInfoName;
@@ -175,7 +176,7 @@ public final class PluginSetDialogComponent implements SpreadsheetDialogComponen
 
     @Override
     public boolean shouldIgnore(final HistoryToken token) {
-        return false;
+        return token instanceof PluginDeleteHistoryToken;
     }
 
     @Override


### PR DESCRIPTION
- The spreadsheet list dialog is no longer shown
- New problem, table in dialog is not refreshed, response from DELETE plugin is ignored.

- see https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/4333
- PluginSetDialogComponent delete needs to refresh table