### PR TITLE
SpreadsheetCellLabelSaveHistoryToken

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellLabelHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellLabelHistoryToken.java
@@ -21,6 +21,10 @@ import walkingkooka.net.UrlFragment;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+
+import java.util.Optional;
 
 /**
  * Base class for various label functions for a cell selection.
@@ -37,6 +41,8 @@ public abstract class SpreadsheetCellLabelHistoryToken extends SpreadsheetCellHi
         );
     }
 
+    public abstract Optional<SpreadsheetLabelName> labelName();
+
     @Override
     UrlFragment cellUrlFragment() {
         return LABEL.appendSlashThen(this.cellLabelUrlFragment());
@@ -45,23 +51,13 @@ public abstract class SpreadsheetCellLabelHistoryToken extends SpreadsheetCellHi
     abstract UrlFragment cellLabelUrlFragment();
 
     @Override
-    public HistoryToken clearAction() {
-        return this.selectionSelect();
-    }
-
-    @Override //
-    HistoryToken replaceIdNameAnchoredSelection(final SpreadsheetId id,
-                                                final SpreadsheetName name,
-                                                final AnchoredSpreadsheetSelection anchoredSelection) {
-        return selection(
-            id,
-            name,
-            anchoredSelection
-        ).label();
-    }
-
-    @Override
-    HistoryToken save0(final String value) {
-        return this;
+    final HistoryToken save0(final String labelName) {
+        return labelName.isEmpty() ?
+            this.clearAction() :
+            this.setLabelName(
+                Optional.of(
+                    SpreadsheetSelection.labelName(labelName)
+                )
+            );
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellLabelSaveHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellLabelSaveHistoryToken.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.dominokit.history;
+
+import walkingkooka.net.UrlFragment;
+import walkingkooka.spreadsheet.SpreadsheetId;
+import walkingkooka.spreadsheet.SpreadsheetName;
+import walkingkooka.spreadsheet.dominokit.AppContext;
+import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A request to save a label for a cell selection.
+ * <pre>
+ * /1/SpreadsheetName/cell/A1/label/save/Label222
+ * </pre>
+ */
+public final class SpreadsheetCellLabelSaveHistoryToken extends SpreadsheetCellLabelHistoryToken {
+
+    static SpreadsheetCellLabelSaveHistoryToken with(final SpreadsheetId id,
+                                                     final SpreadsheetName name,
+                                                     final AnchoredSpreadsheetSelection anchoredSelection,
+                                                     final SpreadsheetLabelName labelName) {
+        return new SpreadsheetCellLabelSaveHistoryToken(
+            id,
+            name,
+            anchoredSelection,
+            labelName
+        );
+    }
+
+    private SpreadsheetCellLabelSaveHistoryToken(final SpreadsheetId id,
+                                                 final SpreadsheetName name,
+                                                 final AnchoredSpreadsheetSelection anchoredSelection,
+                                                 final SpreadsheetLabelName labelName) {
+        super(id, name, anchoredSelection);
+        this.labelName = Objects.requireNonNull(labelName, "labelName");
+    }
+
+    @Override
+    public Optional<SpreadsheetLabelName> labelName() {
+        return Optional.of(this.labelName);
+    }
+
+    private final SpreadsheetLabelName labelName;
+
+    // /1/SpreadsheetName/cell/A1/label/save/Label222
+    @Override
+    UrlFragment cellLabelUrlFragment() {
+        return SAVE.appendSlashThen(
+            UrlFragment.with(
+                this.labelName.value()
+            )
+        );
+    }
+
+    @Override //
+    HistoryToken replaceIdNameAnchoredSelection(final SpreadsheetId id,
+                                                final SpreadsheetName name,
+                                                final AnchoredSpreadsheetSelection anchoredSelection) {
+        return selection(
+            id,
+            name,
+            anchoredSelection
+        ).label()
+            .save(
+                Optional.of(this.labelName)
+            );
+    }
+
+    // /1/SpreadsheetName/cell/A1/label
+    @Override
+    public HistoryToken clearAction() {
+        return HistoryToken.cellLabelSelect(
+            this.id(),
+            this.name(),
+            this.anchoredSelection()
+        );
+    }
+
+    @Override
+    void onHistoryTokenChange0(final HistoryToken previous,
+                               final AppContext context) {
+        context.spreadsheetDeltaFetcher()
+            .saveLabelMapping(
+                this.id(),
+                this.labelName.mapping(
+                    this.anchoredSelection()
+                        .selection()
+                        .toExpressionReference()
+                )
+            );
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellLabelSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellLabelSelectHistoryToken.java
@@ -22,6 +22,9 @@ import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.dominokit.AppContext;
 import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
+
+import java.util.Optional;
 
 /**
  * A request to edit a label belonging to a cell selection.
@@ -47,10 +50,32 @@ public final class SpreadsheetCellLabelSelectHistoryToken extends SpreadsheetCel
         super(id, name, anchoredSelection);
     }
 
+    @Override
+    public Optional<SpreadsheetLabelName> labelName() {
+        return Optional.empty();
+    }
+
     // /1/SpreadsheetName/cell/A1/label
     @Override
     UrlFragment cellLabelUrlFragment() {
         return UrlFragment.EMPTY;
+    }
+
+    @Override //
+    HistoryToken replaceIdNameAnchoredSelection(final SpreadsheetId id,
+                                                final SpreadsheetName name,
+                                                final AnchoredSpreadsheetSelection anchoredSelection) {
+        return selection(
+            id,
+            name,
+            anchoredSelection
+        ).label();
+    }
+
+    // /1/SpreadsheetName/cell/A1
+    @Override
+    public HistoryToken clearAction() {
+        return this;
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTest.java
@@ -2693,6 +2693,31 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>, Parse
         );
     }
 
+    @Test
+    public void testParseSpreadsheetIdSpreadsheetNameCellCellSaveEmptyLabel() {
+        this.parseStringAndCheck(
+            "/123/SpreadsheetName456/cell/A1/label/save/",
+            HistoryToken.cellLabelSelect(
+                ID,
+                NAME,
+                CELL.setDefaultAnchor()
+            )
+        );
+    }
+
+    @Test
+    public void testParseSpreadsheetIdSpreadsheetNameCellCellSaveLabel() {
+        this.parseStringAndCheck(
+            "/123/SpreadsheetName456/cell/A1/label/save/Label123",
+            HistoryToken.cellLabelSave(
+                ID,
+                NAME,
+                CELL.setDefaultAnchor(),
+                LABEL
+            )
+        );
+    }
+
     // cell/menu........................................................................................................
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTestCase.java
@@ -32,6 +32,8 @@ import walkingkooka.spreadsheet.engine.SpreadsheetCellFindQuery;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
 import java.util.Arrays;
 import java.util.Optional;
@@ -238,6 +240,38 @@ public abstract class HistoryTokenTestCase<T extends HistoryToken> implements Cl
             expected,
             token.formatter(),
             () -> token + " formatter"
+        );
+    }
+
+    // setLabel.........................................................................................................
+
+    final static SpreadsheetLabelName LABEL = SpreadsheetSelection.labelName("Label123");
+
+    @Test
+    public final void testSetLabelNameWithNullFails() {
+        assertThrows(
+            NullPointerException.class,
+            () -> this.createHistoryToken().setLabelName(null)
+        );
+    }
+
+    final void setLabelNameAndCheck(final HistoryToken historyToken,
+                                    final SpreadsheetLabelName labelName,
+                                    final HistoryToken expected) {
+        this.setLabelNameAndCheck(
+            historyToken,
+            Optional.of(labelName),
+            expected
+        );
+    }
+
+    final void setLabelNameAndCheck(final HistoryToken historyToken,
+                                    final Optional<SpreadsheetLabelName> labelName,
+                                    final HistoryToken expected) {
+        this.checkEquals(
+            expected,
+            historyToken.setLabelName(labelName),
+            historyToken::toString
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellHistoryTokenTestCase.java
@@ -25,7 +25,6 @@ import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellRangeReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
-import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportAnchor;
 
@@ -34,8 +33,6 @@ public abstract class SpreadsheetCellHistoryTokenTestCase<T extends SpreadsheetC
     final static SpreadsheetCellReference CELL = SpreadsheetSelection.A1;
 
     final static SpreadsheetCellRangeReference RANGE = SpreadsheetSelection.parseCellRange("B2:C3");
-
-    final static SpreadsheetLabelName LABEL = SpreadsheetSelection.labelName("Label123");
 
     final static AnchoredSpreadsheetSelection SELECTION = CELL.setDefaultAnchor();
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellLabelHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellLabelHistoryTokenTestCase.java
@@ -17,9 +17,23 @@
 
 package walkingkooka.spreadsheet.dominokit.history;
 
+import org.junit.jupiter.api.Test;
+
 public abstract class SpreadsheetCellLabelHistoryTokenTestCase<T extends SpreadsheetCellLabelHistoryToken> extends SpreadsheetCellHistoryTokenTestCase<T> {
 
     SpreadsheetCellLabelHistoryTokenTestCase() {
         super();
+    }
+
+    @Test
+    public final void testClose() {
+        this.closeAndCheck(
+            this.createHistoryToken(),
+            HistoryToken.cell(
+                ID,
+                NAME,
+                SELECTION
+            )
+        );
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellLabelSaveHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellLabelSaveHistoryTokenTest.java
@@ -25,7 +25,40 @@ import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
 import java.util.Optional;
 
-public final class SpreadsheetCellLabelSelectHistoryTokenTest extends SpreadsheetCellLabelHistoryTokenTestCase<SpreadsheetCellLabelSelectHistoryToken> {
+import static org.junit.Assert.assertThrows;
+
+public final class SpreadsheetCellLabelSaveHistoryTokenTest extends SpreadsheetCellLabelHistoryTokenTestCase<SpreadsheetCellLabelSaveHistoryToken> {
+
+    // with.............................................................................................................
+
+    @Test
+    public void testWithNullLabelFails() {
+        assertThrows(
+            NullPointerException.class,
+            () -> SpreadsheetCellLabelSaveHistoryToken.with(
+                ID,
+                NAME,
+                SELECTION,
+                null
+            )
+        );
+    }
+
+    // parse............................................................................................................
+
+    @Test
+    public void testParseMissingLabelNameFails() {
+        this.parseAndCheck(
+            "/123/SpreadsheetName456/cell/A1/label/save",
+            HistoryToken.cellLabelSelect(
+                ID,
+                NAME,
+                CELL.setDefaultAnchor()
+            )
+        );
+    }
+
+    // setLabelName.....................................................................................................
 
     @Test
     public void testSetLabelName() {
@@ -61,7 +94,12 @@ public final class SpreadsheetCellLabelSelectHistoryTokenTest extends Spreadshee
     public void testSaveEmpty() {
         this.saveAndCheck(
             this.createHistoryToken(),
-            ""
+            "",
+            HistoryToken.cellLabelSelect(
+                ID,
+                NAME,
+                SELECTION
+            )
         );
     }
 
@@ -81,28 +119,31 @@ public final class SpreadsheetCellLabelSelectHistoryTokenTest extends Spreadshee
         );
     }
 
+    // HasUrlFragment...................................................................................................
+
     @Test
     public void testUrlFragment() {
         this.urlFragmentAndCheck(
-            "/123/SpreadsheetName456/cell/A1/label"
+            "/123/SpreadsheetName456/cell/A1/label/save/Label123"
         );
     }
 
     @Override
-    SpreadsheetCellLabelSelectHistoryToken createHistoryToken(final SpreadsheetId id,
+    SpreadsheetCellLabelSaveHistoryToken createHistoryToken(final SpreadsheetId id,
                                                               final SpreadsheetName name,
                                                               final AnchoredSpreadsheetSelection anchoredSelection) {
-        return SpreadsheetCellLabelSelectHistoryToken.with(
+        return SpreadsheetCellLabelSaveHistoryToken.with(
             id,
             name,
-            anchoredSelection
+            anchoredSelection,
+            LABEL
         );
     }
 
     // class............................................................................................................
 
     @Override
-    public Class<SpreadsheetCellLabelSelectHistoryToken> type() {
-        return SpreadsheetCellLabelSelectHistoryToken.class;
+    public Class<SpreadsheetCellLabelSaveHistoryToken> type() {
+        return SpreadsheetCellLabelSaveHistoryToken.class;
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSelectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSelectHistoryTokenTest.java
@@ -24,6 +24,8 @@ import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportAnchor;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 public final class SpreadsheetCellSelectHistoryTokenTest extends SpreadsheetCellHistoryTokenTestCase<SpreadsheetCellSelectHistoryToken> {
@@ -154,6 +156,21 @@ public final class SpreadsheetCellSelectHistoryTokenTest extends SpreadsheetCell
                 ID,
                 NAME,
                 CELL.setDefaultAnchor()
+            )
+        );
+    }
+
+    // setLabel.........................................................................................................
+
+    @Test
+    public void testSetLabelName() {
+        this.setLabelNameAndCheck(
+            this.createHistoryToken(),
+            LABEL,
+            HistoryToken.labelMapping(
+                ID,
+                NAME,
+                Optional.of(LABEL)
             )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnHistoryTokenTestCase.java
@@ -26,6 +26,8 @@ import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportAnchor;
 
+import java.util.Optional;
+
 public abstract class SpreadsheetColumnHistoryTokenTestCase<T extends SpreadsheetColumnHistoryToken> extends SpreadsheetAnchoredSelectionHistoryTokenTestCase<T> {
 
     final static SpreadsheetColumnReference COLUMN = SpreadsheetSelection.parseColumn("A");
@@ -119,6 +121,21 @@ public abstract class SpreadsheetColumnHistoryTokenTestCase<T extends Spreadshee
                 ID,
                 NAME,
                 selection
+            )
+        );
+    }
+
+    // setLabel.........................................................................................................
+
+    @Test
+    public final void testSetLabelName() {
+        this.setLabelNameAndCheck(
+            this.createHistoryToken(),
+            LABEL,
+            HistoryToken.labelMapping(
+                ID,
+                NAME,
+                Optional.of(LABEL)
             )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowHistoryTokenTestCase.java
@@ -26,6 +26,8 @@ import walkingkooka.spreadsheet.reference.SpreadsheetRowReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportAnchor;
 
+import java.util.Optional;
+
 public abstract class SpreadsheetRowHistoryTokenTestCase<T extends SpreadsheetRowHistoryToken> extends SpreadsheetAnchoredSelectionHistoryTokenTestCase<T> {
 
     final static SpreadsheetRowReference ROW = SpreadsheetSelection.parseRow("1");
@@ -119,6 +121,21 @@ public abstract class SpreadsheetRowHistoryTokenTestCase<T extends SpreadsheetRo
                 ID,
                 NAME,
                 selection
+            )
+        );
+    }
+
+    // setLabel.........................................................................................................
+
+    @Test
+    public final void testSetLabelName() {
+        this.setLabelNameAndCheck(
+            this.createHistoryToken(),
+            LABEL,
+            HistoryToken.labelMapping(
+                ID,
+                NAME,
+                Optional.of(LABEL)
             )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/reference/SpreadsheetSelectionMenuTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/reference/SpreadsheetSelectionMenuTest.java
@@ -256,7 +256,7 @@ public final class SpreadsheetSelectionMenuTest implements PublicStaticHelperTes
                 "  -----\n" +
                 "  \"Labels\" [1] id=test-label-SubMenu\n" +
                 "    \"Label123 (A1)\" [/1/SpreadsheetName-1/label/Label123] id=test-label-0-MenuItem\n" +
-                "    \"Create...\" [/1/SpreadsheetName-1/label] id=test-label-create-MenuItem\n"
+                "    \"Create...\" [/1/SpreadsheetName-1/cell/A1/label] id=test-label-create-MenuItem\n"
         );
     }
 
@@ -469,7 +469,7 @@ public final class SpreadsheetSelectionMenuTest implements PublicStaticHelperTes
                 "  -----\n" +
                 "  \"Labels\" [1] id=test-label-SubMenu\n" +
                 "    \"Label123 (A1)\" [/1/SpreadsheetName-1/label/Label123] id=test-label-0-MenuItem\n" +
-                "    \"Create...\" [/1/SpreadsheetName-1/label] id=test-label-create-MenuItem\n"
+                "    \"Create...\" [/1/SpreadsheetName-1/cell/A1/label] id=test-label-create-MenuItem\n"
         );
     }
 
@@ -677,7 +677,7 @@ public final class SpreadsheetSelectionMenuTest implements PublicStaticHelperTes
                 "  -----\n" +
                 "  \"Labels\" [1] id=test-label-SubMenu\n" +
                 "    \"Label123 (A1)\" [/1/SpreadsheetName-1/label/Label123] id=test-label-0-MenuItem\n" +
-                "    \"Create...\" [/1/SpreadsheetName-1/label] id=test-label-create-MenuItem\n"
+                "    \"Create...\" [/1/SpreadsheetName-1/cell/A1/label] id=test-label-create-MenuItem\n"
         );
     }
 
@@ -900,7 +900,7 @@ public final class SpreadsheetSelectionMenuTest implements PublicStaticHelperTes
                 "  -----\n" +
                 "  \"Labels\" [1] id=test-label-SubMenu\n" +
                 "    \"Label123 (A1)\" [/1/SpreadsheetName-1/label/Label123] id=test-label-0-MenuItem\n" +
-                "    \"Create...\" [/1/SpreadsheetName-1/label] id=test-label-create-MenuItem\n"
+                "    \"Create...\" [/1/SpreadsheetName-1/cell/A1/label] id=test-label-create-MenuItem\n"
         );
     }
 
@@ -1136,7 +1136,7 @@ public final class SpreadsheetSelectionMenuTest implements PublicStaticHelperTes
                 "  -----\n" +
                 "  \"Labels\" [1] id=test-label-SubMenu\n" +
                 "    \"Label123 (A1)\" [/1/SpreadsheetName-1/label/Label123] id=test-label-0-MenuItem\n" +
-                "    \"Create...\" [/1/SpreadsheetName-1/label] id=test-label-create-MenuItem\n"
+                "    \"Create...\" [/1/SpreadsheetName-1/cell/A1/label] id=test-label-create-MenuItem\n"
         );
     }
 
@@ -1433,7 +1433,7 @@ public final class SpreadsheetSelectionMenuTest implements PublicStaticHelperTes
                 "  -----\n" +
                 "  \"Labels\" [1] id=test-label-SubMenu\n" +
                 "    \"Label123 (B2)\" [/1/SpreadsheetName-1/label/Label123] id=test-label-0-MenuItem\n" +
-                "    \"Create...\" [/1/SpreadsheetName-1/label] id=test-label-create-MenuItem\n"
+                "    \"Create...\" [/1/SpreadsheetName-1/cell/B2:C3/bottom-right/label] id=test-label-create-MenuItem\n"
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/toolbar/SpreadsheetToolbarComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/toolbar/SpreadsheetToolbarComponentTest.java
@@ -185,7 +185,7 @@ public final class SpreadsheetToolbarComponentTest implements HistoryTokenAwareC
                 "      mdi-sort \"Sort\" [#/1/Spreadsheet123/cell/A1:B2/bottom-right/sort/edit] id=toolbar-sort-Link\n" +
                 "        SpreadsheetTooltipComponent\n" +
                 "          \"Sort cell(s), column(s), row(s)...\"\n" +
-                "      mdi-flag-checkered \"Create Label\" [#/1/Spreadsheet123/label] id=toolbar-label-create-Link\n" +
+                "      mdi-flag-checkered \"Create Label\" [#/1/Spreadsheet123/cell/A1:B2/bottom-right/label] id=toolbar-label-create-Link\n" +
                 "        SpreadsheetTooltipComponent\n" +
                 "          \"Create Label\"\n" +
                 "      mdi-reload \"Reload\" [#/1/Spreadsheet123/reload] id=toolbar-reload-Link\n" +


### PR DESCRIPTION
- closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/3416
- toolbar: create label should pass in any selected cell/cellrange

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/4010
- create label history token should also include selection

- NB SpreadsheetLabelMappingDialogComponent not updated to handle SpreadsheetCellLabelXXXHistoryToken