### PR TITLE
HistoryTokenTestCase.setSaveValue *FIX*

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/format/SpreadsheetFormatterSelectorDialogComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/format/SpreadsheetFormatterSelectorDialogComponent.java
@@ -306,11 +306,7 @@ public final class SpreadsheetFormatterSelectorDialogComponent implements Spread
                 Optional.of(
                     context.historyToken()
                         .setSaveValue(
-                            Optional.of(
-                                edit.selector()
-                                    .map(SpreadsheetFormatterSelector::toString)
-                                    .orElse("")
-                            )
+                            edit.selector()
                         )
                 )
             );

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/parser/SpreadsheetParserSelectorDialogComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/parser/SpreadsheetParserSelectorDialogComponent.java
@@ -306,11 +306,7 @@ public final class SpreadsheetParserSelectorDialogComponent implements Spreadshe
                 Optional.of(
                     context.historyToken()
                         .setSaveValue(
-                            Optional.of(
-                                edit.selector()
-                                    .map(SpreadsheetParserSelector::toString)
-                                    .orElse("")
-                            )
+                            edit.selector()
                         )
                 )
             );

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTestCase.java
@@ -596,6 +596,14 @@ public abstract class HistoryTokenTestCase<T extends HistoryToken> implements Cl
         );
     }
 
+    final void setSaveValueFails(final Optional<?> value) {
+        final T token = this.createHistoryToken();
+        assertThrows(
+            RuntimeException.class, // InvalidArgumentException | ClassCastException
+            () -> token.setSaveValue(value)
+        );
+    }
+
     final void setSaveValueAndCheck(final Optional<?> save) {
         this.setSaveValueAndCheck(
             this.createHistoryToken(),

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/PluginSaveHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/PluginSaveHistoryTokenTest.java
@@ -20,6 +20,7 @@ package walkingkooka.spreadsheet.dominokit.history;
 import org.junit.jupiter.api.Test;
 import walkingkooka.plugin.PluginName;
 
+import java.util.Optional;
 import java.util.OptionalInt;
 
 import static org.junit.Assert.assertThrows;
@@ -55,6 +56,36 @@ public final class PluginSaveHistoryTokenTest extends PluginNameHistoryTokenTest
             HistoryToken.pluginListSelect(
                 OptionalInt.empty(), // offset
                 OptionalInt.empty() // count
+            )
+        );
+    }
+
+    // setSaveValue.....................................................................................................
+
+    @Test
+    public void testSetSaveValueWithInvalidOptionalValueFails() {
+        this.setSaveValueFails(
+            Optional.of(this)
+        );
+    }
+
+    @Test
+    public void testSetSaveValueWithEmptyFails() {
+        this.setSaveValueFails(
+            Optional.empty()
+        );
+    }
+
+    @Test
+    public void testSetSaveValueWithNotEmpty() {
+        final String value = "Hello";
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(value),
+            HistoryToken.pluginSave(
+                PLUGIN_NAME,
+                value
             )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/PluginSelectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/PluginSelectHistoryTokenTest.java
@@ -20,6 +20,7 @@ package walkingkooka.spreadsheet.dominokit.history;
 import org.junit.jupiter.api.Test;
 import walkingkooka.plugin.PluginName;
 
+import java.util.Optional;
 import java.util.OptionalInt;
 
 public final class PluginSelectHistoryTokenTest extends PluginNameHistoryTokenTestCase<PluginSelectHistoryToken> {
@@ -48,6 +49,36 @@ public final class PluginSelectHistoryTokenTest extends PluginNameHistoryTokenTe
             HistoryToken.pluginListSelect(
                 OptionalInt.empty(), // offset
                 OptionalInt.empty() // count
+            )
+        );
+    }
+
+    // setSaveValue.....................................................................................................
+
+    @Test
+    public void testSetSaveValueWithInvalidOptionalValueFails() {
+        this.setSaveValueFails(
+            Optional.of(this)
+        );
+    }
+
+    @Test
+    public void testSetSaveValueWithEmptyFails() {
+        this.setSaveValueFails(
+            Optional.empty()
+        );
+    }
+
+    @Test
+    public void testSetSaveValueWithNotEmpty() {
+        final String value = "Hello";
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(value),
+            HistoryToken.pluginSave(
+                PLUGIN_NAME,
+                value
             )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/PluginUploadSaveHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/PluginUploadSaveHistoryTokenTest.java
@@ -20,6 +20,8 @@ package walkingkooka.spreadsheet.dominokit.history;
 import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.dominokit.file.BrowserFile;
 
+import java.util.Optional;
+
 public final class PluginUploadSaveHistoryTokenTest extends PluginHistoryTokenTestCase<PluginUploadSaveHistoryToken> {
 
     // parse............................................................................................................
@@ -100,6 +102,34 @@ public final class PluginUploadSaveHistoryTokenTest extends PluginHistoryTokenTe
     public void testClose() {
         this.closeAndCheck(
             HistoryToken.pluginUploadSelect()
+        );
+    }
+
+    // setSaveValue.....................................................................................................
+
+    @Test
+    public void testSetSaveValueWithInvalidOptionalValueFails() {
+        this.setSaveValueFails(
+            Optional.of(this)
+        );
+    }
+
+    @Test
+    public void testSetSaveValueWithEmptyFails() {
+        this.setSaveValueFails(Optional.empty());
+    }
+
+    @Test
+    public void testSetSaveValueWithNotEmpty() {
+        final BrowserFile file = BrowserFile.base64(
+            "Different",
+            "FileContent456"
+        );
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(file),
+            HistoryToken.pluginUploadSave(file)
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/PluginUploadSelectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/PluginUploadSelectHistoryTokenTest.java
@@ -18,7 +18,9 @@
 package walkingkooka.spreadsheet.dominokit.history;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.spreadsheet.dominokit.file.BrowserFile;
 
+import java.util.Optional;
 import java.util.OptionalInt;
 
 public final class PluginUploadSelectHistoryTokenTest extends PluginHistoryTokenTestCase<PluginUploadSelectHistoryToken> {
@@ -48,6 +50,34 @@ public final class PluginUploadSelectHistoryTokenTest extends PluginHistoryToken
                 OptionalInt.empty(), // offset
                 OptionalInt.empty() // count
             )
+        );
+    }
+
+    // setSaveValue.....................................................................................................
+
+    @Test
+    public void testSetSaveValueWithInvalidOptionalValueFails() {
+        this.setSaveValueFails(
+            Optional.of(this)
+        );
+    }
+
+    @Test
+    public void testSetSaveValueWithEmptyFails() {
+        this.setSaveValueFails(Optional.empty());
+    }
+
+    @Test
+    public void testSetSaveValueWithNotEmpty() {
+        final BrowserFile file = BrowserFile.base64(
+            "Different",
+            "FileContent456"
+        );
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(file),
+            HistoryToken.pluginUploadSave(file)
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormatterHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormatterHistoryTokenTestCase.java
@@ -17,11 +17,57 @@
 
 package walkingkooka.spreadsheet.dominokit.history;
 
+import org.junit.jupiter.api.Test;
+import walkingkooka.spreadsheet.format.SpreadsheetFormatterSelector;
+
+import java.util.Optional;
+
 public abstract class SpreadsheetCellFormatterHistoryTokenTestCase<T extends SpreadsheetCellFormatterHistoryToken> extends SpreadsheetCellHistoryTokenTestCase<T> {
 
     SpreadsheetCellFormatterHistoryTokenTestCase() {
         super();
     }
 
+    // setSaveValue.....................................................................................................
 
+    @Test
+    public final void testSetSaveValueWithInvalidOptionalValueFails() {
+        this.setSaveValueFails(
+            Optional.of(this)
+        );
+    }
+
+    @Test
+    public final void testSetSaveValueWithEmpty() {
+        final Optional<SpreadsheetFormatterSelector> value = Optional.empty();
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            value,
+            HistoryToken.cellFormatterSave(
+                ID,
+                NAME,
+                SELECTION,
+                value
+            )
+        );
+    }
+
+    @Test
+    public final void testSetSaveValueWithNonEmpty() {
+        final Optional<SpreadsheetFormatterSelector> value = Optional.of(
+            SpreadsheetFormatterSelector.parse("different")
+        );
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            value,
+            HistoryToken.cellFormatterSave(
+                ID,
+                NAME,
+                SELECTION,
+                value
+            )
+        );
+    }
 }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormatterSaveHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormatterSaveHistoryTokenTest.java
@@ -20,7 +20,6 @@ package walkingkooka.spreadsheet.dominokit.history;
 import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
-import walkingkooka.spreadsheet.format.SpreadsheetFormatterSelector;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetFormatPattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
 import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
@@ -123,39 +122,6 @@ public final class SpreadsheetCellFormatterSaveHistoryTokenTest extends Spreadsh
                 ID,
                 NAME,
                 SELECTION
-            )
-        );
-    }
-
-    // saveValue........................................................................................................
-
-    @Test
-    public void testSetSaveValue() {
-        final SpreadsheetFormatPattern pattern = SpreadsheetPattern.parseTimeFormatPattern("hh:mm");
-        final SpreadsheetFormatterSelector selector = pattern.spreadsheetFormatterSelector();
-
-        this.setSaveValueAndCheck(
-            this.createHistoryToken(),
-            selector.text(),
-            HistoryToken.cellFormatterSave(
-                ID,
-                NAME,
-                SELECTION,
-                Optional.of(selector)
-            )
-        );
-    }
-
-    @Test
-    public void testSetSaveValueWithEmpty() {
-        this.setSaveValueAndCheck(
-            this.createHistoryToken(),
-            "",
-            HistoryToken.cellFormatterSave(
-                ID,
-                NAME,
-                SELECTION,
-                Optional.empty()
             )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormatterSelectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormatterSelectHistoryTokenTest.java
@@ -20,14 +20,9 @@ package walkingkooka.spreadsheet.dominokit.history;
 import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
-import walkingkooka.spreadsheet.format.SpreadsheetFormatterSelector;
-import walkingkooka.spreadsheet.format.pattern.SpreadsheetFormatPattern;
-import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
 import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportAnchor;
-
-import java.util.Optional;
 
 public final class SpreadsheetCellFormatterSelectHistoryTokenTest extends SpreadsheetCellFormatterHistoryTokenTestCase<SpreadsheetCellFormatterSelectHistoryToken> {
 
@@ -78,39 +73,6 @@ public final class SpreadsheetCellFormatterSelectHistoryTokenTest extends Spread
                 ID,
                 NAME,
                 SELECTION
-            )
-        );
-    }
-
-    // saveValue........................................................................................................
-
-    @Test
-    public void testSetSaveValue() {
-        final SpreadsheetFormatPattern pattern = SpreadsheetPattern.parseTimeFormatPattern("hh:mm");
-        final SpreadsheetFormatterSelector selector = pattern.spreadsheetFormatterSelector();
-
-        this.setSaveValueAndCheck(
-            this.createHistoryToken(),
-            selector.text(),
-            HistoryToken.cellFormatterSave(
-                ID,
-                NAME,
-                SELECTION,
-                Optional.of(selector)
-            )
-        );
-    }
-
-    @Test
-    public void testSetSaveValueWithEmpty() {
-        this.setSaveValueAndCheck(
-            this.createHistoryToken(),
-            "",
-            HistoryToken.cellFormatterSave(
-                ID,
-                NAME,
-                SELECTION,
-                Optional.empty()
             )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormatterUnselectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormatterUnselectHistoryTokenTest.java
@@ -20,7 +20,6 @@ package walkingkooka.spreadsheet.dominokit.history;
 import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
-import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
 import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportAnchor;
@@ -79,24 +78,6 @@ public final class SpreadsheetCellFormatterUnselectHistoryTokenTest extends Spre
         this.deleteAndCheck(
             this.createHistoryToken(),
             this.createHistoryToken()
-        );
-    }
-
-    // saveValue........................................................................................................
-
-    @Test
-    public void testSetSaveValue() {
-        this.setSaveValueAndCheck(
-            SpreadsheetPattern.parseDateFormatPattern("dd/mm/yyyy")
-                .spreadsheetFormatterSelector()
-                .toString()
-        );
-    }
-
-    @Test
-    public void testSetSaveValueWithEmpty() {
-        this.setSaveValueAndCheck(
-            ""
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormulaHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellFormulaHistoryTokenTestCase.java
@@ -19,6 +19,8 @@ package walkingkooka.spreadsheet.dominokit.history;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 public abstract class SpreadsheetCellFormulaHistoryTokenTestCase<T extends SpreadsheetCellFormulaHistoryToken> extends SpreadsheetCellHistoryTokenTestCase<T> {
 
     SpreadsheetCellFormulaHistoryTokenTestCase() {
@@ -31,6 +33,47 @@ public abstract class SpreadsheetCellFormulaHistoryTokenTestCase<T extends Sprea
     public final void testPatternKind() {
         this.patternKindAndCheck(
             this.createHistoryToken()
+        );
+    }
+
+    // setSaveValue.....................................................................................................
+
+    @Test
+    public final void testSetSaveValueWithInvalidOptionalValueFails() {
+        this.setSaveValueFails(
+            Optional.of(this)
+        );
+    }
+
+    @Test
+    public final void testSetSaveValueWithEmptyFormula() {
+        final String value = "";
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.empty(),
+            HistoryToken.cellFormulaSave(
+                ID,
+                NAME,
+                SELECTION,
+                value
+            )
+        );
+    }
+
+    @Test
+    public final void testSetSaveValueWithDifferentFormula() {
+        final String value = "different";
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(value),
+            HistoryToken.cellFormulaSave(
+                ID,
+                NAME,
+                SELECTION,
+                value
+            )
         );
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellLabelHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellLabelHistoryTokenTestCase.java
@@ -18,6 +18,10 @@
 package walkingkooka.spreadsheet.dominokit.history;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+
+import java.util.Optional;
 
 public abstract class SpreadsheetCellLabelHistoryTokenTestCase<T extends SpreadsheetCellLabelHistoryToken> extends SpreadsheetCellHistoryTokenTestCase<T> {
 
@@ -83,6 +87,38 @@ public abstract class SpreadsheetCellLabelHistoryTokenTestCase<T extends Spreads
                 LABEL.setDefaultAnchor()
             ),
             LABEL
+        );
+    }
+
+    // setSaveValue.....................................................................................................
+
+    @Test
+    public final void testSetSaveValueWithInvalidOptionalValueFails() {
+        this.setSaveValueFails(
+            Optional.of(this)
+        );
+    }
+
+    @Test
+    public final void testSetSaveValueWithEmptyLabelName() {
+        this.setSaveValueFails(
+            Optional.empty()
+        );
+    }
+
+    @Test
+    public final void testSetSaveValueWithDifferentLabelName() {
+        final SpreadsheetLabelName value = SpreadsheetSelection.labelName("Different");
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(value),
+            HistoryToken.cellLabelSave(
+                ID,
+                NAME,
+                SELECTION,
+                value
+            )
         );
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellParserHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellParserHistoryTokenTestCase.java
@@ -17,9 +17,57 @@
 
 package walkingkooka.spreadsheet.dominokit.history;
 
+import org.junit.jupiter.api.Test;
+import walkingkooka.spreadsheet.parser.SpreadsheetParserSelector;
+
+import java.util.Optional;
+
 public abstract class SpreadsheetCellParserHistoryTokenTestCase<T extends SpreadsheetCellParserHistoryToken> extends SpreadsheetCellHistoryTokenTestCase<T> {
 
     SpreadsheetCellParserHistoryTokenTestCase() {
         super();
+    }
+
+    // setSaveValue.....................................................................................................
+
+    @Test
+    public final void testSetSaveValueWithInvalidOptionalValueFails() {
+        this.setSaveValueFails(
+            Optional.of(this)
+        );
+    }
+
+    @Test
+    public final void testSetSaveValueWithEmpty() {
+        final Optional<SpreadsheetParserSelector> value = Optional.empty();
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            value,
+            HistoryToken.cellParserSave(
+                ID,
+                NAME,
+                SELECTION,
+                value
+            )
+        );
+    }
+
+    @Test
+    public final void testSetSaveValueWithNonEmpty() {
+        final Optional<SpreadsheetParserSelector> value = Optional.of(
+            SpreadsheetParserSelector.parse("different")
+        );
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            value,
+            HistoryToken.cellParserSave(
+                ID,
+                NAME,
+                SELECTION,
+                value
+            )
+        );
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellParserSaveHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellParserSaveHistoryTokenTest.java
@@ -22,7 +22,6 @@ import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetParsePattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
-import walkingkooka.spreadsheet.parser.SpreadsheetParserSelector;
 import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportAnchor;
@@ -123,39 +122,6 @@ public final class SpreadsheetCellParserSaveHistoryTokenTest extends Spreadsheet
                 ID,
                 NAME,
                 SELECTION
-            )
-        );
-    }
-
-    // saveValue........................................................................................................
-
-    @Test
-    public void testSetSaveValue() {
-        final SpreadsheetParsePattern pattern = SpreadsheetPattern.parseTimeParsePattern("hh:mm");
-        final SpreadsheetParserSelector selector = pattern.spreadsheetParserSelector();
-
-        this.setSaveValueAndCheck(
-            this.createHistoryToken(),
-            selector.text(),
-            HistoryToken.cellParserSave(
-                ID,
-                NAME,
-                SELECTION,
-                Optional.of(selector)
-            )
-        );
-    }
-
-    @Test
-    public void testSetSaveValueWithEmpty() {
-        this.setSaveValueAndCheck(
-            this.createHistoryToken(),
-            "",
-            HistoryToken.cellParserSave(
-                ID,
-                NAME,
-                SELECTION,
-                Optional.empty()
             )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellParserSelectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellParserSelectHistoryTokenTest.java
@@ -22,12 +22,9 @@ import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetParsePattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
-import walkingkooka.spreadsheet.parser.SpreadsheetParserSelector;
 import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportAnchor;
-
-import java.util.Optional;
 
 public final class SpreadsheetCellParserSelectHistoryTokenTest extends SpreadsheetCellParserHistoryTokenTestCase<SpreadsheetCellParserSelectHistoryToken> {
 
@@ -80,39 +77,6 @@ public final class SpreadsheetCellParserSelectHistoryTokenTest extends Spreadshe
                 ID,
                 NAME,
                 SELECTION
-            )
-        );
-    }
-
-    // saveValue........................................................................................................
-
-    @Test
-    public void testSetSaveValue() {
-        final SpreadsheetParsePattern pattern = SpreadsheetPattern.parseTimeParsePattern("hh:mm");
-        final SpreadsheetParserSelector selector = pattern.spreadsheetParserSelector();
-
-        this.setSaveValueAndCheck(
-            this.createHistoryToken(),
-            selector.text(),
-            HistoryToken.cellParserSave(
-                ID,
-                NAME,
-                SELECTION,
-                Optional.of(selector)
-            )
-        );
-    }
-
-    @Test
-    public void testSetSaveValueWithEmpty() {
-        this.setSaveValueAndCheck(
-            this.createHistoryToken(),
-            "",
-            HistoryToken.cellParserSave(
-                ID,
-                NAME,
-                SELECTION,
-                Optional.empty()
             )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellParserUnselectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellParserUnselectHistoryTokenTest.java
@@ -71,22 +71,6 @@ public final class SpreadsheetCellParserUnselectHistoryTokenTest extends Spreads
         this.closeAndCheck();
     }
 
-    // saveValue........................................................................................................
-
-    @Test
-    public void testSetSaveValue() {
-        this.setSaveValueAndCheck(
-            "dd/mm/yyyy"
-        );
-    }
-
-    @Test
-    public void testSetSaveValueWithEmpty() {
-        this.setSaveValueAndCheck(
-            ""
-        );
-    }
-
     @Override
     SpreadsheetCellParserUnselectHistoryToken createHistoryToken(final SpreadsheetId id,
                                                                  final SpreadsheetName name,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSaveCellHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSaveCellHistoryTokenTest.java
@@ -26,6 +26,7 @@ import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
+import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -199,6 +200,27 @@ public final class SpreadsheetCellSaveCellHistoryTokenTest extends SpreadsheetCe
         return MARSHALL_CONTEXT.marshallCollection(
             cells
         ).toString();
+    }
+
+    // setSaveValue.....................................................................................................
+
+    @Test
+    public void testSetSaveValueWithDifferentCell() {
+        final Set<SpreadsheetCell> value = Sets.of(
+            CELL
+                .setFormula(SpreadsheetFormula.EMPTY.setText("different"))
+        );
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(value),
+            SpreadsheetCellSaveCellHistoryToken.with(
+                ID,
+                NAME,
+                SELECTION,
+                value
+            )
+        );
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSaveFormatterHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSaveFormatterHistoryTokenTest.java
@@ -280,6 +280,29 @@ public final class SpreadsheetCellSaveFormatterHistoryTokenTest extends Spreadsh
         );
     }
 
+    // setSaveValue.....................................................................................................
+
+    @Test
+    public void testSetSaveValueWithDifferentFormatter() {
+        final Map<SpreadsheetCellReference, Optional<SpreadsheetFormatterSelector>> value = Maps.of(
+            CELL,
+            Optional.of(
+                SpreadsheetFormatterSelector.parse("different")
+            )
+        );
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(value),
+            SpreadsheetCellSaveFormatterHistoryToken.with(
+                ID,
+                NAME,
+                SELECTION,
+                value
+            )
+        );
+    }
+
     @Override
     SpreadsheetCellSaveFormatterHistoryToken createHistoryToken(final SpreadsheetId id,
                                                                 final SpreadsheetName name,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSaveFormulaHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSaveFormulaHistoryTokenTest.java
@@ -26,6 +26,7 @@ import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -183,6 +184,27 @@ public final class SpreadsheetCellSaveFormulaHistoryTokenTest extends Spreadshee
                 cellToFormulaText
             ),
             "/123/SpreadsheetName456/cell/A1:A3/bottom-right/save/formula/" + marshallMap(cellToFormulaText)
+        );
+    }
+
+    // setSaveValue.....................................................................................................
+
+    @Test
+    public void testSetSaveValueWithDifferentFormula() {
+        final Map<SpreadsheetCellReference, String> value = Maps.of(
+            CELL,
+            "different"
+        );
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(value),
+            HistoryToken.cellSaveFormula(
+                ID,
+                NAME,
+                SELECTION,
+                value
+            )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSaveHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSaveHistoryTokenTestCase.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallContext;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallContexts;
 
+import java.util.Optional;
+
 public abstract class SpreadsheetCellSaveHistoryTokenTestCase<T extends SpreadsheetCellSaveHistoryToken<?>> extends SpreadsheetCellHistoryTokenTestCase<T> {
 
     SpreadsheetCellSaveHistoryTokenTestCase() {
@@ -35,6 +37,15 @@ public abstract class SpreadsheetCellSaveHistoryTokenTestCase<T extends Spreadsh
     public final void testPatternKind() {
         this.patternKindAndCheck(
             this.createHistoryToken()
+        );
+    }
+
+    // setSaveValue.....................................................................................................
+
+    @Test
+    public final void testSetSaveValueWithInvalidOptionalValueFails() {
+        this.setSaveValueFails(
+            Optional.of(this)
         );
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSaveParserHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSaveParserHistoryTokenTest.java
@@ -278,6 +278,29 @@ public final class SpreadsheetCellSaveParserHistoryTokenTest extends Spreadsheet
         );
     }
 
+    // setSaveValue.....................................................................................................
+
+    @Test
+    public void testSetSaveValueWithDifferentParser() {
+        final Map<SpreadsheetCellReference, Optional<SpreadsheetParserSelector>> value = Maps.of(
+            CELL,
+            Optional.of(
+                SpreadsheetParserSelector.parse("different")
+            )
+        );
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(value),
+            SpreadsheetCellSaveParserHistoryToken.with(
+                ID,
+                NAME,
+                SELECTION,
+                value
+            )
+        );
+    }
+
     @Override
     SpreadsheetCellSaveParserHistoryToken createHistoryToken(final SpreadsheetId id,
                                                              final SpreadsheetName name,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSaveStyleHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSaveStyleHistoryTokenTest.java
@@ -30,6 +30,7 @@ import walkingkooka.tree.text.TextStyle;
 import walkingkooka.tree.text.TextStylePropertyName;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -211,6 +212,30 @@ public final class SpreadsheetCellSaveStyleHistoryTokenTest extends SpreadsheetC
                 cellToStyle
             ),
             "/123/SpreadsheetName456/cell/A1:A3/bottom-right/save/style/" + marshallMap(cellToStyle)
+        );
+    }
+
+    // setSaveValue.....................................................................................................
+
+    @Test
+    public void testSetSaveValueWithDifferentStyle() {
+        final Map<SpreadsheetCellReference, TextStyle> value = Maps.of(
+            CELL,
+            TextStyle.EMPTY.set(
+                TextStylePropertyName.COLOR,
+                Color.parse("#999")
+            )
+        );
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(value),
+            SpreadsheetCellSaveStyleHistoryToken.with(
+                ID,
+                NAME,
+                SELECTION,
+                value
+            )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSelectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSelectHistoryTokenTest.java
@@ -18,13 +18,25 @@
 package walkingkooka.spreadsheet.dominokit.history;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.collect.map.Maps;
+import walkingkooka.collect.set.Sets;
+import walkingkooka.color.Color;
+import walkingkooka.spreadsheet.SpreadsheetCell;
+import walkingkooka.spreadsheet.SpreadsheetFormula;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
+import walkingkooka.spreadsheet.format.SpreadsheetFormatterSelector;
+import walkingkooka.spreadsheet.parser.SpreadsheetParserSelector;
 import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
+import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportAnchor;
+import walkingkooka.tree.text.TextStyle;
+import walkingkooka.tree.text.TextStylePropertyName;
 
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 
@@ -156,6 +168,109 @@ public final class SpreadsheetCellSelectHistoryTokenTest extends SpreadsheetCell
                 ID,
                 NAME,
                 CELL.setDefaultAnchor()
+            )
+        );
+    }
+
+    // setSaveValue.....................................................................................................
+
+    @Test
+    public void testSetSaveValueWithDifferentCell() {
+        final Set<SpreadsheetCell> value = Sets.of(
+            CELL.setFormula(SpreadsheetFormula.EMPTY.setText("different"))
+        );
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(value),
+            HistoryToken.cellSaveCell(
+                ID,
+                NAME,
+                SELECTION,
+                value
+            )
+        );
+    }
+
+    @Test
+    public void testSetSaveValueWithDifferentFormatter() {
+        final Map<SpreadsheetCellReference, Optional<SpreadsheetFormatterSelector>> value = Maps.of(
+            CELL,
+            Optional.of(
+                SpreadsheetFormatterSelector.parse("different")
+            )
+        );
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(value),
+            HistoryToken.cellSaveFormatter(
+                ID,
+                NAME,
+                SELECTION,
+                value
+            )
+        );
+    }
+
+    @Test
+    public void testSetSaveValueWithDifferentFormula() {
+        final Map<SpreadsheetCellReference, String> value = Maps.of(
+            CELL,
+            "different"
+        );
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(value),
+            HistoryToken.cellSaveFormula(
+                ID,
+                NAME,
+                SELECTION,
+                value
+            )
+        );
+    }
+
+    @Test
+    public void testSetSaveValueWithDifferentParser() {
+        final Map<SpreadsheetCellReference, Optional<SpreadsheetParserSelector>> value = Maps.of(
+            CELL,
+            Optional.of(
+                SpreadsheetParserSelector.parse("different")
+            )
+        );
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(value),
+            HistoryToken.cellSaveParser(
+                ID,
+                NAME,
+                SELECTION,
+                value
+            )
+        );
+    }
+
+    @Test
+    public void testSetSaveValueWithDifferentStyle() {
+        final Map<SpreadsheetCellReference, TextStyle> value = Maps.of(
+            CELL,
+            TextStyle.EMPTY.set(
+                TextStylePropertyName.COLOR,
+                Color.parse("#999")
+            )
+        );
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(value),
+            HistoryToken.cellSaveStyle(
+                ID,
+                NAME,
+                SELECTION,
+                value
             )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSortHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellSortHistoryTokenTestCase.java
@@ -22,6 +22,8 @@ import walkingkooka.spreadsheet.compare.SpreadsheetColumnOrRowSpreadsheetCompara
 import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
+import java.util.Optional;
+
 public abstract class SpreadsheetCellSortHistoryTokenTestCase<T extends SpreadsheetCellSortHistoryToken> extends SpreadsheetCellHistoryTokenTestCase<T> {
 
     final static String COMPARATOR_NAMES_LIST_STRING = "A=day-of-month UP,month-of-year UP,year DOWN";
@@ -47,6 +49,40 @@ public abstract class SpreadsheetCellSortHistoryTokenTestCase<T extends Spreadsh
                 ID,
                 NAME,
                 CELL.setDefaultAnchor()
+            )
+        );
+    }
+
+    // setSaveValue.....................................................................................................
+
+    @Test
+    public final void testSetSaveValueWithInvalidOptionalValueFails() {
+        this.setSaveValueFails(
+            Optional.of(this)
+        );
+    }
+
+    @Test
+    public final void testSetSaveValueWithEmpty() {
+        final Optional<SpreadsheetColumnOrRowSpreadsheetComparatorNamesList> value = Optional.empty();
+
+        this.setSaveValueFails(
+            value
+        );
+    }
+
+    @Test
+    public final void testSetSaveValueWithNonEmpty() {
+        final SpreadsheetColumnOrRowSpreadsheetComparatorNamesList value = SpreadsheetColumnOrRowSpreadsheetComparatorNamesList.parse("A=different");
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(value),
+            HistoryToken.cellSortSave(
+                ID,
+                NAME,
+                SELECTION,
+                value
             )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleHistoryTokenTestCase.java
@@ -24,6 +24,8 @@ import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
 import walkingkooka.tree.text.TextStylePropertyName;
 
+import java.util.Optional;
+
 public abstract class SpreadsheetCellStyleHistoryTokenTestCase<T extends SpreadsheetCellStyleHistoryToken<Color>> extends SpreadsheetCellHistoryTokenTestCase<T> {
 
     final static TextStylePropertyName<Color> PROPERTY_NAME = TextStylePropertyName.COLOR;
@@ -40,6 +42,51 @@ public abstract class SpreadsheetCellStyleHistoryTokenTestCase<T extends Spreads
     public final void testPatternKind() {
         this.patternKindAndCheck(
             this.createHistoryToken()
+        );
+    }
+
+    // setSaveValue.....................................................................................................
+
+    @Test
+    public final void testSetSaveValueWithInvalidOptionalValueFails() {
+        this.setSaveValueFails(
+            Optional.of(this)
+        );
+    }
+
+    @Test
+    public final void testSetSaveValueWithEmpty() {
+        final Optional<Color> value = Optional.empty();
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            value,
+            HistoryToken.cellStyleSave(
+                ID,
+                NAME,
+                SELECTION,
+                PROPERTY_NAME,
+                value
+            )
+        );
+    }
+
+    @Test
+    public final void testSetSaveValueWithNonEmpty() {
+        final Optional<Color> value = Optional.of(
+            Color.parse("#999")
+        );
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            value,
+            HistoryToken.cellStyleSave(
+                ID,
+                NAME,
+                SELECTION,
+                PROPERTY_NAME,
+                value
+            )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnSortHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnSortHistoryTokenTestCase.java
@@ -22,6 +22,8 @@ import walkingkooka.spreadsheet.compare.SpreadsheetColumnOrRowSpreadsheetCompara
 import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
+import java.util.Optional;
+
 public abstract class SpreadsheetColumnSortHistoryTokenTestCase<T extends SpreadsheetColumnSortHistoryToken> extends SpreadsheetColumnHistoryTokenTestCase<T> {
 
     final static String COMPARATOR_NAMES_LIST_STRING = "A=day-of-month UP,month-of-year UP,year DOWN";
@@ -47,6 +49,40 @@ public abstract class SpreadsheetColumnSortHistoryTokenTestCase<T extends Spread
                 ID,
                 NAME,
                 COLUMN.setDefaultAnchor()
+            )
+        );
+    }
+
+    // setSaveValue.....................................................................................................
+
+    @Test
+    public final void testSetSaveValueWithInvalidOptionalValueFails() {
+        this.setSaveValueFails(
+            Optional.of(this)
+        );
+    }
+
+    @Test
+    public final void testSetSaveValueWithEmpty() {
+        final Optional<SpreadsheetColumnOrRowSpreadsheetComparatorNamesList> value = Optional.empty();
+
+        this.setSaveValueAndCheck(
+            value
+        );
+    }
+
+    @Test
+    public final void testSetSaveValueWithNonEmpty() {
+        final SpreadsheetColumnOrRowSpreadsheetComparatorNamesList value = SpreadsheetColumnOrRowSpreadsheetComparatorNamesList.parse("A=different");
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(value),
+            HistoryToken.columnSortSave(
+                ID,
+                NAME,
+                SELECTION,
+                value
             )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingSaveHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingSaveHistoryTokenTest.java
@@ -47,6 +47,62 @@ public final class SpreadsheetLabelMappingSaveHistoryTokenTest extends Spreadshe
         );
     }
 
+    // setSaveValue.....................................................................................................
+
+    @Test
+    public void testSetSaveValueWithInvalidOptionalValueFails() {
+        this.setSaveValueFails(
+            Optional.of(this)
+        );
+    }
+
+    @Test
+    public void testSetSaveValueWithDifferentCell() {
+        final SpreadsheetExpressionReference value = SpreadsheetSelection.parseCell("Z9");
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(value),
+            HistoryToken.labelMappingSave(
+                ID,
+                NAME,
+                LABEL.setLabelMappingTarget(value)
+            )
+        );
+    }
+
+    @Test
+    public void testSetSaveValueWithDifferentCellRange() {
+        final SpreadsheetExpressionReference value = SpreadsheetSelection.parseCellRange("A1:Z9");
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(value),
+            HistoryToken.labelMappingSave(
+                ID,
+                NAME,
+                LABEL.setLabelMappingTarget(value)
+            )
+        );
+    }
+
+    @Test
+    public void testSetSaveValueWithDifferentLabel() {
+        final SpreadsheetExpressionReference value = SpreadsheetSelection.labelName("Different");
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(value),
+            HistoryToken.labelMappingSave(
+                ID,
+                NAME,
+                LABEL.setLabelMappingTarget(value)
+            )
+        );
+    }
+
+    // urlFragment......................................................................................................
+
     @Test
     public void testUrlFragmentCell() {
         this.urlFragmentAndCheck(

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingSelectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingSelectHistoryTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellRangeReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
@@ -69,6 +70,60 @@ public final class SpreadsheetLabelMappingSelectHistoryTokenTest extends Spreads
                 Optional.of(LABEL)
             ),
             LABEL
+        );
+    }
+
+    // setSaveValue.....................................................................................................
+
+    @Test
+    public void testSetSaveValueWithInvalidOptionalValueFails() {
+        this.setSaveValueFails(
+            Optional.of(this)
+        );
+    }
+
+    @Test
+    public void testSetSaveValueWithDifferentCell() {
+        final SpreadsheetExpressionReference value = SpreadsheetSelection.parseCell("Z9");
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(value),
+            HistoryToken.labelMappingSave(
+                ID,
+                NAME,
+                LABEL.setLabelMappingTarget(value)
+            )
+        );
+    }
+
+    @Test
+    public void testSetSaveValueWithDifferentCellRange() {
+        final SpreadsheetExpressionReference value = SpreadsheetSelection.parseCellRange("A1:Z9");
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(value),
+            HistoryToken.labelMappingSave(
+                ID,
+                NAME,
+                LABEL.setLabelMappingTarget(value)
+            )
+        );
+    }
+
+    @Test
+    public void testSetSaveValueWithDifferentLabel() {
+        final SpreadsheetExpressionReference value = SpreadsheetSelection.labelName("Different");
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(value),
+            HistoryToken.labelMappingSave(
+                ID,
+                NAME,
+                LABEL.setLabelMappingTarget(value)
+            )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySaveHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySaveHistoryTokenTest.java
@@ -238,6 +238,40 @@ public final class SpreadsheetMetadataPropertySaveHistoryTokenTest extends Sprea
         );
     }
 
+    // setSaveValue.....................................................................................................
+
+    @Test
+    public void testSetSaveValueWithEmpty() {
+        final Optional<ExpressionNumberKind> value = Optional.empty();
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            value,
+            HistoryToken.metadataPropertySave(
+                ID,
+                NAME,
+                EXPRESSION_NUMBER_KIND,
+                value
+            )
+        );
+    }
+
+    @Test
+    public void testSetSaveValueWithDifferentNotEmpty() {
+        final Optional<ExpressionNumberKind> value = Optional.of(ExpressionNumberKind.DOUBLE);
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            value,
+            HistoryToken.metadataPropertySave(
+                ID,
+                NAME,
+                EXPRESSION_NUMBER_KIND,
+                value
+            )
+        );
+    }
+
     // helper...........................................................................................................
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySelectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySelectHistoryTokenTest.java
@@ -286,7 +286,7 @@ public final class SpreadsheetMetadataPropertySelectHistoryTokenTest extends Spr
                 NAME,
                 propertyName
             ),
-            value.toString(),
+            Optional.of(value),
             HistoryToken.metadataPropertySave(
                 ID,
                 NAME,
@@ -308,7 +308,7 @@ public final class SpreadsheetMetadataPropertySelectHistoryTokenTest extends Spr
                 NAME,
                 propertyName
             ),
-            "",
+            Optional.empty(),
             HistoryToken.metadataPropertySave(
                 ID,
                 NAME,
@@ -324,7 +324,7 @@ public final class SpreadsheetMetadataPropertySelectHistoryTokenTest extends Spr
 
         this.setSaveValueAndCheck(
             this.createHistoryToken(),
-            kind.name(),
+            Optional.of(kind),
             HistoryToken.metadataPropertySave(
                 ID,
                 NAME,
@@ -340,7 +340,7 @@ public final class SpreadsheetMetadataPropertySelectHistoryTokenTest extends Spr
     public void testSetSaveValueExpressionNumberKindEmpty() {
         this.setSaveValueAndCheck(
             this.createHistoryToken(),
-            "",
+            Optional.empty(),
             HistoryToken.metadataPropertySave(
                 ID,
                 NAME,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSaveHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSaveHistoryTokenTest.java
@@ -158,6 +158,42 @@ public final class SpreadsheetMetadataPropertyStyleSaveHistoryTokenTest extends 
         );
     }
 
+    // setSaveValue.....................................................................................................
+
+    @Test
+    public void testSetSaveValueWithEmptyValue() {
+        final Optional<Color> value = Optional.empty();
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            value,
+            HistoryToken.metadataPropertyStyleSave(
+                ID,
+                NAME,
+                STYLE_PROPERTY_NAME,
+                value
+            )
+        );
+    }
+
+    @Test
+    public void testSetSaveValueWithValue() {
+        final Optional<Color> value = Optional.of(
+            Color.parse("#999")
+        );
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            value,
+            HistoryToken.metadataPropertyStyleSave(
+                ID,
+                NAME,
+                STYLE_PROPERTY_NAME,
+                value
+            )
+        );
+    }
+
     @Override
     SpreadsheetMetadataPropertyStyleSaveHistoryToken<Color> createHistoryToken(final SpreadsheetId id,
                                                                                final SpreadsheetName name,

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSelectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSelectHistoryTokenTest.java
@@ -30,10 +30,10 @@ import java.util.Optional;
 
 public final class SpreadsheetMetadataPropertyStyleSelectHistoryTokenTest extends SpreadsheetMetadataPropertyStyleHistoryTokenTestCase<SpreadsheetMetadataPropertyStyleSelectHistoryToken<Color>, Color> {
 
-    // saveValue........................................................................................................
+    // setSaveValue.....................................................................................................
 
     @Test
-    public void testSetSaveValueStyle() {
+    public void testSetSaveValueStyleWithString() {
         final SpreadsheetMetadataPropertyStyleSelectHistoryToken<Color> historyToken = this.createHistoryToken();
         final String value = "#123456";
 
@@ -62,6 +62,42 @@ public final class SpreadsheetMetadataPropertyStyleSelectHistoryTokenTest extend
                 NAME,
                 STYLE_PROPERTY_NAME,
                 Optional.empty()
+            )
+        );
+    }
+
+    // setSaveValue.....................................................................................................
+
+    @Test
+    public void testSetSaveValueWithEmptyValue() {
+        final Optional<Color> value = Optional.empty();
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            value,
+            HistoryToken.metadataPropertyStyleSave(
+                ID,
+                NAME,
+                STYLE_PROPERTY_NAME,
+                value
+            )
+        );
+    }
+
+    @Test
+    public void testSetSaveValueWithValue() {
+        final Optional<Color> value = Optional.of(
+            Color.parse("#999")
+        );
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            value,
+            HistoryToken.metadataPropertyStyleSave(
+                ID,
+                NAME,
+                STYLE_PROPERTY_NAME,
+                value
             )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowSortHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowSortHistoryTokenTestCase.java
@@ -22,6 +22,8 @@ import walkingkooka.spreadsheet.compare.SpreadsheetColumnOrRowSpreadsheetCompara
 import walkingkooka.spreadsheet.reference.AnchoredSpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
+import java.util.Optional;
+
 public abstract class SpreadsheetRowSortHistoryTokenTestCase<T extends SpreadsheetRowSortHistoryToken> extends SpreadsheetRowHistoryTokenTestCase<T> {
 
     final static String COMPARATOR_NAMES_LIST_STRING = "1=day-of-month UP,month-of-year UP,year DOWN";
@@ -47,6 +49,40 @@ public abstract class SpreadsheetRowSortHistoryTokenTestCase<T extends Spreadshe
                 ID,
                 NAME,
                 ROW.setDefaultAnchor()
+            )
+        );
+    }
+
+    // setSaveValue.....................................................................................................
+
+    @Test
+    public final void testSetSaveValueWithInvalidOptionalValueFails() {
+        this.setSaveValueFails(
+            Optional.of(this)
+        );
+    }
+
+    @Test
+    public final void testSetSaveValueWithEmpty() {
+        final Optional<SpreadsheetColumnOrRowSpreadsheetComparatorNamesList> value = Optional.empty();
+
+        this.setSaveValueAndCheck(
+            value
+        );
+    }
+
+    @Test
+    public final void testSetSaveValueWithNonEmpty() {
+        final SpreadsheetColumnOrRowSpreadsheetComparatorNamesList value = SpreadsheetColumnOrRowSpreadsheetComparatorNamesList.parse("1=different");
+
+        this.setSaveValueAndCheck(
+            this.createHistoryToken(),
+            Optional.of(value),
+            HistoryToken.rowSortSave(
+                ID,
+                NAME,
+                ROW.setDefaultAnchor(),
+                value
             )
         );
     }


### PR DESCRIPTION
- Previously many were broken eg XXXSaveHistoryToken.setSaveValues(Optional<?>) would not work correctly and required using setSaveValue(String)

- NB cant handle SpreadsheetCellFormatterHistoryToken & SpreadsheetCellParserHistoryToken where Map values could be all empty Optionals.