### PR TITLE
PluginHistoryToken.urlFragment cached

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/PluginHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/PluginHistoryToken.java
@@ -43,13 +43,20 @@ public abstract class PluginHistoryToken extends HistoryToken {
 
     @Override
     public final UrlFragment urlFragment() {
-        // special-case PluginUploadHistoryToken because it is not prefixed by #/plugin
-        return this instanceof PluginUploadHistoryToken ?
-            this.pluginUrlFragment() :
-            UrlFragment.SLASH.append(
-                HistoryToken.PLUGIN
-            ).appendSlashThen(this.pluginUrlFragment());
+        if (null == this.urlFragment) {
+            // special-case PluginUploadHistoryToken because it is not prefixed by #/plugin
+            this.urlFragment = this instanceof PluginUploadHistoryToken ?
+                this.pluginUrlFragment() :
+                UrlFragment.SLASH.append(
+                    HistoryToken.PLUGIN
+                ).appendSlashThen(this.pluginUrlFragment());
+        }
+
+        return this.urlFragment;
     }
+
+    // cache initially null
+    private UrlFragment urlFragment;
 
     abstract UrlFragment pluginUrlFragment();
 }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/PluginHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/PluginHistoryTokenTestCase.java
@@ -20,6 +20,8 @@ package walkingkooka.spreadsheet.dominokit.history;
 import org.junit.jupiter.api.Test;
 import walkingkooka.net.UrlFragment;
 
+import static org.junit.Assert.assertSame;
+
 public abstract class PluginHistoryTokenTestCase<T extends PluginHistoryToken> extends HistoryTokenTestCase<T> {
 
     PluginHistoryTokenTestCase() {
@@ -70,4 +72,16 @@ public abstract class PluginHistoryTokenTestCase<T extends PluginHistoryToken> e
             () -> "parse " + fragment
         );
     }
+
+    // urlFragment......................................................................................................
+
+    @Test
+    public final void testUrlFragmentCached() {
+        final T token = this.createHistoryToken();
+        assertSame(
+            token.urlFragment(),
+            token.urlFragment()
+        );
+    }
 }
+


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/4389
- PluginHistoryToken.urlFragment() should be cached