### PR TITLE
SpreadsheetTextViewComponent honour file line endings FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/text/SpreadsheetTextViewComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/text/SpreadsheetTextViewComponent.java
@@ -36,6 +36,10 @@ public final class SpreadsheetTextViewComponent extends SpreadsheetTextViewCompo
     private SpreadsheetTextViewComponent() {
         super();
         this.element = ElementsFactory.elements.div();
+
+        // https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/4338
+        // honour(render) "file" line endings
+        this.setCssText("white-space: pre;");
     }
 
     @Override


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/4338
- SpreadsheetTextViewComponent ignores text line endings