### PR TITLE
SpreadsheetFindDialogComponent links positioning FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/find/SpreadsheetFindDialogComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/find/SpreadsheetFindDialogComponent.java
@@ -141,6 +141,8 @@ public final class SpreadsheetFindDialogComponent implements SpreadsheetDialogCo
                 ).setFooter(
                     Lists.of(
                         SpreadsheetFlexLayout.row()
+                            .setCssProperty("margin-top", "5px")
+                            .setCssProperty("margin-left", "-5px")
                             .appendChild(this.find)
                             .appendChild(this.reset)
                             .appendChild(this.loadHighlightingQuery)


### PR DESCRIPTION
- Previously the links along the bottom were shifted slightly to the right and without space with the textbox above.