### PR TITLE
SpreadsheetDataTableComponent font-size FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/public/index.html
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/public/index.html
@@ -27,6 +27,7 @@
             --dui-form-field-input-height: 29px;
             --dui-form-field-input-line-hieght: 28px;
             --dui-card-header-padding: var(--dui-spc-2);
+            --dui-datattable-font-size: 1rem;
         }
 
         TABLE#viewport {


### PR DESCRIPTION
- Previously the default font-size was 0.875 resulting in a 14px rather than 15px text