### PR TITLE
HistoryTokenAnchorComponent disabled black not blue

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenAnchorComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenAnchorComponent.java
@@ -107,11 +107,16 @@ public final class HistoryTokenAnchorComponent extends HistoryTokenAnchorCompone
 
         final CSSStyleDeclaration style = element.style;
 
+        // disabled is black, without underline and not-allowed pointer
+        // enabled is blue, underlined and pointer=pointer
         style.textDecoration = disabled ? "none" : "underline";
 
         style.cursor = disabled ?
             "not-allowed !important" :
             "pointer !important";
+        style.color = disabled ?
+            "var(--dui-hyperlink-disabled-color)" :
+            "var(--dui-hyperlink-color)";
 
         this.iconBefore = null;
         this.iconAfter = null;

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/public/index.html
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/public/index.html
@@ -24,6 +24,7 @@
     <style>
         * {
             --dui-hyperlink-color: blue;
+            --dui-hyperlink-disabled-color: black;
             --dui-form-field-input-height: 29px;
             --dui-form-field-input-line-hieght: 28px;
             --dui-card-header-padding: var(--dui-spc-2);


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/4425
- Disabled links shouldnt be "blue" same colour as enabled links

- New variable "--dui-hyperlink-disabled-color: black;"