### PR TITLE
Revert "PluginListXXXHistoryToken SpreadsheetListXXXHistoryToken list…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryToken.java
@@ -191,10 +191,6 @@ public abstract class HistoryToken implements HasUrlFragment,
 
     final static UrlFragment LABELS = UrlFragment.parse(LABELS_STRING);
 
-    final static String LIST_STRING = "list";
-
-    final static UrlFragment LIST = UrlFragment.parse(LIST_STRING);
-
     final static String MENU_STRING = "menu";
 
     final static UrlFragment MENU = UrlFragment.parse(MENU_STRING);
@@ -260,6 +256,10 @@ public abstract class HistoryToken implements HasUrlFragment,
     final static String UNFREEZE_STRING = "unfreeze";
 
     final static UrlFragment UNFREEZE = UrlFragment.parse(UNFREEZE_STRING);
+
+    final static String WILDCARD_STRING = "*";
+
+    final static UrlFragment WILDCARD = UrlFragment.parse(WILDCARD_STRING);
 
     final static JsonNodeMarshallContext MARSHALL_CONTEXT = JsonNodeMarshallContexts.basic();
 
@@ -1372,7 +1372,7 @@ public abstract class HistoryToken implements HasUrlFragment,
                     case SELECT_STRING:
                         token = SPREADSHEET_LIST_SELECT_HISTORY_TOKEN;
                         break;
-                    case LIST_STRING:
+                    case WILDCARD_STRING:
                         token = SPREADSHEET_LIST_SELECT_HISTORY_TOKEN;
                         token = token.parseOffsetCountReload(cursor);
                         break;
@@ -2876,7 +2876,7 @@ public abstract class HistoryToken implements HasUrlFragment,
         boolean addStar = true;
 
         if(offsetAndCount.isNotEmpty()) {
-            urlFragment = urlFragment.appendSlashThen(LIST)
+            urlFragment = urlFragment.appendSlashThen(WILDCARD)
                 .append(
                     offsetAndCount.urlFragment()
                 );
@@ -2885,7 +2885,7 @@ public abstract class HistoryToken implements HasUrlFragment,
 
         if (false == suffix.isEmpty()) {
             if (addStar) {
-                urlFragment = urlFragment.appendSlashThen(LIST);
+                urlFragment = urlFragment.appendSlashThen(WILDCARD);
             }
 
             urlFragment = urlFragment.appendSlashThen(suffix);

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/PluginListHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/PluginListHistoryToken.java
@@ -56,7 +56,7 @@ public abstract class PluginListHistoryToken extends PluginHistoryToken {
         HistoryToken historyToken = this;
 
         switch (component) {
-            case LIST_STRING:
+            case WILDCARD_STRING:
                 historyToken = this.parseOffsetCountReload(cursor);
                 break;
             default:

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/PluginListSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/PluginListSelectHistoryToken.java
@@ -23,7 +23,7 @@ import walkingkooka.spreadsheet.dominokit.AppContext;
 /**
  * A token that represents a plugin list files dialog.
  * <pre>
- * /plugin/list/offset/1/count/10/
+ * /plugin/STAR/offset/1/count/10/
  * </pre>
  */
 public final class PluginListSelectHistoryToken extends PluginListHistoryToken {

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/datatable/SpreadsheetDataTableComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/datatable/SpreadsheetDataTableComponentTest.java
@@ -433,11 +433,11 @@ public final class SpreadsheetDataTableComponentTest implements ClassTesting<Spr
                 ).previousNextLinks(ID_PREFIX)
                 .setPrevious(
                     Optional.of(
-                        HistoryToken.parseString("/list/offset/11/count/5")
+                        HistoryToken.parseString("/*/offset/11/count/5")
                     )
                 ).setNext(
                     Optional.of(
-                        HistoryToken.parseString("/list/offset/22/count/5")
+                        HistoryToken.parseString("/*/offset/22/count/5")
                     )
                 ),
             "SpreadsheetDataTableComponent\n" +
@@ -471,8 +471,8 @@ public final class SpreadsheetDataTableComponentTest implements ClassTesting<Spr
                 "  CHILDREN\n" +
                 "    SpreadsheetFlexLayout\n" +
                 "      ROW\n" +
-                "        mdi-arrow-left \"previous\" [#/list/offset/11/count/5] id=tableId123-previous-Link\n" +
-                "        \"next\" [#/list/offset/22/count/5] mdi-arrow-right id=tableId123-next-Link\n"
+                "        mdi-arrow-left \"previous\" [#/*/offset/11/count/5] id=tableId123-previous-Link\n" +
+                "        \"next\" [#/*/offset/22/count/5] mdi-arrow-right id=tableId123-next-Link\n"
         );
     }
 
@@ -560,7 +560,7 @@ public final class SpreadsheetDataTableComponentTest implements ClassTesting<Spr
                 "    SpreadsheetFlexLayout\n" +
                 "      ROW\n" +
                 "        mdi-arrow-left \"previous\" DISABLED id=tableId123-previous-Link\n" +
-                "        \"next\" [#/list/offset/4/count/5] mdi-arrow-right id=tableId123-next-Link\n"
+                "        \"next\" [#/*/offset/4/count/5] mdi-arrow-right id=tableId123-next-Link\n"
         );
     }
 
@@ -631,7 +631,7 @@ public final class SpreadsheetDataTableComponentTest implements ClassTesting<Spr
                 "  CHILDREN\n" +
                 "    SpreadsheetFlexLayout\n" +
                 "      ROW\n" +
-                "        mdi-arrow-left \"previous\" [#/list/offset/12/count/5] id=tableId123-previous-Link\n" +
+                "        mdi-arrow-left \"previous\" [#/*/offset/12/count/5] id=tableId123-previous-Link\n" +
                 "        \"next\" DISABLED mdi-arrow-right id=tableId123-next-Link\n"
         );
     }
@@ -719,8 +719,8 @@ public final class SpreadsheetDataTableComponentTest implements ClassTesting<Spr
                 "  CHILDREN\n" +
                 "    SpreadsheetFlexLayout\n" +
                 "      ROW\n" +
-                "        mdi-arrow-left \"previous\" [#/list/offset/12/count/5] id=tableId123-previous-Link\n" +
-                "        \"next\" [#/list/offset/20/count/5] mdi-arrow-right id=tableId123-next-Link\n"
+                "        mdi-arrow-left \"previous\" [#/*/offset/12/count/5] id=tableId123-previous-Link\n" +
+                "        \"next\" [#/*/offset/20/count/5] mdi-arrow-right id=tableId123-next-Link\n"
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTest.java
@@ -2257,7 +2257,7 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>, Parse
     @Test
     public void testParsePluginOffset() {
         this.parseStringAndCheck(
-            "/plugin/list/offset/123",
+            "/plugin/*/offset/123",
             HistoryToken.pluginListSelect(
                 HistoryTokenOffsetAndCount.with(
                     OptionalInt.of(123), // offset
@@ -2271,7 +2271,7 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>, Parse
     @Test
     public void testParsePluginCount() {
         this.parseStringAndCheck(
-            "/plugin/list/count/456",
+            "/plugin/*/count/456",
             HistoryToken.pluginListSelect(
                 HistoryTokenOffsetAndCount.with(
                     OptionalInt.empty(), // offset
@@ -2294,7 +2294,7 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>, Parse
     @Test
     public void testParsePluginStarReload() {
         this.parseStringAndCheck(
-            "/plugin/list/reload",
+            "/plugin/*/reload",
             HistoryToken.pluginListReload(
                 HistoryTokenOffsetAndCount.with(
                     OptionalInt.empty(), // offset
@@ -2307,7 +2307,7 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>, Parse
     @Test
     public void testParsePluginStarOffsetReload() {
         this.parseStringAndCheck(
-            "/plugin/list/offset/123/reload",
+            "/plugin/*/offset/123/reload",
             HistoryToken.pluginListReload(
                 HistoryTokenOffsetAndCount.with(
                     OptionalInt.of(123), // offset

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/PluginListReloadHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/PluginListReloadHistoryTokenTest.java
@@ -134,7 +134,7 @@ public final class PluginListReloadHistoryTokenTest extends PluginListHistoryTok
     @Test
     public void testParseInvalidOffset() {
         this.parseAndCheck(
-            "/plugin/list/offset/X/reload",
+            "/plugin/*/offset/X/reload",
             HistoryToken.pluginListSelect(
                 HistoryTokenOffsetAndCount.EMPTY
             )
@@ -144,7 +144,7 @@ public final class PluginListReloadHistoryTokenTest extends PluginListHistoryTok
     @Test
     public void testParseReload() {
         this.parseAndCheck(
-            "/plugin/list/reload",
+            "/plugin/*/reload",
             PluginListReloadHistoryToken.with(
                 HistoryTokenOffsetAndCount.EMPTY
             )
@@ -154,7 +154,7 @@ public final class PluginListReloadHistoryTokenTest extends PluginListHistoryTok
     @Test
     public void testParseOffset() {
         this.parseAndCheck(
-            "/plugin/list/offset/10/reload",
+            "/plugin/*/offset/10/reload",
             PluginListReloadHistoryToken.with(
                 HistoryTokenOffsetAndCount.EMPTY.setOffset(
                     OptionalInt.of(10)
@@ -166,7 +166,7 @@ public final class PluginListReloadHistoryTokenTest extends PluginListHistoryTok
     @Test
     public void testParseCount() {
         this.parseAndCheck(
-            "/plugin/list/count/20/reload",
+            "/plugin/*/count/20/reload",
             PluginListReloadHistoryToken.with(
                 HistoryTokenOffsetAndCount.EMPTY.setCount(
                     OptionalInt.of(20)
@@ -178,7 +178,7 @@ public final class PluginListReloadHistoryTokenTest extends PluginListHistoryTok
     @Test
     public void testParseOffsetAndCount() {
         this.parseAndCheck(
-            "/plugin/list/offset/10/count/20/reload",
+            "/plugin/*/offset/10/count/20/reload",
             PluginListReloadHistoryToken.with(
                 HistoryTokenOffsetAndCount.with(
                     OptionalInt.of(10), // offset
@@ -192,7 +192,7 @@ public final class PluginListReloadHistoryTokenTest extends PluginListHistoryTok
 
     @Test
     public void testUrlFragment() {
-        this.urlFragmentAndCheck("/plugin/list/offset/1/count/23/reload");
+        this.urlFragmentAndCheck("/plugin/*/offset/1/count/23/reload");
     }
 
     @Test
@@ -203,7 +203,7 @@ public final class PluginListReloadHistoryTokenTest extends PluginListHistoryTok
                     OptionalInt.of(10)
                 )
             ),
-            "/plugin/list/offset/10/reload"
+            "/plugin/*/offset/10/reload"
         );
     }
 
@@ -216,7 +216,7 @@ public final class PluginListReloadHistoryTokenTest extends PluginListHistoryTok
                     OptionalInt.of(20) // count
                 )
             ),
-            "/plugin/list/offset/10/count/20/reload"
+            "/plugin/*/offset/10/count/20/reload"
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/PluginListSelectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/PluginListSelectHistoryTokenTest.java
@@ -134,7 +134,7 @@ public final class PluginListSelectHistoryTokenTest extends PluginListHistoryTok
     @Test
     public void testParseInvalidOffset() {
         this.parseAndCheck(
-            "/plugin/list/offset/X",
+            "/plugin/*/offset/X",
             PluginListSelectHistoryToken.with(HistoryTokenOffsetAndCount.EMPTY)
         );
     }
@@ -142,7 +142,7 @@ public final class PluginListSelectHistoryTokenTest extends PluginListHistoryTok
     @Test
     public void testParseOffset() {
         this.parseAndCheck(
-            "/plugin/list/offset/10",
+            "/plugin/*/offset/10",
             PluginListSelectHistoryToken.with(
                 HistoryTokenOffsetAndCount.EMPTY.setOffset(
                     OptionalInt.of(10)
@@ -154,7 +154,7 @@ public final class PluginListSelectHistoryTokenTest extends PluginListHistoryTok
     @Test
     public void testParseCount() {
         this.parseAndCheck(
-            "/plugin/list/count/20",
+            "/plugin/*/count/20",
             PluginListSelectHistoryToken.with(
                 HistoryTokenOffsetAndCount.EMPTY.setCount(
                     OptionalInt.of(20)
@@ -166,7 +166,7 @@ public final class PluginListSelectHistoryTokenTest extends PluginListHistoryTok
     @Test
     public void testParseOffsetAndCount() {
         this.parseAndCheck(
-            "/plugin/list/offset/10/count/20",
+            "/plugin/*/offset/10/count/20",
             PluginListSelectHistoryToken.with(
                 HistoryTokenOffsetAndCount.with(
                     OptionalInt.of(10), // offset
@@ -195,7 +195,7 @@ public final class PluginListSelectHistoryTokenTest extends PluginListHistoryTok
                     OptionalInt.of(10)
                 )
             ),
-            "/plugin/list/offset/10"
+            "/plugin/*/offset/10"
         );
     }
 
@@ -208,7 +208,7 @@ public final class PluginListSelectHistoryTokenTest extends PluginListHistoryTok
                     OptionalInt.of(20) // count
                 )
             ),
-            "/plugin/list/offset/10/count/20"
+            "/plugin/*/offset/10/count/20"
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetListReloadHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetListReloadHistoryTokenTest.java
@@ -126,7 +126,7 @@ public final class SpreadsheetListReloadHistoryTokenTest extends SpreadsheetList
     @Test
     public void testParseInvalidOffset() {
         this.parseAndCheck(
-            "/list/offset/X/reload/",
+            "/*/offset/X/reload/",
             HistoryToken.spreadsheetListSelect(HistoryTokenOffsetAndCount.EMPTY)
         );
     }
@@ -140,9 +140,9 @@ public final class SpreadsheetListReloadHistoryTokenTest extends SpreadsheetList
     }
 
     @Test
-    public void testParseListReload() {
+    public void testParseStarReload() {
         this.parseAndCheck(
-            "/list/reload",
+            "/*/reload",
             SpreadsheetListReloadHistoryToken.with(HistoryTokenOffsetAndCount.EMPTY)
         );
     }
@@ -150,7 +150,7 @@ public final class SpreadsheetListReloadHistoryTokenTest extends SpreadsheetList
     @Test
     public void testParseOffset() {
         this.parseAndCheck(
-            "/list/offset/10/reload",
+            "/*/offset/10/reload",
             SpreadsheetListReloadHistoryToken.with(
                 HistoryTokenOffsetAndCount.with(
                     OptionalInt.of(10), // offset
@@ -163,7 +163,7 @@ public final class SpreadsheetListReloadHistoryTokenTest extends SpreadsheetList
     @Test
     public void testParseCount() {
         this.parseAndCheck(
-            "/list/count/20/reload",
+            "/*/count/20/reload",
             SpreadsheetListReloadHistoryToken.with(
                 HistoryTokenOffsetAndCount.with(
                     OptionalInt.empty(), // offset
@@ -176,7 +176,7 @@ public final class SpreadsheetListReloadHistoryTokenTest extends SpreadsheetList
     @Test
     public void testParseOffsetAndCount() {
         this.parseAndCheck(
-            "/list/offset/10/count/20/reload",
+            "/*/offset/10/count/20/reload",
             SpreadsheetListReloadHistoryToken.with(
                 HistoryTokenOffsetAndCount.with(
                     OptionalInt.of(10), // offset
@@ -188,7 +188,7 @@ public final class SpreadsheetListReloadHistoryTokenTest extends SpreadsheetList
 
     @Test
     public void testUrlFragment() {
-        this.urlFragmentAndCheck("/list/offset/1/count/23/reload");
+        this.urlFragmentAndCheck("/*/offset/1/count/23/reload");
     }
 
     @Test
@@ -200,7 +200,7 @@ public final class SpreadsheetListReloadHistoryTokenTest extends SpreadsheetList
                     OptionalInt.empty() // count
                 )
             ),
-            "/list/offset/10/reload"
+            "/*/offset/10/reload"
         );
     }
 
@@ -213,7 +213,7 @@ public final class SpreadsheetListReloadHistoryTokenTest extends SpreadsheetList
                     OptionalInt.of(20) // count
                 )
             ),
-            "/list/offset/10/count/20/reload"
+            "/*/offset/10/count/20/reload"
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetListSelectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetListSelectHistoryTokenTest.java
@@ -126,7 +126,7 @@ public final class SpreadsheetListSelectHistoryTokenTest extends SpreadsheetList
     @Test
     public void testParseInvalidOffset() {
         this.parseAndCheck(
-            "/list/offset/X",
+            "/*/offset/X",
             SpreadsheetListSelectHistoryToken.with(HistoryTokenOffsetAndCount.EMPTY)
         );
     }
@@ -134,7 +134,7 @@ public final class SpreadsheetListSelectHistoryTokenTest extends SpreadsheetList
     @Test
     public void testParseOffset() {
         this.parseAndCheck(
-            "/list/offset/10",
+            "/*/offset/10",
             SpreadsheetListSelectHistoryToken.with(
                 HistoryTokenOffsetAndCount.with(
                     OptionalInt.of(10), // offset
@@ -147,7 +147,7 @@ public final class SpreadsheetListSelectHistoryTokenTest extends SpreadsheetList
     @Test
     public void testParseCount() {
         this.parseAndCheck(
-            "/list/count/20",
+            "/*/count/20",
             SpreadsheetListSelectHistoryToken.with(
                 HistoryTokenOffsetAndCount.EMPTY.setCount(
                     OptionalInt.of(20)
@@ -159,7 +159,7 @@ public final class SpreadsheetListSelectHistoryTokenTest extends SpreadsheetList
     @Test
     public void testParseOffsetAndCount() {
         this.parseAndCheck(
-            "/list/offset/10/count/20",
+            "/*/offset/10/count/20",
             SpreadsheetListSelectHistoryToken.with(
                 HistoryTokenOffsetAndCount.with(
                     OptionalInt.of(10), // offset
@@ -171,7 +171,7 @@ public final class SpreadsheetListSelectHistoryTokenTest extends SpreadsheetList
 
     @Test
     public void testUrlFragment() {
-        this.urlFragmentAndCheck("/list/offset/1/count/23");
+        this.urlFragmentAndCheck("/*/offset/1/count/23");
     }
 
     @Test
@@ -182,7 +182,7 @@ public final class SpreadsheetListSelectHistoryTokenTest extends SpreadsheetList
                     OptionalInt.of(10)
                 )
             ),
-            "/list/offset/10"
+            "/*/offset/10"
         );
     }
 
@@ -195,7 +195,7 @@ public final class SpreadsheetListSelectHistoryTokenTest extends SpreadsheetList
                     OptionalInt.of(20) // count
                 )
             ),
-            "/list/offset/10/count/20"
+            "/*/offset/10/count/20"
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/plugin/PluginSetDialogComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/plugin/PluginSetDialogComponentTest.java
@@ -85,7 +85,7 @@ public final class PluginSetDialogComponentTest implements SpreadsheetDialogComp
 
     @Test
     public void testTableFullOfPlugins() {
-        final TestAppContext appContext = new TestAppContext("/plugin/list/count/3");
+        final TestAppContext appContext = new TestAppContext("/plugin/*/count/3");
         appContext.savePlugins(4);
 
         final PluginSetDialogComponent dialog = PluginSetDialogComponent.with(
@@ -193,7 +193,7 @@ public final class PluginSetDialogComponentTest implements SpreadsheetDialogComp
                 "                SpreadsheetFlexLayout\n" +
                 "                  ROW\n" +
                 "                    mdi-arrow-left \"previous\" DISABLED id=pluginList-previous-Link\n" +
-                "                    \"next\" [#/plugin/list/offset/2/count/3] mdi-arrow-right id=pluginList-next-Link\n" +
+                "                    \"next\" [#/plugin/*/offset/2/count/3] mdi-arrow-right id=pluginList-next-Link\n" +
                 "              PLUGINS\n" +
                 "                EmptyStatePlugin (mdi-gauge-empty) \"No plugins available\"\n" +
                 "      SpreadsheetFlexLayout\n" +
@@ -205,7 +205,7 @@ public final class PluginSetDialogComponentTest implements SpreadsheetDialogComp
 
     @Test
     public void testTableFullOfPluginsOffset1() {
-        final TestAppContext appContext = new TestAppContext("/plugin/list/offset/1/count/3");
+        final TestAppContext appContext = new TestAppContext("/plugin/*/offset/1/count/3");
         appContext.savePlugins(1 + 3 + 1);
 
         final PluginSetDialogComponent dialog = PluginSetDialogComponent.with(
@@ -238,7 +238,7 @@ public final class PluginSetDialogComponentTest implements SpreadsheetDialogComp
                 "              CHILDREN\n" +
                 "                SpreadsheetFlexLayout\n" +
                 "                  ROW\n" +
-                "                    mdi-arrow-left \"previous\" [#/plugin/list/offset/0/count/3] id=pluginList-previous-Link\n" +
+                "                    mdi-arrow-left \"previous\" [#/plugin/*/offset/0/count/3] id=pluginList-previous-Link\n" +
                 "                    \"next\" DISABLED mdi-arrow-right id=pluginList-next-Link\n" +
                 "              PLUGINS\n" +
                 "                EmptyStatePlugin (mdi-gauge-empty) \"No plugins available\"\n" +

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/plugin/PluginSetTableComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/plugin/PluginSetTableComponentTest.java
@@ -255,8 +255,8 @@ public final class PluginSetTableComponentTest implements TableComponentTesting<
                 "        CHILDREN\n" +
                 "          SpreadsheetFlexLayout\n" +
                 "            ROW\n" +
-                "              mdi-arrow-left \"previous\" [#/plugin/list/offset/7/count/4] id=Table123-previous-Link\n" +
-                "              \"next\" [#/plugin/list/offset/13/count/4] mdi-arrow-right id=Table123-next-Link\n" +
+                "              mdi-arrow-left \"previous\" [#/plugin/*/offset/7/count/4] id=Table123-previous-Link\n" +
+                "              \"next\" [#/plugin/*/offset/13/count/4] mdi-arrow-right id=Table123-next-Link\n" +
                 "        PLUGINS\n" +
                 "          EmptyStatePlugin (mdi-gauge-empty) \"No plugins available\"\n"
         );

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/spreadsheet/SpreadsheetListDialogComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/spreadsheet/SpreadsheetListDialogComponentTest.java
@@ -69,15 +69,15 @@ public final class SpreadsheetListDialogComponentTest implements SpreadsheetDial
                 "      SpreadsheetFlexLayout\n" +
                 "        ROW\n" +
                 "          \"Create\" [#/create] id=spreadsheetList-create-Link\n" +
-                "          \"Reload\" [#/list/reload] mdi-reload id=spreadsheetList-reload-Link\n" +
-                "          \"10 Rows\" [#/list/count/10] id=spreadsheetList-count-10-rows-Link\n" +
-                "          \"20 Rows\" [#/list/count/20] id=spreadsheetList-count-20-rows-Link\n"
+                "          \"Reload\" [#/*/reload] mdi-reload id=spreadsheetList-reload-Link\n" +
+                "          \"10 Rows\" [#/*/count/10] id=spreadsheetList-count-10-rows-Link\n" +
+                "          \"20 Rows\" [#/*/count/20] id=spreadsheetList-count-20-rows-Link\n"
         );
     }
 
     @Test
     public void testSeveralRows() {
-        final AppContext context = appContext("/list/offset/1/count/3");
+        final AppContext context = appContext("/*/offset/1/count/3");
 
         final SpreadsheetListDialogComponent dialog = this.dialog(
             spreadsheetListComponentContext(context)
@@ -106,16 +106,16 @@ public final class SpreadsheetListDialogComponentTest implements SpreadsheetDial
                 "              CHILDREN\n" +
                 "                SpreadsheetFlexLayout\n" +
                 "                  ROW\n" +
-                "                    mdi-arrow-left \"previous\" [#/list/offset/0/count/3] id=spreadsheetList-previous-Link\n" +
+                "                    mdi-arrow-left \"previous\" [#/*/offset/0/count/3] id=spreadsheetList-previous-Link\n" +
                 "                    \"next\" DISABLED mdi-arrow-right id=spreadsheetList-next-Link\n" +
                 "              PLUGINS\n" +
                 "                EmptyStatePlugin (mdi-gauge-empty) \"No spreadsheets\"\n" +
                 "      SpreadsheetFlexLayout\n" +
                 "        ROW\n" +
                 "          \"Create\" [#/create] id=spreadsheetList-create-Link\n" +
-                "          \"Reload\" [#/list/offset/1/count/3/reload] mdi-reload id=spreadsheetList-reload-Link\n" +
-                "          \"10 Rows\" [#/list/offset/1/count/10] id=spreadsheetList-count-10-rows-Link\n" +
-                "          \"20 Rows\" [#/list/offset/1/count/20] id=spreadsheetList-count-20-rows-Link\n"
+                "          \"Reload\" [#/*/offset/1/count/3/reload] mdi-reload id=spreadsheetList-reload-Link\n" +
+                "          \"10 Rows\" [#/*/offset/1/count/10] id=spreadsheetList-count-10-rows-Link\n" +
+                "          \"20 Rows\" [#/*/offset/1/count/20] id=spreadsheetList-count-20-rows-Link\n"
         );
 
         // previous history token opens the diloag, otherwise the metadata's below will be ignored.
@@ -194,16 +194,16 @@ public final class SpreadsheetListDialogComponentTest implements SpreadsheetDial
                 "              CHILDREN\n" +
                 "                SpreadsheetFlexLayout\n" +
                 "                  ROW\n" +
-                "                    mdi-arrow-left \"previous\" [#/list/offset/0/count/3] id=spreadsheetList-previous-Link\n" +
-                "                    \"next\" [#/list/offset/3/count/3] mdi-arrow-right id=spreadsheetList-next-Link\n" +
+                "                    mdi-arrow-left \"previous\" [#/*/offset/0/count/3] id=spreadsheetList-previous-Link\n" +
+                "                    \"next\" [#/*/offset/3/count/3] mdi-arrow-right id=spreadsheetList-next-Link\n" +
                 "              PLUGINS\n" +
                 "                EmptyStatePlugin (mdi-gauge-empty) \"No spreadsheets\"\n" +
                 "      SpreadsheetFlexLayout\n" +
                 "        ROW\n" +
                 "          \"Create\" [#/create] id=spreadsheetList-create-Link\n" +
-                "          \"Reload\" [#/list/offset/1/count/3/reload] mdi-reload id=spreadsheetList-reload-Link\n" +
-                "          \"10 Rows\" [#/list/offset/1/count/10] id=spreadsheetList-count-10-rows-Link\n" +
-                "          \"20 Rows\" [#/list/offset/1/count/20] id=spreadsheetList-count-20-rows-Link\n"
+                "          \"Reload\" [#/*/offset/1/count/3/reload] mdi-reload id=spreadsheetList-reload-Link\n" +
+                "          \"10 Rows\" [#/*/offset/1/count/10] id=spreadsheetList-count-10-rows-Link\n" +
+                "          \"20 Rows\" [#/*/offset/1/count/20] id=spreadsheetList-count-20-rows-Link\n"
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/spreadsheet/SpreadsheetListTableComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/spreadsheet/SpreadsheetListTableComponentTest.java
@@ -166,7 +166,7 @@ public final class SpreadsheetListTableComponentTest implements TableComponentTe
                     )
                 )
             ),
-            "/list/offset/1/count/2",
+            "/*/offset/1/count/2",
             "SpreadsheetListTableComponent\n" +
                 "  SpreadsheetCard\n" +
                 "    Card\n" +
@@ -225,8 +225,8 @@ public final class SpreadsheetListTableComponentTest implements TableComponentTe
                 "        CHILDREN\n" +
                 "          SpreadsheetFlexLayout\n" +
                 "            ROW\n" +
-                "              mdi-arrow-left \"previous\" [#/list/offset/0/count/2] id=Table123-previous-Link\n" +
-                "              \"next\" [#/list/offset/2/count/2] mdi-arrow-right id=Table123-next-Link\n" +
+                "              mdi-arrow-left \"previous\" [#/*/offset/0/count/2] id=Table123-previous-Link\n" +
+                "              \"next\" [#/*/offset/2/count/2] mdi-arrow-right id=Table123-next-Link\n" +
                 "        PLUGINS\n" +
                 "          EmptyStatePlugin (mdi-gauge-empty) \"No spreadsheets\"\n"
         );
@@ -247,7 +247,7 @@ public final class SpreadsheetListTableComponentTest implements TableComponentTe
                     )
                 )
             ),
-            "/list/count/2",
+            "/*/count/2",
             "SpreadsheetListTableComponent\n" +
                 "  SpreadsheetCard\n" +
                 "    Card\n" +
@@ -307,7 +307,7 @@ public final class SpreadsheetListTableComponentTest implements TableComponentTe
                 "          SpreadsheetFlexLayout\n" +
                 "            ROW\n" +
                 "              mdi-arrow-left \"previous\" DISABLED id=Table123-previous-Link\n" +
-                "              \"next\" [#/list/offset/1/count/2] mdi-arrow-right id=Table123-next-Link\n" +
+                "              \"next\" [#/*/offset/1/count/2] mdi-arrow-right id=Table123-next-Link\n" +
                 "        PLUGINS\n" +
                 "          EmptyStatePlugin (mdi-gauge-empty) \"No spreadsheets\"\n"
         );


### PR DESCRIPTION
… replaces "*""

This reverts commit 3f18bc3668a6b407e92be10be5638e112cc8edf8.

- Example of a bad ambiguous history token PluginNameHistoryToken "/plugin/list" and PluginListHistoryToken "/plugin/list"
- "*" is not a valid PluginName, solving the above problem.