### PR TITLE
HistoryTokenTestCase.setSelectionAndCheck infinite recursion FIX

### DIFF
--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTestCase.java
@@ -933,6 +933,7 @@ public abstract class HistoryTokenTestCase<T extends HistoryToken> implements Cl
                                     final HistoryToken expected) {
         this.setSelectionAndCheck(
             token,
+            Optional.empty(),
             expected
         );
     }


### PR DESCRIPTION
- Currently unused but could be useful in the future.