### PR TITLE
SpreadsheetCellReferencesHistoryToken.close FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryToken.java
@@ -1758,6 +1758,10 @@ public abstract class HistoryToken implements HasUrlFragment,
             closed = cellLabelSelectHistoryToken.selectionSelect();
         }
 
+        if (this instanceof SpreadsheetCellReferencesHistoryToken) {
+            closed = this.clearAction();
+        }
+
         if (this instanceof SpreadsheetCellSortHistoryToken || this instanceof SpreadsheetColumnSortHistoryToken || this instanceof SpreadsheetRowSortHistoryToken) {
             closed = this.clearAction();
         }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellReferencesHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellReferencesHistoryTokenTest.java
@@ -326,6 +326,20 @@ public final class SpreadsheetCellReferencesHistoryTokenTest extends Spreadsheet
         );
     }
 
+    // close............................................................................................................
+
+    @Test
+    public void testClose() {
+        this.closeAndCheck(
+            this.createHistoryToken(),
+            HistoryToken.cellSelect(
+                ID,
+                NAME,
+                CELL.setDefaultAnchor()
+            )
+        );
+    }
+
     // freezeOrEmpty....................................................................................................
 
     @Test


### PR DESCRIPTION
- Previously #close didnt nothing, this is now fixed.