### PR TITLE
SpreadsheetFormulaSelectAnchorComponent.setShowFormulaText

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/formula/SpreadsheetFormulaSelectAnchorComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/formula/SpreadsheetFormulaSelectAnchorComponent.java
@@ -24,6 +24,7 @@ import walkingkooka.spreadsheet.dominokit.history.HistoryTokenAnchorComponent;
 import walkingkooka.spreadsheet.dominokit.history.SpreadsheetCellFormulaSelectHistoryToken;
 import walkingkooka.spreadsheet.dominokit.history.SpreadsheetCellSelectHistoryToken;
 import walkingkooka.spreadsheet.dominokit.value.ValueHistoryTokenAnchorComponent;
+import walkingkooka.spreadsheet.formula.SpreadsheetFormula;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
 
 import java.util.Objects;
@@ -53,6 +54,7 @@ public final class SpreadsheetFormulaSelectAnchorComponent implements AnchorComp
         );
         this.setId(id);
         this.context = Objects.requireNonNull(context, "context");
+        this.showFormulaText = false;
     }
 
     /**
@@ -76,11 +78,25 @@ public final class SpreadsheetFormulaSelectAnchorComponent implements AnchorComp
             historyToken = this.context.historyToken()
                 .setSelection(value)
                 .formula();
-            if (false == (historyToken instanceof SpreadsheetCellFormulaSelectHistoryToken)) {
+            if (historyToken instanceof SpreadsheetCellFormulaSelectHistoryToken) {
+                final SpreadsheetCellFormulaSelectHistoryToken spreadsheetCellFormulaSelectHistoryToken = historyToken.cast(SpreadsheetCellFormulaSelectHistoryToken.class);
+
+                if (this.showFormulaText) {
+                    text = this.context.formulaText(
+                        spreadsheetCellFormulaSelectHistoryToken.selection()
+                            .get()
+                            .toExpressionReference()
+                    ).orElse(null);
+                }
+
+            } else {
                 historyToken = null;
             }
-            text = value.get()
-                .text();
+
+            if (null == text) {
+                text = value.get()
+                    .text();
+            }
         } else {
             text = "Formula";
         }
@@ -100,6 +116,18 @@ public final class SpreadsheetFormulaSelectAnchorComponent implements AnchorComp
         this.component.setValue(value);
         return this;
     }
+
+    /**
+     * When true the anchor text will show the {@link SpreadsheetFormula#text()} or the {@link SpreadsheetExpressionReference}
+     * when false.
+     */
+    public SpreadsheetFormulaSelectAnchorComponent setShowFormulaText(final boolean showFormulaText) {
+        this.showFormulaText = showFormulaText;
+
+        return this;
+    }
+
+    private boolean showFormulaText;
 
     // AnchorComponentDelegator.........................................................................................
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/formula/SpreadsheetFormulaSelectAnchorComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/formula/SpreadsheetFormulaSelectAnchorComponentTest.java
@@ -107,6 +107,34 @@ public final class SpreadsheetFormulaSelectAnchorComponentTest implements Anchor
         );
     }
 
+    @Test
+    public void testSetShowFormulaTextSetValueWithCell() {
+        this.treePrintAndCheck(
+            this.createComponent()
+                .setShowFormulaText(true)
+                .setValue(
+                    Optional.of(
+                        SpreadsheetSelection.A1
+                    )
+                ),
+            "\"=1+2+3000\" [#/1/SpreadsheetName22/cell/A1/formula] id=formula-anchor-id"
+        );
+    }
+
+    @Test
+    public void testSetShowFormulaTextSetValueWithCellMissingFormula() {
+        this.treePrintAndCheck(
+            this.createComponent()
+                .setShowFormulaText(true)
+                .setValue(
+                    Optional.of(
+                        SpreadsheetSelection.parseCell("B2")
+                    )
+                ),
+            "\"B2\" [#/1/SpreadsheetName22/cell/B2/formula] id=formula-anchor-id"
+        );
+    }
+
     @Override
     public SpreadsheetFormulaSelectAnchorComponent createComponent() {
         return this.createComponent("/1/SpreadsheetName22");
@@ -124,6 +152,15 @@ public final class SpreadsheetFormulaSelectAnchorComponentTest implements Anchor
                 @Override
                 public String toString() {
                     return currentHistoryToken;
+                }
+
+                @Override
+                public Optional<String> formulaText(final SpreadsheetExpressionReference spreadsheetExpressionReference) {
+                    return Optional.ofNullable(
+                        SpreadsheetSelection.A1.equals(spreadsheetExpressionReference) ?
+                        "=1+2+3000" :
+                        null
+                    );
                 }
             }
         );


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/4692
- SpreadsheetFormulaSelectAnchorComponent should support displaying reference=formula