### PR TITLE
SpreadsheetFindDialogComponent.find refresh now includes cellRange FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/find/SpreadsheetFindDialogComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/find/SpreadsheetFindDialogComponent.java
@@ -263,7 +263,9 @@ public final class SpreadsheetFindDialogComponent implements SpreadsheetDialogCo
         this.refreshFind(
             this.context.historyToken()
                 .cast(SpreadsheetCellFindHistoryToken.class)
-                .setQuery(cellFindQuery)
+                .setSelection(
+                    this.cellRange.value()
+                ).setQuery(cellFindQuery)
                 .cast(SpreadsheetCellFindHistoryToken.class)
         );
         this.findCells(cellFindQuery);


### PR DESCRIPTION
- Previously the "find" link was built using the history token and never setting the current #cellRange.