### PR TITLE
SpreadsheetToolbarComponentItemAnchorSort label selection throws UOE FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/toolbar/SpreadsheetToolbarComponentItemAnchorSort.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/toolbar/SpreadsheetToolbarComponentItemAnchorSort.java
@@ -74,7 +74,8 @@ final class SpreadsheetToolbarComponentItemAnchorSort extends SpreadsheetToolbar
             final SpreadsheetAnchoredSelectionHistoryToken anchored = token.cast(SpreadsheetAnchoredSelectionHistoryToken.class);
             final SpreadsheetSelection selection = anchored.anchoredSelection()
                 .selection();
-            if (selection.count() > 1) {
+            // FIXME https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/4777
+            if (false == selection.isLabelName() && selection.count() > 1) {
                 match = true;
             }
         }


### PR DESCRIPTION
- Stops throwing of UOE, but correctly counting the number of cells in the selection still needs to be fixed.
- See https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/4777