### PR TITLE
HistoryToken.labels non SpreadsheetCellHistoryToken FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryToken.java
@@ -2529,19 +2529,36 @@ public abstract class HistoryToken implements HasUrlFragment,
     public final HistoryToken labels(final HistoryTokenOffsetAndCount offsetAndCount) {
         Objects.requireNonNull(offsetAndCount, "offsetAndCount");
 
-        HistoryToken token = this;
+        HistoryToken historyToken = this;
 
-        if (this instanceof SpreadsheetCellHistoryToken) {
-            final SpreadsheetCellHistoryToken cell = this.cast(SpreadsheetCellHistoryToken.class);
-            token = cellLabels(
-                cell.id(),
-                cell.name(),
-                cell.anchoredSelection(),
-                offsetAndCount
-            );
+        if (this instanceof SpreadsheetNameHistoryToken) {
+            final SpreadsheetNameHistoryToken spreadsheetNameHistoryToken = this.cast(SpreadsheetNameHistoryToken.class);
+            final SpreadsheetId id = spreadsheetNameHistoryToken.id();
+            final SpreadsheetName name = spreadsheetNameHistoryToken.name();
+
+            if (this instanceof SpreadsheetCellHistoryToken) {
+                historyToken = cellLabels(
+                    id,
+                    name,
+                    this.cast(SpreadsheetCellHistoryToken.class)
+                        .anchoredSelection(),
+                    offsetAndCount
+                );
+
+                if(historyToken.equals(this)) {
+                    historyToken = this;
+                }
+
+            } else {
+                historyToken = labelMappingList(
+                    id,
+                    name,
+                    offsetAndCount
+                );
+            }
         }
 
-        return token;
+        return historyToken;
     }
 
     // LIST.............................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTestCase.java
@@ -490,6 +490,26 @@ public abstract class HistoryTokenTestCase<T extends HistoryToken> implements Cl
         );
     }
 
+    // labels...........................................................................................................
+
+    final void labelsAndCheck(final HistoryToken token,
+                              final HistoryTokenOffsetAndCount offsetAndCount) {
+        assertSame(
+            token,
+            token.labels(offsetAndCount)
+        );
+    }
+
+    final void labelsAndCheck(final HistoryToken token,
+                              final HistoryTokenOffsetAndCount offsetAndCount,
+                              final HistoryToken expected) {
+        this.checkEquals(
+            expected,
+            token.labels(offsetAndCount),
+            () -> token + " labels " + offsetAndCount
+        );
+    }
+
     // setList..........................................................................................................
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/PluginHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/PluginHistoryTokenTestCase.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.net.UrlFragment;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
+import java.util.OptionalInt;
+
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 public abstract class PluginHistoryTokenTestCase<T extends PluginHistoryToken> extends HistoryTokenTestCase<T> {
@@ -44,6 +46,18 @@ public abstract class PluginHistoryTokenTestCase<T extends PluginHistoryToken> e
     public final void testCreateLabel() {
         this.createLabelAndCheck(
             this.createHistoryToken()
+        );
+    }
+
+    // labels...........................................................................................................
+
+    @Test
+    public final void testLabels() {
+        this.labelsAndCheck(
+            this.createHistoryToken(),
+            HistoryTokenOffsetAndCount.EMPTY.setCount(
+                OptionalInt.of(123)
+            )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellHistoryTokenTestCase.java
@@ -28,6 +28,8 @@ import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportAnchor;
 
+import java.util.OptionalInt;
+
 public abstract class SpreadsheetCellHistoryTokenTestCase<T extends SpreadsheetCellHistoryToken> extends SpreadsheetAnchoredSelectionHistoryTokenTestCase<T> {
 
     final static SpreadsheetCellReference CELL = SpreadsheetSelection.A1;
@@ -163,6 +165,26 @@ public abstract class SpreadsheetCellHistoryTokenTestCase<T extends SpreadsheetC
                 SpreadsheetSelection.parseCell("Z9")
             );
         }
+    }
+
+    // labels...........................................................................................................
+
+    @Test
+    public final void testLabels() {
+        final HistoryTokenOffsetAndCount offsetAndCount = HistoryTokenOffsetAndCount.EMPTY.setCount(
+            OptionalInt.of(123)
+        );
+
+        this.labelsAndCheck(
+            this.createHistoryToken(),
+            offsetAndCount,
+            HistoryToken.cellLabels(
+                ID,
+                NAME,
+                CELL.setDefaultAnchor(),
+                offsetAndCount
+            )
+        );
     }
 
     // menu with selection..............................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnHistoryTokenTestCase.java
@@ -26,6 +26,8 @@ import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportAnchor;
 
+import java.util.OptionalInt;
+
 public abstract class SpreadsheetColumnHistoryTokenTestCase<T extends SpreadsheetColumnHistoryToken> extends SpreadsheetAnchoredSelectionHistoryTokenTestCase<T> {
 
     final static SpreadsheetColumnReference COLUMN = SpreadsheetSelection.parseColumn("A");
@@ -163,6 +165,25 @@ public abstract class SpreadsheetColumnHistoryTokenTestCase<T extends Spreadshee
                 ID,
                 NAME,
                 LABEL
+            )
+        );
+    }
+
+    // labels...........................................................................................................
+
+    @Test
+    public final void testLabels() {
+        final HistoryTokenOffsetAndCount offsetAndCount = HistoryTokenOffsetAndCount.EMPTY.setCount(
+            OptionalInt.of(123)
+        );
+
+        this.labelsAndCheck(
+            this.createHistoryToken(),
+            offsetAndCount,
+            HistoryToken.labelMappingList(
+                ID,
+                NAME,
+                offsetAndCount
             )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCreateHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCreateHistoryTokenTest.java
@@ -23,6 +23,8 @@ import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
+import java.util.OptionalInt;
+
 public final class SpreadsheetCreateHistoryTokenTest extends SpreadsheetHistoryTokenTestCase<SpreadsheetCreateHistoryToken> {
 
     @Test
@@ -72,6 +74,18 @@ public final class SpreadsheetCreateHistoryTokenTest extends SpreadsheetHistoryT
     public void testCreateLabel() {
         this.createLabelAndCheck(
             this.createHistoryToken()
+        );
+    }
+
+    // labels...........................................................................................................
+
+    @Test
+    public final void testLabels() {
+        this.labelsAndCheck(
+            this.createHistoryToken(),
+            HistoryTokenOffsetAndCount.EMPTY.setCount(
+                OptionalInt.of(123)
+            )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLabelMappingHistoryTokenTestCase.java
@@ -20,6 +20,8 @@ package walkingkooka.spreadsheet.dominokit.history;
 import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
+import java.util.OptionalInt;
+
 public abstract class SpreadsheetLabelMappingHistoryTokenTestCase<T extends SpreadsheetLabelMappingHistoryToken> extends SpreadsheetSelectionHistoryTokenTestCase<T> {
 
     SpreadsheetLabelMappingHistoryTokenTestCase() {
@@ -48,6 +50,25 @@ public abstract class SpreadsheetLabelMappingHistoryTokenTestCase<T extends Spre
             HistoryToken.labelMappingCreate(
                 ID,
                 NAME
+            )
+        );
+    }
+
+    // labels...........................................................................................................
+
+    @Test
+    public final void testLabels() {
+        final HistoryTokenOffsetAndCount offsetAndCount = HistoryTokenOffsetAndCount.EMPTY.setCount(
+            OptionalInt.of(123)
+        );
+
+        this.labelsAndCheck(
+            this.createHistoryToken(),
+            offsetAndCount,
+            HistoryToken.labelMappingList(
+                ID,
+                NAME,
+                offsetAndCount
             )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetListDeleteHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetListDeleteHistoryTokenTest.java
@@ -22,6 +22,8 @@ import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
+import java.util.OptionalInt;
+
 public final class SpreadsheetListDeleteHistoryTokenTest extends SpreadsheetIdHistoryTokenTestCase<SpreadsheetListDeleteHistoryToken> {
 
     @Test
@@ -58,6 +60,20 @@ public final class SpreadsheetListDeleteHistoryTokenTest extends SpreadsheetIdHi
             token
         );
     }
+
+    // labels...........................................................................................................
+
+    @Test
+    public final void testLabels() {
+        this.labelsAndCheck(
+            this.createHistoryToken(),
+            HistoryTokenOffsetAndCount.EMPTY.setCount(
+                OptionalInt.of(123)
+            )
+        );
+    }
+
+    // setMetadataPropertyName..........................................................................................
 
     @Test
     public void testSetMetadataPropertyName() {

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetListHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetListHistoryTokenTestCase.java
@@ -80,6 +80,18 @@ public abstract class SpreadsheetListHistoryTokenTestCase<T extends SpreadsheetL
         );
     }
 
+    // labels...........................................................................................................
+
+    @Test
+    public final void testLabels() {
+        this.labelsAndCheck(
+            this.createHistoryToken(),
+            HistoryTokenOffsetAndCount.EMPTY.setCount(
+                OptionalInt.of(123)
+            )
+        );
+    }
+
     // list.............................................................................................................
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetListRenameHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetListRenameHistoryTokenTestCase.java
@@ -20,6 +20,8 @@ package walkingkooka.spreadsheet.dominokit.history;
 import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
+import java.util.OptionalInt;
+
 public abstract class SpreadsheetListRenameHistoryTokenTestCase<T extends SpreadsheetListRenameHistoryToken> extends SpreadsheetIdHistoryTokenTestCase<T> {
 
     SpreadsheetListRenameHistoryTokenTestCase() {
@@ -46,6 +48,20 @@ public abstract class SpreadsheetListRenameHistoryTokenTestCase<T extends Spread
             )
         );
     }
+
+    // labels...........................................................................................................
+
+    @Test
+    public final void testLabels() {
+        this.labelsAndCheck(
+            this.createHistoryToken(),
+            HistoryTokenOffsetAndCount.EMPTY.setCount(
+                OptionalInt.of(123)
+            )
+        );
+    }
+
+    // setSelection.....................................................................................................
 
     @Test
     public final void testSetSelectionWithCell() {

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLoadHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetLoadHistoryTokenTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 
+import java.util.OptionalInt;
+
 public final class SpreadsheetLoadHistoryTokenTest extends SpreadsheetIdHistoryTokenTestCase<SpreadsheetLoadHistoryToken> {
 
     @Test
@@ -54,6 +56,18 @@ public final class SpreadsheetLoadHistoryTokenTest extends SpreadsheetIdHistoryT
             differentId,
             NAME,
             HistoryToken.spreadsheetSelect(differentId, NAME)
+        );
+    }
+
+    // labels...........................................................................................................
+
+    @Test
+    public final void testLabels() {
+        this.labelsAndCheck(
+            this.createHistoryToken(),
+            HistoryTokenOffsetAndCount.EMPTY.setCount(
+                OptionalInt.of(123)
+            )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataHistoryTokenTestCase.java
@@ -20,6 +20,8 @@ package walkingkooka.spreadsheet.dominokit.history;
 import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
+import java.util.OptionalInt;
+
 public abstract class SpreadsheetMetadataHistoryTokenTestCase<T extends SpreadsheetMetadataHistoryToken> extends SpreadsheetNameHistoryTokenTestCase<T> {
 
     SpreadsheetMetadataHistoryTokenTestCase() {
@@ -35,6 +37,25 @@ public abstract class SpreadsheetMetadataHistoryTokenTestCase<T extends Spreadsh
             HistoryToken.labelMappingCreate(
                 ID,
                 NAME
+            )
+        );
+    }
+
+    // labels...........................................................................................................
+
+    @Test
+    public final void testLabels() {
+        final HistoryTokenOffsetAndCount offsetAndCount = HistoryTokenOffsetAndCount.EMPTY.setCount(
+            OptionalInt.of(123)
+        );
+
+        this.labelsAndCheck(
+            this.createHistoryToken(),
+            offsetAndCount,
+            HistoryToken.labelMappingList(
+                ID,
+                NAME,
+                offsetAndCount
             )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetReloadHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetReloadHistoryTokenTest.java
@@ -23,6 +23,8 @@ import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
+import java.util.OptionalInt;
+
 public final class SpreadsheetReloadHistoryTokenTest extends SpreadsheetNameHistoryTokenTestCase<SpreadsheetReloadHistoryToken> {
 
     @Test
@@ -53,6 +55,27 @@ public final class SpreadsheetReloadHistoryTokenTest extends SpreadsheetNameHist
             )
         );
     }
+
+    // labels...........................................................................................................
+
+    @Test
+    public void testLabels() {
+        final HistoryTokenOffsetAndCount offsetAndCount = HistoryTokenOffsetAndCount.EMPTY.setCount(
+            OptionalInt.of(123)
+        );
+
+        this.labelsAndCheck(
+            this.createHistoryToken(),
+            offsetAndCount,
+            HistoryToken.labelMappingList(
+                ID,
+                NAME,
+                offsetAndCount
+            )
+        );
+    }
+
+    // setMetadataPropertyName..........................................................................................
 
     @Test
     public void testSetMetadataPropertyName() {

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRenameHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRenameHistoryTokenTestCase.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
+import java.util.OptionalInt;
+
 public abstract class SpreadsheetRenameHistoryTokenTestCase<T extends SpreadsheetRenameHistoryToken> extends SpreadsheetNameHistoryTokenTestCase<T> {
 
     SpreadsheetRenameHistoryTokenTestCase() {
@@ -49,6 +51,27 @@ public abstract class SpreadsheetRenameHistoryTokenTestCase<T extends Spreadshee
             )
         );
     }
+
+    // labels...........................................................................................................
+
+    @Test
+    public final void testLabels() {
+        final HistoryTokenOffsetAndCount offsetAndCount = HistoryTokenOffsetAndCount.EMPTY.setCount(
+            OptionalInt.of(123)
+        );
+
+        this.labelsAndCheck(
+            this.createHistoryToken(),
+            offsetAndCount,
+            HistoryToken.labelMappingList(
+                ID,
+                NAME,
+                offsetAndCount
+            )
+        );
+    }
+
+    // setMetadataPropertyName..........................................................................................
 
     @Test
     public final void testSetMetadataPropertyName() {

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowHistoryTokenTestCase.java
@@ -26,6 +26,8 @@ import walkingkooka.spreadsheet.reference.SpreadsheetRowReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewportAnchor;
 
+import java.util.OptionalInt;
+
 public abstract class SpreadsheetRowHistoryTokenTestCase<T extends SpreadsheetRowHistoryToken> extends SpreadsheetAnchoredSelectionHistoryTokenTestCase<T> {
 
     final static SpreadsheetRowReference ROW = SpreadsheetSelection.parseRow("1");
@@ -163,6 +165,25 @@ public abstract class SpreadsheetRowHistoryTokenTestCase<T extends SpreadsheetRo
                 ID,
                 NAME,
                 LABEL
+            )
+        );
+    }
+
+    // labels...........................................................................................................
+
+    @Test
+    public final void testLabels() {
+        final HistoryTokenOffsetAndCount offsetAndCount = HistoryTokenOffsetAndCount.EMPTY.setCount(
+            OptionalInt.of(123)
+        );
+
+        this.labelsAndCheck(
+            this.createHistoryToken(),
+            offsetAndCount,
+            HistoryToken.labelMappingList(
+                ID,
+                NAME,
+                offsetAndCount
             )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetSelectHistoryTokenTest.java
@@ -23,6 +23,8 @@ import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
+import java.util.OptionalInt;
+
 public final class SpreadsheetSelectHistoryTokenTest extends SpreadsheetNameHistoryTokenTestCase<SpreadsheetSelectHistoryToken> {
 
     @Test
@@ -46,6 +48,25 @@ public final class SpreadsheetSelectHistoryTokenTest extends SpreadsheetNameHist
             HistoryToken.labelMappingCreate(
                 ID,
                 NAME
+            )
+        );
+    }
+
+    // labels...........................................................................................................
+
+    @Test
+    public void testLabels() {
+        final HistoryTokenOffsetAndCount offsetAndCount = HistoryTokenOffsetAndCount.EMPTY.setCount(
+            OptionalInt.of(123)
+        );
+
+        this.labelsAndCheck(
+            this.createHistoryToken(),
+            offsetAndCount,
+            HistoryToken.labelMappingList(
+                ID,
+                NAME,
+                offsetAndCount
             )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/label/SpreadsheetLabelListAnchorComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/label/SpreadsheetLabelListAnchorComponentTest.java
@@ -77,7 +77,7 @@ public final class SpreadsheetLabelListAnchorComponentTest implements AnchorComp
 
         this.treePrintAndCheck(
             component,
-            "\"Labels\" [#/3/SpreadsheetName333] id=label-list-anchor-id"
+            "\"Labels\" [#/3/SpreadsheetName333/label] id=label-list-anchor-id"
         );
     }
 


### PR DESCRIPTION
- Previous many non SpreadsheetNameHistoryToken sub-classes such as column/row would return this rather than SpreadsheetLabelMappingListHistoryToken.