### PR TITLE
SpreadsheetDeltaLabelsTableComponent cell column formula link should …

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/delta/BasicSpreadsheetDeltaLabelsTableComponentContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/delta/BasicSpreadsheetDeltaLabelsTableComponentContext.java
@@ -25,6 +25,8 @@ import walkingkooka.spreadsheet.dominokit.history.HistoryContext;
 import walkingkooka.spreadsheet.dominokit.history.HistoryContextDelegator;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolver;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -39,12 +41,14 @@ final class BasicSpreadsheetDeltaLabelsTableComponentContext implements Spreadsh
                                                                  final Function<SpreadsheetExpressionReference, Set<SpreadsheetExpressionReference>> cellToReferences,
                                                                  final Function<SpreadsheetLabelName, Optional<SpreadsheetCell>> labelToCell,
                                                                  final HasSpreadsheetDeltaFetcherWatchers hasSpreadsheetDeltaFetcherWatchers,
+                                                                 final SpreadsheetLabelNameResolver spreadsheetLabelNameResolver,
                                                                  final HistoryContext historyContext) {
         return new BasicSpreadsheetDeltaLabelsTableComponentContext(
             Objects.requireNonNull(cellToFormulaText, "cellToFormulaText"),
             Objects.requireNonNull(cellToReferences, "cellToReferences"),
             Objects.requireNonNull(labelToCell, "labelToCell"),
             Objects.requireNonNull(hasSpreadsheetDeltaFetcherWatchers, "hasSpreadsheetDeltaFetcherWatchers"),
+            Objects.requireNonNull(spreadsheetLabelNameResolver, "spreadsheetLabelNameResolver"),
             Objects.requireNonNull(historyContext, "historyContext")
         );
     }
@@ -53,12 +57,14 @@ final class BasicSpreadsheetDeltaLabelsTableComponentContext implements Spreadsh
                                                              final Function<SpreadsheetExpressionReference, Set<SpreadsheetExpressionReference>> cellToReferences,
                                                              final Function<SpreadsheetLabelName, Optional<SpreadsheetCell>> labelToCell,
                                                              final HasSpreadsheetDeltaFetcherWatchers hasSpreadsheetDeltaFetcherWatchers,
+                                                             final SpreadsheetLabelNameResolver spreadsheetLabelNameResolver,
                                                              final HistoryContext historyContext) {
         this.cellToFormulaText = cellToFormulaText;
         this.cellToReferences = cellToReferences;
         this.labelToCell = labelToCell;
 
         this.hasSpreadsheetDeltaFetcherWatchers = hasSpreadsheetDeltaFetcherWatchers;
+        this.spreadsheetLabelNameResolver = spreadsheetLabelNameResolver;
         this.historyContext = historyContext;
     }
 
@@ -89,6 +95,14 @@ final class BasicSpreadsheetDeltaLabelsTableComponentContext implements Spreadsh
     }
 
     private final HasSpreadsheetDeltaFetcherWatchers hasSpreadsheetDeltaFetcherWatchers;
+
+
+    @Override
+    public Optional<SpreadsheetSelection> resolveLabel(final SpreadsheetLabelName spreadsheetLabelName) {
+        return this.spreadsheetLabelNameResolver.resolveLabel(spreadsheetLabelName);
+    }
+
+    private final SpreadsheetLabelNameResolver spreadsheetLabelNameResolver;
 
     // HistoryContextDelegator..........................................................................................
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/delta/FakeSpreadsheetDeltaLabelsTableComponentContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/delta/FakeSpreadsheetDeltaLabelsTableComponentContext.java
@@ -22,6 +22,7 @@ import walkingkooka.spreadsheet.dominokit.fetcher.SpreadsheetDeltaFetcherWatcher
 import walkingkooka.spreadsheet.dominokit.formula.FakeSpreadsheetFormulaSelectAnchorComponentContext;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
 import java.util.Optional;
 import java.util.Set;
@@ -50,6 +51,11 @@ public class FakeSpreadsheetDeltaLabelsTableComponentContext extends FakeSpreads
 
     @Override
     public Runnable addSpreadsheetDeltaFetcherWatcherOnce(final SpreadsheetDeltaFetcherWatcher watcher) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<SpreadsheetSelection> resolveLabel(final SpreadsheetLabelName spreadsheetLabelName) {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/delta/SpreadsheetDeltaLabelsTableComponentContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/delta/SpreadsheetDeltaLabelsTableComponentContext.java
@@ -23,13 +23,15 @@ import walkingkooka.spreadsheet.dominokit.formula.SpreadsheetFormulaSelectAnchor
 import walkingkooka.spreadsheet.dominokit.history.HistoryContext;
 import walkingkooka.spreadsheet.dominokit.label.SpreadsheetLabelLinksComponentContext;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolver;
 
 import java.util.Optional;
 
 public interface SpreadsheetDeltaLabelsTableComponentContext extends HistoryContext,
     HasSpreadsheetDeltaFetcherWatchers,
     SpreadsheetFormulaSelectAnchorComponentContext,
-    SpreadsheetLabelLinksComponentContext {
+    SpreadsheetLabelLinksComponentContext,
+    SpreadsheetLabelNameResolver {
 
     /**
      * Returns a {@link SpreadsheetCell} for the given {@link SpreadsheetLabelName}.

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/delta/SpreadsheetDeltaLabelsTableComponentContexts.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/delta/SpreadsheetDeltaLabelsTableComponentContexts.java
@@ -23,6 +23,7 @@ import walkingkooka.spreadsheet.dominokit.fetcher.HasSpreadsheetDeltaFetcherWatc
 import walkingkooka.spreadsheet.dominokit.history.HistoryContext;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolver;
 
 import java.util.Optional;
 import java.util.Set;
@@ -37,12 +38,14 @@ public final class SpreadsheetDeltaLabelsTableComponentContexts implements Publi
                                                                     final Function<SpreadsheetExpressionReference, Set<SpreadsheetExpressionReference>> cellToReferences,
                                                                     final Function<SpreadsheetLabelName, Optional<SpreadsheetCell>> labelToCell,
                                                                     final HasSpreadsheetDeltaFetcherWatchers hasSpreadsheetDeltaFetcherWatchers,
+                                                                    final SpreadsheetLabelNameResolver spreadsheetLabelNameResolver,
                                                                     final HistoryContext historyContext) {
         return BasicSpreadsheetDeltaLabelsTableComponentContext.with(
             cellToFormulaText,
             cellToReferences,
             labelToCell,
             hasSpreadsheetDeltaFetcherWatchers,
+            spreadsheetLabelNameResolver,
             historyContext
         );
     }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/delta/SpreadsheetDeltaLabelsTableComponentSpreadsheetDataTableComponentCellRenderer.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/delta/SpreadsheetDeltaLabelsTableComponentSpreadsheetDataTableComponentCellRenderer.java
@@ -26,6 +26,7 @@ import walkingkooka.spreadsheet.dominokit.label.SpreadsheetLabelLinksComponent;
 import walkingkooka.spreadsheet.dominokit.label.SpreadsheetLabelSelectAnchorComponent;
 import walkingkooka.spreadsheet.dominokit.value.SpreadsheetTextNodeComponent;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
 import java.util.Optional;
 
@@ -84,15 +85,25 @@ final class SpreadsheetDeltaLabelsTableComponentSpreadsheetDataTableComponentCel
     private Component renderCellFormula(final SpreadsheetDeltaLabelsTableComponentRow row) {
         final SpreadsheetLabelName labelName = row.mapping.label();
 
-        return SpreadsheetFormulaSelectAnchorComponent.with(
+        final SpreadsheetFormulaSelectAnchorComponent component = SpreadsheetFormulaSelectAnchorComponent.with(
                 this.idPrefix + labelName + "-formula" + SpreadsheetElementIds.LINK,
                 this.context
             ).showFormulaText()
             .setValue(
-                Optional.of(
-                    row.mapping.label()
-                )
+                Optional.of(labelName)
             );
+
+        // https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/4799
+        // Prefer to show target reference (cell etc) than the label, if formula is shown leave as is.
+        if(component.textContent().equalsIgnoreCase(labelName.text())) {
+            final SpreadsheetSelection notLabel = this.context.resolveLabel(labelName)
+                .orElse(null);
+            if(null != notLabel) {
+                component.setTextContent(notLabel.text());
+            }
+        }
+
+        return component;
     }
 
     private SpreadsheetTextNodeComponent renderCellFormattedValue(final SpreadsheetDeltaLabelsTableComponentRow row) {

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/label/AppContextSpreadsheetLabelMappingListDialogComponentContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/label/AppContextSpreadsheetLabelMappingListDialogComponentContext.java
@@ -30,6 +30,7 @@ import walkingkooka.spreadsheet.dominokit.log.LoggingContextDelegator;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -84,6 +85,12 @@ final class AppContextSpreadsheetLabelMappingListDialogComponentContext implemen
                 offsetAndCount.count()
                     .orElse(0)
             );
+    }
+
+    @Override
+    public Optional<SpreadsheetSelection> resolveLabel(final SpreadsheetLabelName spreadsheetLabelName) {
+        return this.context.spreadsheetViewportCache()
+            .resolveLabel(spreadsheetLabelName);
     }
 
     // HasSpreadsheetDeltaFetcherWatchersDelegator......................................................................

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/label/FakeSpreadsheetLabelMappingListDialogComponentContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/label/FakeSpreadsheetLabelMappingListDialogComponentContext.java
@@ -21,6 +21,10 @@ import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.dominokit.delta.FakeSpreadsheetDeltaLabelsTableComponentContext;
 import walkingkooka.spreadsheet.dominokit.history.HistoryTokenOffsetAndCount;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+
+import java.util.Optional;
 
 public class FakeSpreadsheetLabelMappingListDialogComponentContext extends FakeSpreadsheetDeltaLabelsTableComponentContext
     implements SpreadsheetLabelMappingListDialogComponentContext {
@@ -32,6 +36,11 @@ public class FakeSpreadsheetLabelMappingListDialogComponentContext extends FakeS
     @Override
     public void loadLabelMappings(final SpreadsheetId id,
                                   final HistoryTokenOffsetAndCount offsetAndCount) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<SpreadsheetSelection> resolveLabel(final SpreadsheetLabelName spreadsheetLabelName) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/delta/BasicSpreadsheetDeltaLabelsTableComponentContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/delta/BasicSpreadsheetDeltaLabelsTableComponentContextTest.java
@@ -26,6 +26,8 @@ import walkingkooka.spreadsheet.dominokit.history.HistoryContext;
 import walkingkooka.spreadsheet.dominokit.history.HistoryContexts;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolver;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolvers;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
 import java.util.Objects;
@@ -69,6 +71,8 @@ public final class BasicSpreadsheetDeltaLabelsTableComponentContextTest implemen
         }
     };
 
+    private final static SpreadsheetLabelNameResolver SPREADSHEET_LABEL_NAME_RESOLVER = SpreadsheetLabelNameResolvers.fake();
+
     private final static HistoryContext HISTORY_CONTEXT = HistoryContexts.fake();
 
     // with.............................................................................................................
@@ -82,6 +86,7 @@ public final class BasicSpreadsheetDeltaLabelsTableComponentContextTest implemen
                 null,
                 LABEL_TO_CELL,
                 HAS_SPREADSHEET_DELTA_FETCHER_WATCHERS,
+                SPREADSHEET_LABEL_NAME_RESOLVER,
                 HISTORY_CONTEXT
             )
         );
@@ -96,6 +101,7 @@ public final class BasicSpreadsheetDeltaLabelsTableComponentContextTest implemen
                 CELL_TO_REFERENCES,
                 null,
                 HAS_SPREADSHEET_DELTA_FETCHER_WATCHERS,
+                SPREADSHEET_LABEL_NAME_RESOLVER,
                 HISTORY_CONTEXT
             )
         );
@@ -109,6 +115,22 @@ public final class BasicSpreadsheetDeltaLabelsTableComponentContextTest implemen
                 CELL_TO_FORMULA_TEXT,
                 CELL_TO_REFERENCES,
                 LABEL_TO_CELL,
+                null,
+                SPREADSHEET_LABEL_NAME_RESOLVER,
+                HISTORY_CONTEXT
+            )
+        );
+    }
+
+    @Test
+    public void testWithNullSpreadsheetLabelNameResolverFails() {
+        assertThrows(
+            NullPointerException.class,
+            () -> BasicSpreadsheetDeltaLabelsTableComponentContext.with(
+                CELL_TO_FORMULA_TEXT,
+                CELL_TO_REFERENCES,
+                LABEL_TO_CELL,
+                HAS_SPREADSHEET_DELTA_FETCHER_WATCHERS,
                 null,
                 HISTORY_CONTEXT
             )
@@ -124,6 +146,7 @@ public final class BasicSpreadsheetDeltaLabelsTableComponentContextTest implemen
                 CELL_TO_REFERENCES,
                 LABEL_TO_CELL,
                 HAS_SPREADSHEET_DELTA_FETCHER_WATCHERS,
+                SPREADSHEET_LABEL_NAME_RESOLVER,
                 null
             )
         );
@@ -136,6 +159,7 @@ public final class BasicSpreadsheetDeltaLabelsTableComponentContextTest implemen
             CELL_TO_REFERENCES,
             LABEL_TO_CELL,
             HAS_SPREADSHEET_DELTA_FETCHER_WATCHERS,
+            SPREADSHEET_LABEL_NAME_RESOLVER,
             HISTORY_CONTEXT
         );
     }
@@ -170,6 +194,7 @@ public final class BasicSpreadsheetDeltaLabelsTableComponentContextTest implemen
                 CELL_TO_REFERENCES,
                 LABEL_TO_CELL,
                 HAS_SPREADSHEET_DELTA_FETCHER_WATCHERS,
+                SPREADSHEET_LABEL_NAME_RESOLVER,
                 HISTORY_CONTEXT
             ),
             CELL_TO_FORMULA_TEXT +

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/delta/SpreadsheetDeltaLabelsTableComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/delta/SpreadsheetDeltaLabelsTableComponentTest.java
@@ -128,7 +128,7 @@ public final class SpreadsheetDeltaLabelsTableComponentTest implements TableComp
                 "        ROW(S)\n" +
                 "          ROW 0\n" +
                 "            \"LabelXYZ\" [#/1/Spreadsheet222/label/LabelXYZ] id=ID123-labels-LabelXYZ-Link\n" +
-                "            \"LabelXYZ\" [#/1/Spreadsheet222/cell/LabelXYZ/formula] id=ID123-labels-LabelXYZ-formula-Link\n" +
+                "            \"A1\" [#/1/Spreadsheet222/cell/LabelXYZ/formula] id=ID123-labels-LabelXYZ-formula-Link\n" +
                 "            SpreadsheetTextNodeComponent\n" +
                 "            SpreadsheetLabelLinksComponent\n" +
                 "              SpreadsheetLinkListComponent\n" +
@@ -179,7 +179,7 @@ public final class SpreadsheetDeltaLabelsTableComponentTest implements TableComp
                 "        ROW(S)\n" +
                 "          ROW 0\n" +
                 "            \"LabelXYZ\" [#/1/Spreadsheet222/label/LabelXYZ] id=ID123-labels-LabelXYZ-Link\n" +
-                "            \"LabelXYZ\" [#/1/Spreadsheet222/cell/LabelXYZ/formula] id=ID123-labels-LabelXYZ-formula-Link\n" +
+                "            \"A1\" [#/1/Spreadsheet222/cell/LabelXYZ/formula] id=ID123-labels-LabelXYZ-formula-Link\n" +
                 "            SpreadsheetTextNodeComponent\n" +
                 "            SpreadsheetLabelLinksComponent\n" +
                 "              SpreadsheetLinkListComponent\n" +
@@ -244,7 +244,7 @@ public final class SpreadsheetDeltaLabelsTableComponentTest implements TableComp
                 "                    \"Delete\" [#/1/Spreadsheet222/label/LABEL2/delete] id=ID123-labels-LABEL2-delete-Link\n" +
                 "          ROW 1\n" +
                 "            \"LabelXYZ\" [#/1/Spreadsheet222/label/LabelXYZ] id=ID123-labels-LabelXYZ-Link\n" +
-                "            \"LabelXYZ\" [#/1/Spreadsheet222/cell/LabelXYZ/formula] id=ID123-labels-LabelXYZ-formula-Link\n" +
+                "            \"A1\" [#/1/Spreadsheet222/cell/LabelXYZ/formula] id=ID123-labels-LabelXYZ-formula-Link\n" +
                 "            SpreadsheetTextNodeComponent\n" +
                 "            SpreadsheetLabelLinksComponent\n" +
                 "              SpreadsheetLinkListComponent\n" +
@@ -299,6 +299,11 @@ public final class SpreadsheetDeltaLabelsTableComponentTest implements TableComp
                         return null;
                     }
                 },
+                (l) -> Optional.ofNullable(
+                    LABEL.equals(l) ?
+                        SpreadsheetSelection.A1 :
+                        null
+                ),
                 new FakeHistoryContext() {
                     @Override
                     public HistoryToken historyToken() {

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/label/SpreadsheetLabelMappingListDialogComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/label/SpreadsheetLabelMappingListDialogComponentTest.java
@@ -204,7 +204,7 @@ public final class SpreadsheetLabelMappingListDialogComponentTest implements Spr
                 "              ROW(S)\n" +
                 "                ROW 0\n" +
                 "                  \"A1LABEL\" [#/1/SpreadsheetName222/label/A1LABEL] id=labels-labels-A1LABEL-Link\n" +
-                "                  \"=1+2\" [#/1/SpreadsheetName222/cell/A1LABEL/formula] id=labels-labels-A1LABEL-formula-Link\n" +
+                "                  \"=1+2\" [#/1/SpreadsheetName222/cell/A1LABEL/formula] id=labels-labels-A1LABEL-formula-Link\n" + // <---formula shouldnt be replaced by cell reference
                 "                  SpreadsheetTextNodeComponent\n" +
                 "                  SpreadsheetLabelLinksComponent\n" +
                 "                    SpreadsheetLinkListComponent\n" +
@@ -214,7 +214,7 @@ public final class SpreadsheetLabelMappingListDialogComponentTest implements Spr
                 "                          \"Delete\" [#/1/SpreadsheetName222/label/A1LABEL/delete] id=labels-labels-A1LABEL-delete-Link\n" +
                 "                ROW 1\n" +
                 "                  \"B2LABEL\" [#/1/SpreadsheetName222/label/B2LABEL] id=labels-labels-B2LABEL-Link\n" +
-                "                  \"B2LABEL\" [#/1/SpreadsheetName222/cell/B2LABEL/formula] id=labels-labels-B2LABEL-formula-Link\n" +
+                "                  \"B2\" [#/1/SpreadsheetName222/cell/B2LABEL/formula] id=labels-labels-B2LABEL-formula-Link\n" +
                 "                  SpreadsheetTextNodeComponent\n" +
                 "                  SpreadsheetLabelLinksComponent\n" +
                 "                    SpreadsheetLinkListComponent\n" +
@@ -327,7 +327,7 @@ public final class SpreadsheetLabelMappingListDialogComponentTest implements Spr
                 "              ROW(S)\n" +
                 "                ROW 0\n" +
                 "                  \"B2LABEL\" [#/1/SpreadsheetName222/label/B2LABEL] id=labels-labels-B2LABEL-Link\n" +
-                "                  \"B2LABEL\" [#/1/SpreadsheetName222/cell/B2LABEL/formula] id=labels-labels-B2LABEL-formula-Link\n" +
+                "                  \"B2\" [#/1/SpreadsheetName222/cell/B2LABEL/formula] id=labels-labels-B2LABEL-formula-Link\n" +
                 "                  SpreadsheetTextNodeComponent\n" +
                 "                  SpreadsheetLabelLinksComponent\n" +
                 "                    SpreadsheetLinkListComponent\n" +
@@ -337,7 +337,7 @@ public final class SpreadsheetLabelMappingListDialogComponentTest implements Spr
                 "                          \"Delete\" [#/1/SpreadsheetName222/label/B2LABEL/delete] id=labels-labels-B2LABEL-delete-Link\n" +
                 "                ROW 1\n" +
                 "                  \"C3LABEL\" [#/1/SpreadsheetName222/label/C3LABEL] id=labels-labels-C3LABEL-Link\n" +
-                "                  \"C3LABEL\" [#/1/SpreadsheetName222/cell/C3LABEL/formula] id=labels-labels-C3LABEL-formula-Link\n" +
+                "                  \"C3\" [#/1/SpreadsheetName222/cell/C3LABEL/formula] id=labels-labels-C3LABEL-formula-Link\n" +
                 "                  SpreadsheetTextNodeComponent\n" +
                 "                  SpreadsheetLabelLinksComponent\n" +
                 "                    SpreadsheetLinkListComponent\n" +
@@ -411,6 +411,11 @@ public final class SpreadsheetLabelMappingListDialogComponentTest implements Spr
             return this.cache;
         }
 
+        @Override
+        public Optional<SpreadsheetSelection> resolveLabel(final SpreadsheetLabelName spreadsheetLabelName) {
+            return this.cache.resolveLabel(spreadsheetLabelName);
+        }
+
         private final SpreadsheetViewportCache cache = SpreadsheetViewportCache.empty(this);
 
         @Override
@@ -472,6 +477,11 @@ public final class SpreadsheetLabelMappingListDialogComponentTest implements Spr
         public void loadLabelMappings(final SpreadsheetId id,
                                       final HistoryTokenOffsetAndCount offsetAndCount) {
             // NOP
+        }
+
+        @Override
+        public Optional<SpreadsheetSelection> resolveLabel(final SpreadsheetLabelName spreadsheetLabelName) {
+            return this.context.resolveLabel(spreadsheetLabelName);
         }
 
         private final AppContext context;


### PR DESCRIPTION
…display cell reference not label FIX

- If the formula text is displayed, leave only replace if the label was used.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/4799
- SpreadsheetDeltaLabelsTableComponent cell column formula link should display cell reference not label