### PR TITLE
SpreadsheetLabelMappingListDialogComponent delegate ComponentLifecycl…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/label/AppContextSpreadsheetLabelMappingListDialogComponentContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/label/AppContextSpreadsheetLabelMappingListDialogComponentContext.java
@@ -24,7 +24,9 @@ import walkingkooka.spreadsheet.dominokit.fetcher.HasSpreadsheetDeltaFetcherWatc
 import walkingkooka.spreadsheet.dominokit.fetcher.HasSpreadsheetDeltaFetcherWatchersDelegator;
 import walkingkooka.spreadsheet.dominokit.history.HistoryContext;
 import walkingkooka.spreadsheet.dominokit.history.HistoryContextDelegator;
+import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
 import walkingkooka.spreadsheet.dominokit.history.HistoryTokenOffsetAndCount;
+import walkingkooka.spreadsheet.dominokit.history.SpreadsheetLabelMappingListHistoryToken;
 import walkingkooka.spreadsheet.dominokit.log.LoggingContext;
 import walkingkooka.spreadsheet.dominokit.log.LoggingContextDelegator;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
@@ -98,6 +100,18 @@ final class AppContextSpreadsheetLabelMappingListDialogComponentContext implemen
     @Override
     public HasSpreadsheetDeltaFetcherWatchers hasSpreadsheetDeltaFetcherWatchers() {
         return this.context;
+    }
+
+    // ComponentLifecycleMatcher........................................................................................
+
+    @Override
+    public boolean shouldIgnore(final HistoryToken token) {
+        return false;
+    }
+
+    @Override
+    public boolean isMatch(final HistoryToken token) {
+        return token instanceof SpreadsheetLabelMappingListHistoryToken;
     }
 
     // HistoryContextDelegator..........................................................................................

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/label/FakeSpreadsheetLabelMappingListDialogComponentContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/label/FakeSpreadsheetLabelMappingListDialogComponentContext.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.dominokit.label;
 
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.dominokit.delta.FakeSpreadsheetDeltaLabelsTableComponentContext;
+import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
 import walkingkooka.spreadsheet.dominokit.history.HistoryTokenOffsetAndCount;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
@@ -46,6 +47,16 @@ public class FakeSpreadsheetLabelMappingListDialogComponentContext extends FakeS
 
     @Override
     public SpreadsheetMetadata spreadsheetMetadata() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean shouldIgnore(final HistoryToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isMatch(final HistoryToken token) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/label/SpreadsheetLabelMappingListDialogComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/label/SpreadsheetLabelMappingListDialogComponent.java
@@ -122,12 +122,12 @@ public final class SpreadsheetLabelMappingListDialogComponent implements Spreads
 
     @Override
     public boolean shouldIgnore(final HistoryToken token) {
-        return false;
+        return this.context.shouldIgnore(token);
     }
 
     @Override
     public boolean isMatch(final HistoryToken token) {
-        return token instanceof SpreadsheetLabelMappingListHistoryToken;
+        return this.context.isMatch(token);
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/label/SpreadsheetLabelMappingListDialogComponentContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/label/SpreadsheetLabelMappingListDialogComponentContext.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.dominokit.label;
 
 import walkingkooka.spreadsheet.SpreadsheetId;
+import walkingkooka.spreadsheet.dominokit.ComponentLifecycleMatcher;
 import walkingkooka.spreadsheet.dominokit.delta.SpreadsheetDeltaLabelsTableComponentContext;
 import walkingkooka.spreadsheet.dominokit.dialog.SpreadsheetDialogComponentContext;
 import walkingkooka.spreadsheet.dominokit.fetcher.HasSpreadsheetDeltaFetcherWatchers;
@@ -32,6 +33,7 @@ public interface SpreadsheetLabelMappingListDialogComponentContext extends Histo
     SpreadsheetDeltaLabelsTableComponentContext,
     HasSpreadsheetDeltaFetcherWatchers,
     HasSpreadsheetMetadata,
+    ComponentLifecycleMatcher,
     SpreadsheetDialogComponentContext {
 
     /**

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/label/SpreadsheetLabelMappingListDialogComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/label/SpreadsheetLabelMappingListDialogComponentTest.java
@@ -36,6 +36,7 @@ import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
 import walkingkooka.spreadsheet.dominokit.history.HistoryTokenOffsetAndCount;
 import walkingkooka.spreadsheet.dominokit.history.HistoryTokenWatcher;
 import walkingkooka.spreadsheet.dominokit.history.HistoryTokenWatchers;
+import walkingkooka.spreadsheet.dominokit.history.SpreadsheetLabelMappingListHistoryToken;
 import walkingkooka.spreadsheet.dominokit.viewport.SpreadsheetViewportCache;
 import walkingkooka.spreadsheet.engine.SpreadsheetDelta;
 import walkingkooka.spreadsheet.formula.SpreadsheetFormula;
@@ -485,6 +486,16 @@ public final class SpreadsheetLabelMappingListDialogComponentTest implements Spr
         }
 
         private final AppContext context;
+
+        @Override
+        public boolean shouldIgnore(final HistoryToken token) {
+            return false;
+        }
+
+        @Override
+        public boolean isMatch(final HistoryToken token) {
+            return token instanceof SpreadsheetLabelMappingListHistoryToken;
+        }
     }
 
     // ClassTesting.....................................................................................................


### PR DESCRIPTION
…eMatcher SpreadsheetLabelMappingListDialogComponentContext

- This is the first step to allow a different SpreadsheetLabelMappingListDialogComponentContext to handle SpreadsheetCellLabelsHistoryToken (cell label lists).