### PR TITLE
DateTimeSymbolsDialogComponent.clear missing dateTimeSymbols FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/datetimesymbols/DateTimeSymbolsDialogComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/datetimesymbols/DateTimeSymbolsDialogComponent.java
@@ -389,6 +389,7 @@ public final class DateTimeSymbolsDialogComponent implements SpreadsheetDialogCo
         this.monthNameAbbreviations.clear();
         this.weekDayNames.clear();
         this.weekDayNameAbbreviations.clear();
+        this.dateTimeSymbols.clear();
     }
 
     private final DateTimeSymbolsComponent dateTimeSymbols;


### PR DESCRIPTION
- Doesnt fix the missing error messages when a field is empty.