### PR TITLE
HistoryTokenSaveValueAnchorComponent.setStringValue deleted

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/value/HistoryTokenSaveValueAnchorComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/value/HistoryTokenSaveValueAnchorComponent.java
@@ -21,7 +21,6 @@ import walkingkooka.Cast;
 import walkingkooka.spreadsheet.dominokit.history.HistoryContext;
 import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
 import walkingkooka.spreadsheet.dominokit.history.HistoryTokenAnchorComponent;
-import walkingkooka.text.CharSequences;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -43,10 +42,8 @@ public final class HistoryTokenSaveValueAnchorComponent<T> implements ValueHisto
 
     private HistoryTokenSaveValueAnchorComponent(final String id,
                                                  final HistoryContext context) {
-        this.historyTokenAnchorComponent = HistoryTokenAnchorComponent.empty();
-
         this.component = ValueHistoryTokenAnchorComponent.with(
-            this.historyTokenAnchorComponent,
+            HistoryTokenAnchorComponent.empty(),
             this::getter,
             this::setter
         );
@@ -83,20 +80,6 @@ public final class HistoryTokenSaveValueAnchorComponent<T> implements ValueHisto
             Optional.ofNullable(historyToken)
         );
     }
-
-    public HistoryTokenSaveValueAnchorComponent<T> setStringValue(final String value) {
-        this.historyTokenAnchorComponent.setHistoryToken(
-            Optional.ofNullable(
-                this.autoDisableWhenMissingValue && CharSequences.isNullOrEmpty(value) ?
-                    null :
-                    this.context.historyToken()
-                        .setSaveValue(value)
-            )
-        );
-        return this;
-    }
-
-    private final HistoryTokenAnchorComponent historyTokenAnchorComponent;
 
     /**
      * Will disable the link if setValue is given a {@link Optional#empty()}.

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/value/HistoryTokenSaveValueAnchorComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/value/HistoryTokenSaveValueAnchorComponentTest.java
@@ -20,7 +20,6 @@ package walkingkooka.spreadsheet.dominokit.value;
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
 import walkingkooka.color.Color;
-import walkingkooka.plugin.PluginName;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
@@ -118,31 +117,6 @@ public final class HistoryTokenSaveValueAnchorComponentTest implements AnchorCom
         );
     }
 
-    @Test
-    public void testSetStringValue() {
-        this.treePrintAndCheck(
-            this.createComponent(
-                HistoryToken.pluginSelect(
-                    PluginName.with("Plugin1")
-                )
-            ).setStringValue("Plugin2"),
-            "\"Save\" [#/plugin/Plugin1/save/Plugin2] id=HistoryTokenSaveValueAnchorComponent-Link"
-        );
-    }
-
-    @Test
-    public void testSetStringValueSetTextContent() {
-        this.treePrintAndCheck(
-            this.createComponent(
-                    HistoryToken.pluginSelect(
-                        PluginName.with("Plugin1")
-                    )
-                ).setTextContent("Action123")
-                .setStringValue("Plugin2"),
-            "\"Action123\" [#/plugin/Plugin1/save/Plugin2] id=HistoryTokenSaveValueAnchorComponent-Link"
-        );
-    }
-
     // autoDisableWhenMissingValue......................................................................................
 
     @Test
@@ -181,34 +155,6 @@ public final class HistoryTokenSaveValueAnchorComponentTest implements AnchorCom
                     )
                 ),
             "\"Save\" [#/1/SpreadsheetName1/cell/A1/style/color/save/%23123456] id=HistoryTokenSaveValueAnchorComponent-Link"
-        );
-    }
-
-    @Test
-    public void testAutoDisableWhenMissingValueSetStringValueNotEmptyString() {
-        this.treePrintAndCheck(
-            this.createComponent(
-                    HistoryToken.pluginSelect(
-                        PluginName.with("Plugin1")
-                    )
-                )
-                .autoDisableWhenMissingValue()
-                .setStringValue("Hello"),
-            "\"Save\" [#/plugin/Plugin1/save/Hello] id=HistoryTokenSaveValueAnchorComponent-Link"
-        );
-    }
-
-    @Test
-    public void testAutoDisableWhenMissingValueSetStringValueEmptyString() {
-        this.treePrintAndCheck(
-            this.createComponent(
-                    HistoryToken.pluginSelect(
-                        PluginName.with("Plugin1")
-                    )
-                )
-                .autoDisableWhenMissingValue()
-                .setStringValue(""),
-            "\"Save\" DISABLED id=HistoryTokenSaveValueAnchorComponent-Link"
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/5160
- HistoryTokenSaveValueAnchorComponent.setStringValue should capture exceptions and record errors like setValue