### PR TITLE
Fetcher.onBegin skip log null when body absent FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/App.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/App.java
@@ -720,7 +720,11 @@ public class App implements EntryPoint,
                         final Url url,
                         final Optional<FetcherRequestBody<?>> body,
                         final AppContext context) {
-        context.debug(method + " " + url, body.orElse(null));
+        if(body.isPresent()) {
+            context.debug(method + " " + url, body.get());
+        } else {
+            context.debug(method + " " + url);
+        }
     }
 
     @Override


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/5588
- Fetcher log shouldnt log "null" when body is absent