### PR TITLE
SpreadsheetDialogComponentContext.selectionTextStylePropertyDialogTit…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/dialog/SpreadsheetDialogComponentContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/dialog/SpreadsheetDialogComponentContext.java
@@ -47,13 +47,14 @@ public interface SpreadsheetDialogComponentContext extends HistoryContext,
     /**
      * Helper that may be used to create a standard dialog for a {@link SpreadsheetSelection} and a style view or edit.
      */
-    static String selectionTextStylePropertyDialogTitle(final SpreadsheetSelection selection,
-                                                        final TextStylePropertyName<?> propertyName) {
-        Objects.requireNonNull(selection, "selection");
+    default String selectionTextStylePropertyDialogTitle(final TextStylePropertyName<?> propertyName) {
+
         Objects.requireNonNull(propertyName, "propertyName");
 
         return selectionDialogTitle(
-            selection,
+            this.historyToken()
+                .selection()
+                .get(),
             CaseKind.kebabToTitle(
                 propertyName.value()
             )

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/dialog/SpreadsheetDialogComponentContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/dialog/SpreadsheetDialogComponentContextTest.java
@@ -117,28 +117,6 @@ public final class SpreadsheetDialogComponentContextTest implements ClassTesting
     // selectionTextStylePropertyDialogTitle............................................................................
 
     @Test
-    public void testSelectionTextStylePropertyDialogTitleWithNullSelectionFails() {
-        assertThrows(
-            NullPointerException.class,
-            () -> SpreadsheetDialogComponentContext.selectionTextStylePropertyDialogTitle(
-                null,
-                TextStylePropertyName.TEXT_ALIGN
-            )
-        );
-    }
-
-    @Test
-    public void testSelectionTextStylePropertyDialogTitleWithNullActionFails() {
-        assertThrows(
-            NullPointerException.class,
-            () -> SpreadsheetDialogComponentContext.selectionTextStylePropertyDialogTitle(
-                SpreadsheetSelection.A1,
-                null
-            )
-        );
-    }
-
-    @Test
     public void testSelectionTextStylePropertyDialogTitleWithTextAlign() {
         this.selectionStylePropertyDialogTitleAndCheck(
             SpreadsheetSelection.A1,
@@ -179,10 +157,17 @@ public final class SpreadsheetDialogComponentContextTest implements ClassTesting
                                                            final String expected) {
         this.checkEquals(
             expected,
-            SpreadsheetDialogComponentContext.selectionTextStylePropertyDialogTitle(
-                selection,
-                propertyName
-            ),
+            new FakeSpreadsheetDialogComponentContext() {
+                @Override
+                public HistoryToken historyToken() {
+                    return HistoryToken.cellStyle(
+                        ID,
+                        NAME,
+                        selection.setDefaultAnchor(),
+                        propertyName
+                    );
+                }
+            }.selectionTextStylePropertyDialogTitle(propertyName),
             () -> "selection: " + selection + " propertyName: " + propertyName
         );
     }


### PR DESCRIPTION
…le instance method was static

- Previously the selection was a required property. The current HistoryToken.selection() is now called.