### PR TITLE
DateTimeSymbolsDialogComponent.localeLoad

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/datetimesymbols/AppContextDateTimeSymbolsDialogComponentContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/datetimesymbols/AppContextDateTimeSymbolsDialogComponentContext.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.dominokit.datetimesymbols;
 
 import walkingkooka.spreadsheet.dominokit.AppContext;
+import walkingkooka.spreadsheet.dominokit.fetcher.DateTimeSymbolsFetcherWatcher;
 import walkingkooka.spreadsheet.dominokit.fetcher.SpreadsheetDeltaFetcherWatcher;
 import walkingkooka.spreadsheet.dominokit.fetcher.SpreadsheetMetadataFetcherWatcher;
 import walkingkooka.spreadsheet.dominokit.history.HistoryContext;
@@ -31,6 +32,17 @@ abstract class AppContextDateTimeSymbolsDialogComponentContext implements DateTi
 
     AppContextDateTimeSymbolsDialogComponentContext(final AppContext context) {
         this.context = context;
+    }
+
+    @Override
+    public final void findDateTimeSymbolsWithLocaleStartsWith(final String startsWith) {
+        this.context.dateTimeSymbolsFetcher()
+            .getDateTimeSymbolsLocaleStartsWith(startsWith);
+    }
+
+    @Override
+    public final Runnable addDateTimeSymbolsFetcherWatcher(final DateTimeSymbolsFetcherWatcher watcher) {
+        return this.context.addDateTimeSymbolsFetcherWatcher(watcher);
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/datetimesymbols/DateTimeSymbolsDialogComponentContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/datetimesymbols/DateTimeSymbolsDialogComponentContext.java
@@ -20,6 +20,7 @@ package walkingkooka.spreadsheet.dominokit.datetimesymbols;
 import walkingkooka.datetime.DateTimeSymbols;
 import walkingkooka.spreadsheet.dominokit.ComponentLifecycleMatcher;
 import walkingkooka.spreadsheet.dominokit.dialog.SpreadsheetDialogComponentContext;
+import walkingkooka.spreadsheet.dominokit.fetcher.DateTimeSymbolsFetcherWatcher;
 import walkingkooka.spreadsheet.dominokit.fetcher.SpreadsheetDeltaFetcherWatcher;
 import walkingkooka.spreadsheet.dominokit.fetcher.SpreadsheetMetadataFetcherWatcher;
 import walkingkooka.spreadsheet.dominokit.label.SpreadsheetLabelMappingDialogComponent;
@@ -39,6 +40,11 @@ public interface DateTimeSymbolsDialogComponentContext extends
     Optional<DateTimeSymbols> copyDateTimeSymbols();
 
     /**
+     * Calls the server to find {@link DateTimeSymbols} for the locale startsWith parameter
+     */
+    void findDateTimeSymbolsWithLocaleStartsWith(final String startsWith);
+
+    /**
      * Gets the current {@link DateTimeSymbols}
      */
     Optional<DateTimeSymbols> loadDateTimeSymbols();
@@ -52,6 +58,11 @@ public interface DateTimeSymbolsDialogComponentContext extends
      * Adds a {@link SpreadsheetDeltaFetcherWatcher}.
      */
     Runnable addSpreadsheetDeltaFetcherWatcher(final SpreadsheetDeltaFetcherWatcher watcher);
+
+    /**
+     * Adds a {@link DateTimeSymbolsFetcherWatcher}
+     */
+    Runnable addDateTimeSymbolsFetcherWatcher(final DateTimeSymbolsFetcherWatcher watcher);
 
     /**
      * Adds a {@link SpreadsheetMetadataFetcherWatcher}.

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/datetimesymbols/FakeDateTimeSymbolsDialogComponentContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/datetimesymbols/FakeDateTimeSymbolsDialogComponentContext.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.dominokit.datetimesymbols;
 
 import walkingkooka.datetime.DateTimeSymbols;
 import walkingkooka.spreadsheet.dominokit.dialog.FakeSpreadsheetDialogComponentContext;
+import walkingkooka.spreadsheet.dominokit.fetcher.DateTimeSymbolsFetcherWatcher;
 import walkingkooka.spreadsheet.dominokit.fetcher.SpreadsheetDeltaFetcherWatcher;
 import walkingkooka.spreadsheet.dominokit.fetcher.SpreadsheetMetadataFetcherWatcher;
 import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
@@ -47,12 +48,22 @@ public class FakeDateTimeSymbolsDialogComponentContext extends FakeSpreadsheetDi
     }
 
     @Override
+    public void findDateTimeSymbolsWithLocaleStartsWith(final String startsWith) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Optional<DateTimeSymbols> loadDateTimeSymbols() {
         throw new UnsupportedOperationException();
     }
 
     @Override
     public void save(final Optional<DateTimeSymbols> symbols) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Runnable addDateTimeSymbolsFetcherWatcher(final DateTimeSymbolsFetcherWatcher watcher) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/locale/SpreadsheetLocaleComponentSuggestionsValue.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/locale/SpreadsheetLocaleComponentSuggestionsValue.java
@@ -18,7 +18,9 @@
 package walkingkooka.spreadsheet.dominokit.locale;
 
 import walkingkooka.Value;
+import walkingkooka.datetime.DateTimeSymbols;
 import walkingkooka.locale.LocaleContexts;
+import walkingkooka.spreadsheet.server.datetimesymbols.DateTimeSymbolsHateosResource;
 import walkingkooka.text.CharSequences;
 import walkingkooka.text.HasText;
 import walkingkooka.util.HasLocale;
@@ -26,88 +28,99 @@ import walkingkooka.util.HasLocale;
 import java.util.Locale;
 import java.util.Objects;
 
-final class SpreadsheetLocaleComponentSuggestionsValue<T> implements HasLocale,
+public final class SpreadsheetLocaleComponentSuggestionsValue<T> implements HasLocale,
     HasText,
     Value<T>,
-    Comparable<SpreadsheetLocaleComponentSuggestionsValue<T>>{
+    Comparable<SpreadsheetLocaleComponentSuggestionsValue<T>> {
 
-static <T> SpreadsheetLocaleComponentSuggestionsValue<T> with(final Locale locale,
-                                                              final String text,
-                                                              final T value) {
-    return new SpreadsheetLocaleComponentSuggestionsValue(
-        Objects.requireNonNull(locale, "locale"),
-        CharSequences.failIfNullOrEmpty(text, "text"),
-        Objects.requireNonNull(value, "value")
-    );
-}
+    public static SpreadsheetLocaleComponentSuggestionsValue<DateTimeSymbols> fromDateTimeSymbolsHateosResource(final DateTimeSymbolsHateosResource resource) {
+        Objects.requireNonNull(resource, "resource");
+        return with(
+            Locale.forLanguageTag(
+                resource.hateosLinkId()
+            ),
+            resource.text(),
+            resource.value()
+        );
+    }
 
-private SpreadsheetLocaleComponentSuggestionsValue(final Locale locale,
-                                                   final String text,
-                                                   final T value) {
-    this.locale = locale;
-    this.text = text;
-    this.value = value;
-}
+    static <T> SpreadsheetLocaleComponentSuggestionsValue<T> with(final Locale locale,
+                                                                  final String text,
+                                                                  final T value) {
+        return new SpreadsheetLocaleComponentSuggestionsValue(
+            Objects.requireNonNull(locale, "locale"),
+            CharSequences.failIfNullOrEmpty(text, "text"),
+            Objects.requireNonNull(value, "value")
+        );
+    }
 
-@Override
-public Locale locale() {
-    return this.locale;
-}
+    private SpreadsheetLocaleComponentSuggestionsValue(final Locale locale,
+                                                       final String text,
+                                                       final T value) {
+        this.locale = locale;
+        this.text = text;
+        this.value = value;
+    }
 
-private final Locale locale;
+    @Override
+    public Locale locale() {
+        return this.locale;
+    }
 
-@Override
-public String text() {
-    return this.text;
-}
+    private final Locale locale;
+
+    @Override
+    public String text() {
+        return this.text;
+    }
 
 // Value............................................................................................................
 
-@Override
-public T value() {
-    return this.value;
-}
+    @Override
+    public T value() {
+        return this.value;
+    }
 
-private final T value;
+    private final T value;
 
 // Object...........................................................................................................
 
-@Override
-public int hashCode() {
-    return Objects.hash(
-        this.locale,
-        this.text,
-        this.value
-    );
-}
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+            this.locale,
+            this.text,
+            this.value
+        );
+    }
 
-@Override
-public boolean equals(final Object other) {
-    return this == other ||
-        (other instanceof SpreadsheetLocaleComponentSuggestionsValue && this.equals0((SpreadsheetLocaleComponentSuggestionsValue) other));
-}
+    @Override
+    public boolean equals(final Object other) {
+        return this == other ||
+            (other instanceof SpreadsheetLocaleComponentSuggestionsValue && this.equals0((SpreadsheetLocaleComponentSuggestionsValue) other));
+    }
 
-private boolean equals0(final SpreadsheetLocaleComponentSuggestionsValue other) {
-    return this.locale.equals(other.locale) &&
-        this.text.equals(other.text) &&
-        this.value.equals(other.value);
-}
+    private boolean equals0(final SpreadsheetLocaleComponentSuggestionsValue other) {
+        return this.locale.equals(other.locale) &&
+            this.text.equals(other.text) &&
+            this.value.equals(other.value);
+    }
 
-@Override
-public String toString() {
-    return this.text;
-}
+    @Override
+    public String toString() {
+        return this.text;
+    }
 
-private final String text;
+    private final String text;
 
 // Comparable.......................................................................................................
 
-@Override
-public int compareTo(final SpreadsheetLocaleComponentSuggestionsValue other) {
-    return LocaleContexts.CASE_SENSITIVITY.comparator()
-        .compare(
-            this.text,
-            other.text
-        );
-}
+    @Override
+    public int compareTo(final SpreadsheetLocaleComponentSuggestionsValue other) {
+        return LocaleContexts.CASE_SENSITIVITY.comparator()
+            .compare(
+                this.text,
+                other.text
+            );
+    }
 }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/datetimesymbols/DateTimeSymbolsDialogComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/datetimesymbols/DateTimeSymbolsDialogComponentTest.java
@@ -23,6 +23,7 @@ import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.spreadsheet.dominokit.AppContext;
 import walkingkooka.spreadsheet.dominokit.FakeAppContext;
 import walkingkooka.spreadsheet.dominokit.dialog.SpreadsheetDialogComponentLifecycleTesting;
+import walkingkooka.spreadsheet.dominokit.fetcher.DateTimeSymbolsFetcherWatcher;
 import walkingkooka.spreadsheet.dominokit.fetcher.SpreadsheetDeltaFetcherWatcher;
 import walkingkooka.spreadsheet.dominokit.fetcher.SpreadsheetMetadataFetcherWatcher;
 import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
@@ -103,6 +104,9 @@ public final class DateTimeSymbolsDialogComponentTest implements SpreadsheetDial
                 "                Date Time Symbols []\n" +
                 "                Errors\n" +
                 "                  Expected 5 tokens but got 0\n" +
+                "      SpreadsheetLocaleComponent\n" +
+                "        SpreadsheetSuggestBoxComponent\n" +
+                "          Load from Locale []\n" +
                 "      SpreadsheetLinkListComponent\n" +
                 "        SpreadsheetFlexLayout\n" +
                 "          ROW\n" +
@@ -165,6 +169,9 @@ public final class DateTimeSymbolsDialogComponentTest implements SpreadsheetDial
                 "            ValueSpreadsheetTextBox\n" +
                 "              SpreadsheetTextBox\n" +
                 "                Date Time Symbols [\"am,pm\",\"January,February,March,April,May,June,July,August,September,October,November,December\",\"Jan.,Feb.,Mar.,Apr.,May,Jun.,Jul.,Aug.,Sep.,Oct.,Nov.,Dec.\",\"Sunday,Monday,Tuesday,Wednesday,Thursday,Friday,Saturday\",\"Sun.,Mon.,Tue.,Wed.,Thu.,Fri.,Sat.\"]\n" +
+                "      SpreadsheetLocaleComponent\n" +
+                "        SpreadsheetSuggestBoxComponent\n" +
+                "          Load from Locale []\n" +
                 "      SpreadsheetLinkListComponent\n" +
                 "        SpreadsheetFlexLayout\n" +
                 "          ROW\n" +
@@ -239,7 +246,9 @@ public final class DateTimeSymbolsDialogComponentTest implements SpreadsheetDial
                 "                Date Time Symbols []\n" +
                 "                Errors\n" +
                 "                  Expected 5 tokens but got 0\n" +
-                "      SpreadsheetLinkListComponent\n" +
+                "      SpreadsheetLocaleComponent\n" +
+                "        SpreadsheetSuggestBoxComponent\n" +
+                "          Load from Locale []\n" +"      SpreadsheetLinkListComponent\n" +
                 "        SpreadsheetFlexLayout\n" +
                 "          ROW\n" +
                 "            \"Save\" DISABLED id=dateTimeSymbols-save-Link\n" +
@@ -265,6 +274,11 @@ public final class DateTimeSymbolsDialogComponentTest implements SpreadsheetDial
     private AppContext appContext(final HistoryToken historyToken,
                                   final DateTimeSymbols dateTimeSymbols) {
         return new FakeAppContext() {
+
+            @Override
+            public Runnable addDateTimeSymbolsFetcherWatcher(final DateTimeSymbolsFetcherWatcher watcher) {
+                return null;
+            }
 
             @Override
             public Runnable addHistoryTokenWatcher(final HistoryTokenWatcher watcher) {

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/locale/SpreadsheetLocaleComponentSuggestionsValueTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/locale/SpreadsheetLocaleComponentSuggestionsValueTest.java
@@ -22,9 +22,13 @@ import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.set.SortedSets;
 import walkingkooka.compare.ComparableTesting2;
+import walkingkooka.datetime.DateTimeSymbols;
 import walkingkooka.reflect.ClassTesting;
 import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.spreadsheet.server.datetimesymbols.DateTimeSymbolsHateosResource;
+import walkingkooka.text.HasTextTesting;
 
+import java.text.DateFormatSymbols;
 import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -32,12 +36,49 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class SpreadsheetLocaleComponentSuggestionsValueTest implements ComparableTesting2<SpreadsheetLocaleComponentSuggestionsValue<Integer>>,
-    ClassTesting<SpreadsheetLocaleComponentSuggestionsValue<Integer>> {
+    ClassTesting<SpreadsheetLocaleComponentSuggestionsValue<Integer>>,
+    HasTextTesting {
 
     private final static Locale LOCALE = Locale.ENGLISH;
     private final static String TEXT = "English";
     private final static Integer VALUE = 123;
-    
+
+    // fromDateTimeSymbolsHateosResource................................................................................
+
+    @Test
+    public void testFromDateTimeSymbolsHateosResourceWithNullFails() {
+        assertThrows(
+            NullPointerException.class,
+            () -> SpreadsheetLocaleComponentSuggestionsValue.fromDateTimeSymbolsHateosResource(null)
+        );
+    }
+
+    @Test
+    public void testFromDateTimeSymbolsHateosResource() {
+        final Locale locale = Locale.forLanguageTag("en-AU");
+        final DateTimeSymbols symbols = DateTimeSymbols.fromDateFormatSymbols(
+            new DateFormatSymbols(locale)
+        );
+
+        final SpreadsheetLocaleComponentSuggestionsValue<DateTimeSymbols> value = SpreadsheetLocaleComponentSuggestionsValue.fromDateTimeSymbolsHateosResource(
+            DateTimeSymbolsHateosResource.fromLocale(locale)
+        );
+        this.checkEquals(
+            locale,
+            value.locale(),
+            "locale"
+        );
+        this.textAndCheck(
+            value,
+            "English (Australia)"
+        );
+        this.checkEquals(
+            symbols,
+            value.value(),
+            "value"
+        );
+    }
+
     // with.............................................................................................................
 
     @Test
@@ -141,6 +182,6 @@ public final class SpreadsheetLocaleComponentSuggestionsValueTest implements Com
 
     @Override
     public JavaVisibility typeVisibility() {
-        return JavaVisibility.PACKAGE_PRIVATE;
+        return JavaVisibility.PUBLIC;
     }
 }


### PR DESCRIPTION
- A SpreadsheetLocaleComponent that includes linke to load the symbols for the selected locale.
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/5117
- DateTimeSymbolsDialogComponent locale dropdown