### PR TITLE
SpreadsheetXXXNavigationHistoryToken.patchMetadata was loadCells

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellNavigateHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellNavigateHistoryToken.java
@@ -21,6 +21,7 @@ import walkingkooka.net.UrlFragment;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.dominokit.AppContext;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.spreadsheet.viewport.AnchoredSpreadsheetSelection;
 import walkingkooka.spreadsheet.viewport.SpreadsheetViewportHomeNavigationList;
 
@@ -93,16 +94,16 @@ public final class SpreadsheetCellNavigateHistoryToken extends SpreadsheetCellHi
     @Override
     void onHistoryTokenChange0(final HistoryToken previous,
                                final AppContext context) {
-        // load the cells
-        // http://localhost:12345/api/spreadsheet/1/cell/*/force-recompute?home=A1&width=1568&height=463&includeFrozenColumnsRows=true&selection=F1&selectionType=cell&navigation=right+1567px
-        context.spreadsheetDeltaFetcher()
-            .getCells(
-                this.id(),
-                context.viewport(
-                    this.navigation(),
-                    Optional.of(this.anchoredSelection)
-                ).setIncludeFrozenColumnsRows(true)
-            );
+        // PATCH the metadata viewport
+        context.spreadsheetMetadataFetcher()
+                .patchMetadata(
+                    this.id(),
+                    SpreadsheetMetadataPropertyName.VIEWPORT,
+                    context.viewport(
+                        this.navigation(),
+                        Optional.of(this.anchoredSelection)
+                    )
+                );
 
         context.pushHistoryToken(previous);
     }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnNavigateHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnNavigateHistoryToken.java
@@ -21,6 +21,7 @@ import walkingkooka.net.UrlFragment;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.dominokit.AppContext;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.spreadsheet.viewport.AnchoredSpreadsheetSelection;
 import walkingkooka.spreadsheet.viewport.SpreadsheetViewportHomeNavigationList;
 
@@ -88,15 +89,15 @@ public final class SpreadsheetColumnNavigateHistoryToken extends SpreadsheetColu
     @Override
     void onHistoryTokenChange0(final HistoryToken previous,
                                final AppContext context) {
-        // load the cells
-        // http://localhost:12345/api/spreadsheet/1/cell/*/force-recompute?home=A1&width=1568&height=463&includeFrozenColumnsRows=true&selection=F&selectionType=column&navigation=up+1567px
-        context.spreadsheetDeltaFetcher()
-            .getCells(
+        // PATCH the metadata viewport
+        context.spreadsheetMetadataFetcher()
+            .patchMetadata(
                 this.id(),
+                SpreadsheetMetadataPropertyName.VIEWPORT,
                 context.viewport(
                     this.navigation(),
                     Optional.of(this.anchoredSelection)
-                ).setIncludeFrozenColumnsRows(true)
+                )
             );
 
         context.pushHistoryToken(previous);

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNavigateHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNavigateHistoryToken.java
@@ -22,7 +22,7 @@ import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.dominokit.AppContext;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
-import walkingkooka.spreadsheet.viewport.AnchoredSpreadsheetSelection;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.spreadsheet.viewport.SpreadsheetViewportHomeNavigationList;
 import walkingkooka.text.cursor.TextCursor;
 
@@ -103,15 +103,15 @@ public final class SpreadsheetNavigateHistoryToken extends SpreadsheetNameHistor
     @Override
     void onHistoryTokenChange0(final HistoryToken previous,
                                final AppContext context) {
-        // load the cells
-        // http://localhost:12345/api/spreadsheet/1/cell/*/force-recompute?home=A1&width=1568&height=463&includeFrozenColumnsRows=true&selection=F1&selectionType=cell&navigation=right+1567px
-        context.spreadsheetDeltaFetcher()
-            .getCells(
+        // PATCH the metadata viewport
+        context.spreadsheetMetadataFetcher()
+            .patchMetadata(
                 this.id(),
+                SpreadsheetMetadataPropertyName.VIEWPORT,
                 context.viewport(
                     this.navigation(),
-                    Optional.<AnchoredSpreadsheetSelection>empty()
-                ).setIncludeFrozenColumnsRows(true)
+                    Optional.empty() // no selection
+                )
             );
 
         context.pushHistoryToken(previous);

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowNavigateHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowNavigateHistoryToken.java
@@ -21,6 +21,7 @@ import walkingkooka.net.UrlFragment;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.dominokit.AppContext;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.spreadsheet.viewport.AnchoredSpreadsheetSelection;
 import walkingkooka.spreadsheet.viewport.SpreadsheetViewportHomeNavigationList;
 
@@ -88,15 +89,15 @@ public final class SpreadsheetRowNavigateHistoryToken extends SpreadsheetRowHist
     @Override
     void onHistoryTokenChange0(final HistoryToken previous,
                                final AppContext context) {
-        // load the cells
-        // http://localhost:12345/api/spreadsheet/1/cell/*/force-recompute?home=A1&width=1568&height=463&includeFrozenColumnsRows=true&selection=123&selectionType=row&navigation=down+1567px
-        context.spreadsheetDeltaFetcher()
-            .getCells(
+        // PATCH the metadata viewport
+        context.spreadsheetMetadataFetcher()
+            .patchMetadata(
                 this.id(),
+                SpreadsheetMetadataPropertyName.VIEWPORT,
                 context.viewport(
                     this.navigation(),
                     Optional.of(this.anchoredSelection)
-                ).setIncludeFrozenColumnsRows(true)
+                )
             );
 
         context.pushHistoryToken(previous);


### PR DESCRIPTION
- Previous code, loaded the new cells, but the browser metadata was never updated and held the "old" viewport home.