### PR TITLE
SpreadsheetViewportComponentTable skip rendering invisible columns rows

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportComponentTable.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportComponentTable.java
@@ -277,6 +277,9 @@ final class SpreadsheetViewportComponentTable implements HtmlComponent<HTMLTable
             final Map<SpreadsheetRowReference, SpreadsheetViewportComponentTableRowCells> oldRowsToTableRowCells = this.rowsToTableRowCells;
             final Map<SpreadsheetRowReference, SpreadsheetViewportComponentTableRowCells> newRowsToTableRowCells = Maps.sorted();
 
+            double height = context.viewportGridHeight() -
+                SpreadsheetViewportContext.COLUMN_HEADER_HEIGHT_PIXELS;
+
             // create new rows as necessary
             for (final SpreadsheetRowReference row : rows) {
                 SpreadsheetViewportComponentTableRowCells tableRowCells = oldRowsToTableRowCells.get(row);
@@ -291,6 +294,13 @@ final class SpreadsheetViewportComponentTable implements HtmlComponent<HTMLTable
                     tableRowCells
                 );
                 tbody.appendChild(tableRowCells);
+
+                height = height - context.spreadsheetViewportCache()
+                    .rowHeight(row)
+                    .pixelValue();
+                if(height <= 0) {
+                   break;
+                }
             }
 
             this.rowsToTableRowCells = newRowsToTableRowCells;

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportComponentTableRowCells.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportComponentTableRowCells.java
@@ -79,6 +79,9 @@ final class SpreadsheetViewportComponentTableRowCells extends SpreadsheetViewpor
 
             final SpreadsheetRowReference row = this.rowHeader.selection;
 
+            double rowWidth = context.viewportGridWidth()
+                - SpreadsheetViewportContext.ROW_HEADER_WIDTH_PIXELS;
+
             // create the cells as necessary for this row...
             for (final SpreadsheetColumnReference column : columns) {
                 SpreadsheetViewportComponentTableCellSpreadsheetCell columnTableCell = oldColumnToCells.get(column);
@@ -90,6 +93,12 @@ final class SpreadsheetViewportComponentTableRowCells extends SpreadsheetViewpor
                 }
                 newColumnToCells.put(column, columnTableCell);
                 element.appendChild(columnTableCell);
+
+                rowWidth = rowWidth - columnTableCell.width(context)
+                    .pixelValue();
+                if(rowWidth <= 0) {
+                    break;
+                }
             }
 
             this.columnToCells = newColumnToCells;

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportComponentTableRowColumnHeaders.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportComponentTableRowColumnHeaders.java
@@ -71,6 +71,9 @@ final class SpreadsheetViewportComponentTableRowColumnHeaders extends Spreadshee
             final Map<SpreadsheetColumnReference, SpreadsheetViewportComponentTableCellHeaderSpreadsheetColumn> oldColumnToHeaders = this.columnToHeaders;
             final Map<SpreadsheetColumnReference, SpreadsheetViewportComponentTableCellHeaderSpreadsheetColumn> newColumnToHeaders = Maps.sorted();
 
+            double rowWidth = context.viewportGridWidth()
+                - SpreadsheetViewportContext.ROW_HEADER_WIDTH_PIXELS;
+
             // create new column headers as necessary
             for (final SpreadsheetColumnReference column : columns) {
                 SpreadsheetViewportComponentTableCellHeaderSpreadsheetColumn columnTableCell = oldColumnToHeaders.get(column);
@@ -82,6 +85,13 @@ final class SpreadsheetViewportComponentTableRowColumnHeaders extends Spreadshee
                 }
                 newColumnToHeaders.put(column, columnTableCell);
                 element.appendChild(columnTableCell);
+
+                rowWidth = rowWidth - columnTableCell.width(context)
+                    .pixelValue();
+
+                if(rowWidth <= 0) {
+                    break; // stop rendering invisible columns
+                }
             }
 
             this.columnToHeaders = newColumnToHeaders;

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportContext.java
@@ -29,9 +29,13 @@ import java.util.Objects;
  */
 public interface SpreadsheetViewportContext extends Context {
 
-    Length<?> COLUMN_HEADER_HEIGHT = Length.pixel(30.0);
+    int COLUMN_HEADER_HEIGHT_PIXELS = 30;
 
-    Length<?> ROW_HEADER_WIDTH = Length.pixel(80.0);
+    Length<?> COLUMN_HEADER_HEIGHT = Length.pixel((double)COLUMN_HEADER_HEIGHT_PIXELS);
+
+    int ROW_HEADER_WIDTH_PIXELS = 80;
+
+    Length<?> ROW_HEADER_WIDTH = Length.pixel((double)ROW_HEADER_WIDTH_PIXELS);
 
     /**
      * The {@link TextStyle} for the top/left select all box.

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportComponentTableRowCellsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportComponentTableRowCellsTest.java
@@ -46,6 +46,9 @@ import java.util.Optional;
 
 public final class SpreadsheetViewportComponentTableRowCellsTest extends SpreadsheetViewportComponentTableRowTestCase<SpreadsheetViewportComponentTableRowCells> {
 
+    private final static Length<?> WIDTH = Length.parse("100px");
+    private final static Length<?> HEIGHT = Length.parse("50px");
+
     @Test
     public void testRefresh() {
         final AppContext appContext = new FakeAppContext() {
@@ -81,6 +84,16 @@ public final class SpreadsheetViewportComponentTableRowCellsTest extends Spreads
                     SpreadsheetName.with("SpreadsheetName222"),
                     SpreadsheetSelection.A1.setDefaultAnchor()
                 );
+            }
+
+            @Override
+            public int viewportGridWidth() {
+                return (int)WIDTH.pixelValue();
+            }
+
+            @Override
+            public int viewportGridHeight() {
+                return (int)HEIGHT.pixelValue();
             }
 
             @Override

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportComponentTableRowColumnHeadersTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportComponentTableRowColumnHeadersTest.java
@@ -39,6 +39,9 @@ import java.util.function.Predicate;
 
 public final class SpreadsheetViewportComponentTableRowColumnHeadersTest extends SpreadsheetViewportComponentTableRowTestCase<SpreadsheetViewportComponentTableRowColumnHeaders> {
 
+    private final static Length<?> WIDTH = Length.parse("100px");
+    private final static Length<?> HEIGHT = Length.parse("50px");
+
     @Test
     public void testRefreshNothingSelected() {
         this.treePrintAndCheck2(
@@ -154,6 +157,16 @@ public final class SpreadsheetViewportComponentTableRowColumnHeadersTest extends
         final SpreadsheetViewportComponentTableContext tableContext = new FakeSpreadsheetViewportComponentTableContext() {
 
             @Override
+            public int viewportGridWidth() {
+                return (int)WIDTH.pixelValue();
+            }
+
+            @Override
+            public int viewportGridHeight() {
+                return (int)HEIGHT.pixelValue();
+            }
+
+            @Override
             public HistoryToken historyToken() {
                 return historyToken;
             }
@@ -205,10 +218,10 @@ public final class SpreadsheetViewportComponentTableRowColumnHeadersTest extends
             SpreadsheetMetadataPropertyName.STYLE,
             TextStyle.EMPTY.set(
                 TextStylePropertyName.WIDTH,
-                Length.parse("100px")
+                WIDTH
             ).set(
                 TextStylePropertyName.HEIGHT,
-                Length.parse("50px")
+                HEIGHT
             )
         );
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportComponentTableTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportComponentTableTest.java
@@ -115,22 +115,7 @@ public final class SpreadsheetViewportComponentTableTest implements HtmlComponen
                 "              id=\"viewport-cell-B2\" tabIndex=0 style=\"box-sizing: border-box; color: white; height: 50px; min-height: 50px; min-width: 100px; width: 100px;\"\n" +
                 "          SpreadsheetViewportComponentTableCellSpreadsheetCell\n" +
                 "            TD\n" +
-                "              id=\"viewport-cell-C2\" tabIndex=0 style=\"box-sizing: border-box; color: white; height: 50px; min-height: 50px; min-width: 100px; width: 100px;\"\n" +
-                "      SpreadsheetViewportComponentTableRowCells\n" +
-                "        TR\n" +
-                "          SpreadsheetViewportComponentTableCellHeaderSpreadsheetRow\n" +
-                "            TH\n" +
-                "              id=\"viewport-row-3\" style=\"box-sizing: border-box; color: #333333; height: 50px; min-height: 50px; min-width: 80px; width: 80px;\"\n" +
-                "                \"3\" [#/1/SpreadsheetName222/row/3] id=viewport-row-3-Link\n" +
-                "          SpreadsheetViewportComponentTableCellSpreadsheetCell\n" +
-                "            TD\n" +
-                "              id=\"viewport-cell-A3\" tabIndex=0 style=\"box-sizing: border-box; color: white; height: 50px; min-height: 50px; min-width: 100px; width: 100px;\"\n" +
-                "          SpreadsheetViewportComponentTableCellSpreadsheetCell\n" +
-                "            TD\n" +
-                "              id=\"viewport-cell-B3\" tabIndex=0 style=\"box-sizing: border-box; color: white; height: 50px; min-height: 50px; min-width: 100px; width: 100px;\"\n" +
-                "          SpreadsheetViewportComponentTableCellSpreadsheetCell\n" +
-                "            TD\n" +
-                "              id=\"viewport-cell-C3\" tabIndex=0 style=\"box-sizing: border-box; color: white; height: 50px; min-height: 50px; min-width: 100px; width: 100px;\"\n"
+                "              id=\"viewport-cell-C2\" tabIndex=0 style=\"box-sizing: border-box; color: white; height: 50px; min-height: 50px; min-width: 100px; width: 100px;\"\n"
         );
 
         this.checkEquals(
@@ -199,22 +184,7 @@ public final class SpreadsheetViewportComponentTableTest implements HtmlComponen
                 "              id=\"viewport-cell-B2\" tabIndex=0 style=\"box-sizing: border-box; color: white; height: 50px; min-height: 50px; min-width: 100px; width: 100px;\"\n" +
                 "          SpreadsheetViewportComponentTableCellSpreadsheetCell\n" +
                 "            TD\n" +
-                "              id=\"viewport-cell-C2\" tabIndex=0 style=\"box-sizing: border-box; color: white; height: 50px; min-height: 50px; min-width: 100px; width: 100px;\"\n" +
-                "      SpreadsheetViewportComponentTableRowCells\n" +
-                "        TR\n" +
-                "          SpreadsheetViewportComponentTableCellHeaderSpreadsheetRow\n" +
-                "            TH\n" +
-                "              id=\"viewport-row-3\" style=\"box-sizing: border-box; color: #333333; height: 50px; min-height: 50px; min-width: 80px; width: 80px;\"\n" +
-                "                \"3\" [#/1/SpreadsheetName222/row/3] id=viewport-row-3-Link\n" +
-                "          SpreadsheetViewportComponentTableCellSpreadsheetCell\n" +
-                "            TD\n" +
-                "              id=\"viewport-cell-A3\" tabIndex=0 style=\"box-sizing: border-box; color: white; height: 50px; min-height: 50px; min-width: 100px; width: 100px;\"\n" +
-                "          SpreadsheetViewportComponentTableCellSpreadsheetCell\n" +
-                "            TD\n" +
-                "              id=\"viewport-cell-B3\" tabIndex=0 style=\"box-sizing: border-box; color: white; height: 50px; min-height: 50px; min-width: 100px; width: 100px;\"\n" +
-                "          SpreadsheetViewportComponentTableCellSpreadsheetCell\n" +
-                "            TD\n" +
-                "              id=\"viewport-cell-C3\" tabIndex=0 style=\"box-sizing: border-box; color: white; height: 50px; min-height: 50px; min-width: 100px; width: 100px;\"\n"
+                "              id=\"viewport-cell-C2\" tabIndex=0 style=\"box-sizing: border-box; color: white; height: 50px; min-height: 50px; min-width: 100px; width: 100px;\"\n"
         );
 
         this.checkEquals(
@@ -254,6 +224,16 @@ public final class SpreadsheetViewportComponentTableTest implements HtmlComponen
         };
 
         final SpreadsheetViewportComponentTableContext tableContext = new FakeSpreadsheetViewportComponentTableContext() {
+
+            @Override
+            public int viewportGridWidth() {
+                return 4 * SpreadsheetViewportContext.ROW_HEADER_WIDTH_PIXELS;
+            }
+
+            @Override
+            public int viewportGridHeight() {
+                return 4 * SpreadsheetViewportContext.COLUMN_HEADER_HEIGHT_PIXELS;
+            }
 
             @Override
             public HistoryToken historyToken() {

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportComponentTest.java
@@ -295,10 +295,6 @@ public final class SpreadsheetViewportComponentTest implements HtmlComponentTest
                 "              TH\n" +
                 "                id=\"viewport-column-A\" style=\"background-color: #333333; box-sizing: border-box; height: 30px; min-height: 30px; min-width: 50px; width: 50px;\"\n" +
                 "                  \"A\" [#/1/SpreadsheetName111/column/A] id=viewport-column-A-Link\n" +
-                "            SpreadsheetViewportComponentTableCellHeaderSpreadsheetColumn\n" +
-                "              TH\n" +
-                "                id=\"viewport-column-B\" style=\"background-color: #222222; box-sizing: border-box; height: 30px; min-height: 30px; min-width: 50px; width: 50px;\"\n" +
-                "                  \"B\" [#/1/SpreadsheetName111/column/B] id=viewport-column-B-Link\n" +
                 "      TBODY\n" +
                 "        SpreadsheetViewportComponentTableRowCells\n" +
                 "          TR\n" +
@@ -310,9 +306,6 @@ public final class SpreadsheetViewportComponentTest implements HtmlComponentTest
                 "              TD\n" +
                 "                id=\"viewport-cell-A1\" tabIndex=0 style=\"box-sizing: border-box; color: black; height: 50px; min-height: 50px; min-width: 50px; width: 50px;\"\n" +
                 "                  Text \"*** 3.0\"\n" +
-                "            SpreadsheetViewportComponentTableCellSpreadsheetCell\n" +
-                "              TD\n" +
-                "                id=\"viewport-cell-B1\" tabIndex=0 style=\"background-color: white; box-sizing: border-box; height: 50px; min-height: 50px; min-width: 50px; width: 50px;\"\n" +
                 "        SpreadsheetViewportComponentTableRowCells\n" +
                 "          TR\n" +
                 "            SpreadsheetViewportComponentTableCellHeaderSpreadsheetRow\n" +
@@ -322,9 +315,6 @@ public final class SpreadsheetViewportComponentTest implements HtmlComponentTest
                 "            SpreadsheetViewportComponentTableCellSpreadsheetCell\n" +
                 "              TD\n" +
                 "                id=\"viewport-cell-A2\" tabIndex=0 style=\"background-color: white; box-sizing: border-box; height: 50px; min-height: 50px; min-width: 50px; width: 50px;\"\n" +
-                "            SpreadsheetViewportComponentTableCellSpreadsheetCell\n" +
-                "              TD\n" +
-                "                id=\"viewport-cell-B2\" tabIndex=0 style=\"background-color: white; box-sizing: border-box; height: 50px; min-height: 50px; min-width: 50px; width: 50px;\"\n" +
                 "  SpreadsheetViewportScrollbarComponentRows\n" +
                 "    FlexLayoutComponent\n" +
                 "      COLUMN\n" +
@@ -375,10 +365,6 @@ public final class SpreadsheetViewportComponentTest implements HtmlComponentTest
                 "              TH\n" +
                 "                id=\"viewport-column-A\" style=\"background-color: #333333; box-sizing: border-box; height: 30px; min-height: 30px; min-width: 50px; width: 50px;\"\n" +
                 "                  \"A\" [#/1/SpreadsheetName111/column/A] id=viewport-column-A-Link\n" +
-                "            SpreadsheetViewportComponentTableCellHeaderSpreadsheetColumn\n" +
-                "              TH\n" +
-                "                id=\"viewport-column-B\" style=\"background-color: #222222; box-sizing: border-box; height: 30px; min-height: 30px; min-width: 50px; width: 50px;\"\n" +
-                "                  \"B\" [#/1/SpreadsheetName111/column/B] id=viewport-column-B-Link\n" +
                 "      TBODY\n" +
                 "        SpreadsheetViewportComponentTableRowCells\n" +
                 "          TR\n" +
@@ -390,9 +376,6 @@ public final class SpreadsheetViewportComponentTest implements HtmlComponentTest
                 "              TD\n" +
                 "                id=\"viewport-cell-A1\" tabIndex=0 style=\"box-sizing: border-box; color: black; height: 50px; min-height: 50px; min-width: 50px; width: 50px;\"\n" +
                 "                  Text \"*** 3.0\"\n" +
-                "            SpreadsheetViewportComponentTableCellSpreadsheetCell\n" +
-                "              TD\n" +
-                "                id=\"viewport-cell-B1\" tabIndex=0 style=\"background-color: white; box-sizing: border-box; height: 50px; min-height: 50px; min-width: 50px; width: 50px;\"\n" +
                 "        SpreadsheetViewportComponentTableRowCells\n" +
                 "          TR\n" +
                 "            SpreadsheetViewportComponentTableCellHeaderSpreadsheetRow\n" +
@@ -402,9 +385,6 @@ public final class SpreadsheetViewportComponentTest implements HtmlComponentTest
                 "            SpreadsheetViewportComponentTableCellSpreadsheetCell\n" +
                 "              TD\n" +
                 "                id=\"viewport-cell-A2\" tabIndex=0 style=\"box-sizing: border-box; color: black; height: 50px; min-height: 50px; min-width: 50px; width: 50px;\"\n" +
-                "            SpreadsheetViewportComponentTableCellSpreadsheetCell\n" +
-                "              TD\n" +
-                "                id=\"viewport-cell-B2\" tabIndex=0 style=\"background-color: white; box-sizing: border-box; height: 50px; min-height: 50px; min-width: 50px; width: 50px;\"\n" +
                 "  SpreadsheetViewportScrollbarComponentRows\n" +
                 "    FlexLayoutComponent\n" +
                 "      COLUMN\n" +
@@ -455,10 +435,6 @@ public final class SpreadsheetViewportComponentTest implements HtmlComponentTest
                 "              TH\n" +
                 "                id=\"viewport-column-A\" style=\"background-color: #222222; box-sizing: border-box; height: 30px; min-height: 30px; min-width: 50px; width: 50px;\"\n" +
                 "                  \"A\" [#/1/SpreadsheetName111/column/A] id=viewport-column-A-Link\n" +
-                "            SpreadsheetViewportComponentTableCellHeaderSpreadsheetColumn\n" +
-                "              TH\n" +
-                "                id=\"viewport-column-B\" style=\"background-color: #222222; box-sizing: border-box; height: 30px; min-height: 30px; min-width: 50px; width: 50px;\"\n" +
-                "                  \"B\" [#/1/SpreadsheetName111/column/B] id=viewport-column-B-Link\n" +
                 "      TBODY\n" +
                 "        SpreadsheetViewportComponentTableRowCells\n" +
                 "          TR\n" +
@@ -470,9 +446,6 @@ public final class SpreadsheetViewportComponentTest implements HtmlComponentTest
                 "              TD\n" +
                 "                id=\"viewport-cell-A1\" tabIndex=0 style=\"box-sizing: border-box; color: black; height: 50px; min-height: 50px; min-width: 50px; width: 50px;\"\n" +
                 "                  Text \"*** 3.0\"\n" +
-                "            SpreadsheetViewportComponentTableCellSpreadsheetCell\n" +
-                "              TD\n" +
-                "                id=\"viewport-cell-B1\" tabIndex=0 style=\"box-sizing: border-box; color: black; height: 50px; min-height: 50px; min-width: 50px; width: 50px;\"\n" +
                 "        SpreadsheetViewportComponentTableRowCells\n" +
                 "          TR\n" +
                 "            SpreadsheetViewportComponentTableCellHeaderSpreadsheetRow\n" +
@@ -482,9 +455,6 @@ public final class SpreadsheetViewportComponentTest implements HtmlComponentTest
                 "            SpreadsheetViewportComponentTableCellSpreadsheetCell\n" +
                 "              TD\n" +
                 "                id=\"viewport-cell-A2\" tabIndex=0 style=\"background-color: white; box-sizing: border-box; height: 50px; min-height: 50px; min-width: 50px; width: 50px;\"\n" +
-                "            SpreadsheetViewportComponentTableCellSpreadsheetCell\n" +
-                "              TD\n" +
-                "                id=\"viewport-cell-B2\" tabIndex=0 style=\"background-color: white; box-sizing: border-box; height: 50px; min-height: 50px; min-width: 50px; width: 50px;\"\n" +
                 "  SpreadsheetViewportScrollbarComponentRows\n" +
                 "    FlexLayoutComponent\n" +
                 "      COLUMN\n" +


### PR DESCRIPTION
- Previously was often rendering an extra column or row past the scrollbars and offscreen.