### PR TITLE
SpreadsheetNavigateDialogComponent

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/AppSpreadsheetDialogComponents.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/AppSpreadsheetDialogComponents.java
@@ -50,6 +50,8 @@ import walkingkooka.spreadsheet.dominokit.label.SpreadsheetLabelMappingListDialo
 import walkingkooka.spreadsheet.dominokit.label.SpreadsheetLabelMappingListDialogComponentContexts;
 import walkingkooka.spreadsheet.dominokit.locale.SpreadsheetLocaleDialogComponent;
 import walkingkooka.spreadsheet.dominokit.locale.SpreadsheetLocaleDialogComponentContexts;
+import walkingkooka.spreadsheet.dominokit.navigate.SpreadsheetNavigateDialogComponent;
+import walkingkooka.spreadsheet.dominokit.navigate.SpreadsheetNavigateDialogComponentContexts;
 import walkingkooka.spreadsheet.dominokit.parser.SpreadsheetParserSelectorDialogComponent;
 import walkingkooka.spreadsheet.dominokit.parser.SpreadsheetParserSelectorDialogComponentContexts;
 import walkingkooka.spreadsheet.dominokit.plugin.JarEntryInfoListDialogComponent;
@@ -106,6 +108,8 @@ final class AppSpreadsheetDialogComponents implements PublicStaticHelper {
         label(context);
 
         locale(context);
+
+        navigate(context);
 
         sort(context);
     }
@@ -331,6 +335,24 @@ final class AppSpreadsheetDialogComponents implements PublicStaticHelper {
         );
         PluginAliasSetLikeDialogComponent.with(
             PluginAliasSetLikeDialogComponentContexts.validatorValidators(context)
+        );
+    }
+
+    private static void navigate(final AppContext context) {
+        SpreadsheetNavigateDialogComponent.with(
+            SpreadsheetNavigateDialogComponentContexts.cellNavigate(context)
+        );
+
+        SpreadsheetNavigateDialogComponent.with(
+            SpreadsheetNavigateDialogComponentContexts.columnNavigate(context)
+        );
+
+        SpreadsheetNavigateDialogComponent.with(
+            SpreadsheetNavigateDialogComponentContexts.navigate(context)
+        );
+
+        SpreadsheetNavigateDialogComponent.with(
+            SpreadsheetNavigateDialogComponentContexts.rowNavigate(context)
         );
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/navigate/SpreadsheetNavigateDialogComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/navigate/SpreadsheetNavigateDialogComponent.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.dominokit.navigate;
+
+import walkingkooka.spreadsheet.dominokit.AppContext;
+import walkingkooka.spreadsheet.dominokit.ComponentLifecycleMatcher;
+import walkingkooka.spreadsheet.dominokit.ComponentLifecycleMatcherDelegator;
+import walkingkooka.spreadsheet.dominokit.RefreshContext;
+import walkingkooka.spreadsheet.dominokit.SpreadsheetElementIds;
+import walkingkooka.spreadsheet.dominokit.cell.SpreadsheetCellReferenceComponent;
+import walkingkooka.spreadsheet.dominokit.dialog.DialogComponent;
+import walkingkooka.spreadsheet.dominokit.dialog.DialogComponentLifecycle;
+import walkingkooka.spreadsheet.dominokit.fetcher.NopEmptyResponseFetcherWatcher;
+import walkingkooka.spreadsheet.dominokit.fetcher.NopFetcherWatcher;
+import walkingkooka.spreadsheet.dominokit.fetcher.SpreadsheetMetadataFetcherWatcher;
+import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
+import walkingkooka.spreadsheet.dominokit.history.HistoryTokenAnchorComponent;
+import walkingkooka.spreadsheet.dominokit.history.LoadedSpreadsheetMetadataRequired;
+import walkingkooka.spreadsheet.dominokit.link.AnchorListComponent;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
+import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.viewport.SpreadsheetViewportHomeNavigationList;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * A modal dialog that supports editing a navigation target.
+ */
+public final class SpreadsheetNavigateDialogComponent implements DialogComponentLifecycle,
+    LoadedSpreadsheetMetadataRequired,
+    NopFetcherWatcher,
+    NopEmptyResponseFetcherWatcher,
+    ComponentLifecycleMatcherDelegator,
+    SpreadsheetMetadataFetcherWatcher {
+
+    /**
+     * Creates a new {@link SpreadsheetNavigateDialogComponent}.
+     */
+    public static SpreadsheetNavigateDialogComponent with(final SpreadsheetNavigateDialogComponentContext context) {
+        return new SpreadsheetNavigateDialogComponent(
+            Objects.requireNonNull(context, "context")
+        );
+    }
+
+    private SpreadsheetNavigateDialogComponent(final SpreadsheetNavigateDialogComponentContext context) {
+        this.context = context;
+        context.addHistoryTokenWatcher(this);
+        context.addSpreadsheetMetadataFetcherWatcher(this);
+
+        final String idPrefix = this.idPrefix();
+
+        this.home = SpreadsheetCellReferenceComponent.with(
+            idPrefix + "home" + SpreadsheetElementIds.TEXT_BOX
+        ).addKeyUpListener(
+            (e) -> this.refreshLinks()
+        ).addChangeListener(
+            (oldValue, newValue) -> this.refreshLinks(newValue)
+        );
+
+        this.save = HistoryTokenAnchorComponent.empty()
+            .setId(
+                idPrefix +
+                    "save" +
+                    SpreadsheetElementIds.LINK
+            ).setTextContent("Save");
+        this.undo = HistoryTokenAnchorComponent.empty()
+            .setId(
+                idPrefix +
+                    "undo" +
+                    SpreadsheetElementIds.LINK
+            ).setTextContent("Undo");
+
+        this.close = this.closeAnchor();
+
+        this.dialog = this.dialogCreate();
+    }
+
+    // ids..............................................................................................................
+
+    @Override
+    public String idPrefix() {
+        return ID + "-";
+    }
+
+    private final static String ID = "navigate";
+
+    // dialog...........................................................................................................
+
+    private DialogComponent dialogCreate() {
+        final SpreadsheetNavigateDialogComponentContext context = this.context;
+
+        return DialogComponent.smallerPrompt(
+                ID + SpreadsheetElementIds.DIALOG,
+                DialogComponent.INCLUDE_CLOSE,
+                context
+            ).setTitle(
+                context.dialogTitle()
+            ).appendChild(this.home)
+            .appendChild(
+                AnchorListComponent.empty()
+                    .appendChild(this.save)
+                    .appendChild(this.undo)
+                    .appendChild(this.close)
+            );
+    }
+
+    @Override
+    public DialogComponent dialog() {
+        return this.dialog;
+    }
+
+    private final DialogComponent dialog;
+
+    // ComponentLifecycleMatcherDelegator...............................................................................
+
+    @Override
+    public ComponentLifecycleMatcher componentLifecycleMatcher() {
+        return this.context;
+    }
+
+    // dialog links.....................................................................................................
+
+    private final SpreadsheetCellReferenceComponent home;
+
+    private final HistoryTokenAnchorComponent save;
+
+    private final HistoryTokenAnchorComponent undo;
+
+    /**
+     * A CLOSE link which will close the dialog.
+     */
+    private final HistoryTokenAnchorComponent close;
+
+    // DialogComponentLifecycle.........................................................................................
+
+    @Override
+    public void dialogReset() {
+        this.undo.clear();
+    }
+
+    @Override
+    public void openGiveFocus(final RefreshContext context) {
+        final SpreadsheetCellReference home = this.context.spreadsheetMetadata()
+            .getOrFail(SpreadsheetMetadataPropertyName.VIEWPORT)
+            .rectangle()
+            .home();
+
+        this.undo.setValue(
+            Optional.of(
+                context.historyToken()
+                    .setNavigation(
+                        Optional.of(
+                            SpreadsheetViewportHomeNavigationList.with(home)
+                        )
+                    )
+            )
+        );
+        context.giveFocus(
+            this.home::focus
+        );
+    }
+
+    @Override
+    public void refresh(final RefreshContext context) {
+        this.context.refreshDialogTitle(this);
+
+        this.refreshLinks();
+    }
+
+    private void refreshLinks() {
+        this.refreshLinks(
+            this.home.value()
+        );
+    }
+
+    private void refreshLinks(final Optional<SpreadsheetCellReference> cell) {
+        final SpreadsheetNavigateDialogComponentContext context = this.context;
+
+        final HistoryToken historyToken = context.historyToken();
+
+        this.save.setValue(
+            cell.map(
+                c ->
+                    historyToken.setNavigation(
+                        Optional.of(
+                            SpreadsheetViewportHomeNavigationList.with(c)
+                        )
+                    )
+            )
+        );
+
+        this.close.setHistoryToken(
+            Optional.of(
+                historyToken.close()
+            )
+        );
+    }
+
+    // SpreadsheetMetadataFetcherWatcher................................................................................
+
+    @Override
+    public void onSpreadsheetMetadata(final SpreadsheetMetadata metadata,
+                                      final AppContext context) {
+        this.refreshIfOpen(context);
+    }
+
+    @Override
+    public void onSpreadsheetMetadataSet(final Set<SpreadsheetMetadata> metadatas,
+                                         final AppContext context) {
+        // ignore
+    }
+
+    private final SpreadsheetNavigateDialogComponentContext context;
+}

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/navigate/SpreadsheetNavigateDialogComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/navigate/SpreadsheetNavigateDialogComponentTest.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.dominokit.navigate;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.spreadsheet.dominokit.FakeAppContext;
+import walkingkooka.spreadsheet.dominokit.dialog.DialogComponentLifecycleTesting;
+import walkingkooka.spreadsheet.dominokit.fetcher.SpreadsheetMetadataFetcherWatcher;
+import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
+import walkingkooka.spreadsheet.dominokit.history.HistoryTokenWatcher;
+import walkingkooka.spreadsheet.dominokit.history.HistoryTokenWatchers;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataTesting;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+import walkingkooka.spreadsheet.viewport.SpreadsheetViewport;
+import walkingkooka.spreadsheet.viewport.SpreadsheetViewportRectangle;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public final class SpreadsheetNavigateDialogComponentTest implements DialogComponentLifecycleTesting<SpreadsheetNavigateDialogComponent> {
+
+    // with.............................................................................................................
+
+    @Test
+    public void testWithNullContextFails() {
+        assertThrows(
+            NullPointerException.class,
+            () -> SpreadsheetNavigateDialogComponent.with(null)
+        );
+    }
+
+    // navigate.........................................................................................................
+
+    @Test
+    public void testOnHistoryTokenWithSpreadsheetSelect() {
+        final TestAppContext context = new TestAppContext(
+            HistoryToken.spreadsheetSelect(
+                SPREADSHEET_ID,
+                SPREADSHEET_NAME
+            )
+        );
+
+        final SpreadsheetNavigateDialogComponent dialog = SpreadsheetNavigateDialogComponent.with(
+            SpreadsheetNavigateDialogComponentContexts.navigate(context)
+        );
+
+        // initially empty
+        this.onHistoryTokenChangeAndCheck(
+            dialog,
+            context,
+            "SpreadsheetNavigateDialogComponent\n" +
+                "  DialogComponent\n" +
+                "    Spreadsheet: Navigate\n" +
+                "    id=navigate-Dialog includeClose=true CLOSED\n" +
+                "      SpreadsheetCellReferenceComponent\n" +
+                "        ValueTextBoxComponent\n" +
+                "          TextBoxComponent\n" +
+                "            [] id=navigate-home-TextBox\n" +
+                "            Errors\n" +
+                "              End of text at (1,1) expected CELL\n" +
+                "      AnchorListComponent\n" +
+                "        FlexLayoutComponent\n" +
+                "          ROW\n" +
+                "            \"Save\" DISABLED id=navigate-save-Link\n" +
+                "            \"Undo\" DISABLED id=navigate-undo-Link\n" +
+                "            \"Close\" DISABLED id=navigate-close-Link\n"
+        );
+    }
+
+    @Test
+    public void testOnHistoryTokenWithSpreadsheetNavigate() {
+        final TestAppContext context = new TestAppContext(
+            HistoryToken.navigate(
+                SPREADSHEET_ID,
+                SPREADSHEET_NAME,
+                Optional.empty()
+            )
+        );
+
+        final SpreadsheetNavigateDialogComponent dialog = SpreadsheetNavigateDialogComponent.with(
+            SpreadsheetNavigateDialogComponentContexts.navigate(context)
+        );
+
+        // initially empty
+        this.onHistoryTokenChangeAndCheck(
+            dialog,
+            context,
+            "SpreadsheetNavigateDialogComponent\n" +
+                "  DialogComponent\n" +
+                "    Spreadsheet: Navigate\n" +
+                "    id=navigate-Dialog includeClose=true\n" +
+                "      SpreadsheetCellReferenceComponent\n" +
+                "        ValueTextBoxComponent\n" +
+                "          TextBoxComponent\n" +
+                "            [] id=navigate-home-TextBox\n" +
+                "            Errors\n" +
+                "              End of text at (1,1) expected CELL\n" +
+                "      AnchorListComponent\n" +
+                "        FlexLayoutComponent\n" +
+                "          ROW\n" +
+                "            \"Save\" DISABLED id=navigate-save-Link\n" +
+                "            \"Undo\" [#/1/SpreadsheetName1/navigate/A1] id=navigate-undo-Link\n" +
+                "            \"Close\" [#/1/SpreadsheetName1] id=navigate-close-Link\n"
+        );
+    }
+
+    @Test
+    public void testOnHistoryTokenWithSpreadsheetCellNavigate() {
+        final TestAppContext context = new TestAppContext(
+            HistoryToken.cellNavigate(
+                SPREADSHEET_ID,
+                SPREADSHEET_NAME,
+                SpreadsheetSelection.parseCell("B2")
+                    .setDefaultAnchor(),
+                Optional.empty()
+            )
+        );
+
+        final SpreadsheetNavigateDialogComponent dialog = SpreadsheetNavigateDialogComponent.with(
+            SpreadsheetNavigateDialogComponentContexts.cellNavigate(context)
+        );
+
+        // initially empty
+        this.onHistoryTokenChangeAndCheck(
+            dialog,
+            context,
+            "SpreadsheetNavigateDialogComponent\n" +
+                "  DialogComponent\n" +
+                "    B2: Navigate\n" +
+                "    id=navigate-Dialog includeClose=true\n" +
+                "      SpreadsheetCellReferenceComponent\n" +
+                "        ValueTextBoxComponent\n" +
+                "          TextBoxComponent\n" +
+                "            [] id=navigate-home-TextBox\n" +
+                "            Errors\n" +
+                "              End of text at (1,1) expected CELL\n" +
+                "      AnchorListComponent\n" +
+                "        FlexLayoutComponent\n" +
+                "          ROW\n" +
+                "            \"Save\" DISABLED id=navigate-save-Link\n" +
+                "            \"Undo\" [#/1/SpreadsheetName1/cell/B2/navigate/A1] id=navigate-undo-Link\n" +
+                "            \"Close\" [#/1/SpreadsheetName1/cell/B2] id=navigate-close-Link\n"
+        );
+    }
+
+    @Test
+    public void testOnHistoryTokenWithSpreadsheetColumnNavigate() {
+        final TestAppContext context = new TestAppContext(
+            HistoryToken.columnNavigate(
+                SPREADSHEET_ID,
+                SPREADSHEET_NAME,
+                SpreadsheetSelection.parseColumn("C")
+                    .setDefaultAnchor(),
+                Optional.empty()
+            )
+        );
+
+        final SpreadsheetNavigateDialogComponent dialog = SpreadsheetNavigateDialogComponent.with(
+            SpreadsheetNavigateDialogComponentContexts.columnNavigate(context)
+        );
+
+        // initially empty
+        this.onHistoryTokenChangeAndCheck(
+            dialog,
+            context,
+            "SpreadsheetNavigateDialogComponent\n" +
+                "  DialogComponent\n" +
+                "    C: Navigate\n" +
+                "    id=navigate-Dialog includeClose=true\n" +
+                "      SpreadsheetCellReferenceComponent\n" +
+                "        ValueTextBoxComponent\n" +
+                "          TextBoxComponent\n" +
+                "            [] id=navigate-home-TextBox\n" +
+                "            Errors\n" +
+                "              End of text at (1,1) expected CELL\n" +
+                "      AnchorListComponent\n" +
+                "        FlexLayoutComponent\n" +
+                "          ROW\n" +
+                "            \"Save\" DISABLED id=navigate-save-Link\n" +
+                "            \"Undo\" [#/1/SpreadsheetName1/column/C/navigate/A1] id=navigate-undo-Link\n" +
+                "            \"Close\" [#/1/SpreadsheetName1/column/C] id=navigate-close-Link\n"
+        );
+    }
+
+    @Test
+    public void testOnHistoryTokenWithSpreadsheetRowNavigate() {
+        final TestAppContext context = new TestAppContext(
+            HistoryToken.rowNavigate(
+                SPREADSHEET_ID,
+                SPREADSHEET_NAME,
+                SpreadsheetSelection.parseRow("99")
+                    .setDefaultAnchor(),
+                Optional.empty()
+            )
+        );
+
+        final SpreadsheetNavigateDialogComponent dialog = SpreadsheetNavigateDialogComponent.with(
+            SpreadsheetNavigateDialogComponentContexts.rowNavigate(context)
+        );
+
+        // initially empty
+        this.onHistoryTokenChangeAndCheck(
+            dialog,
+            context,
+            "SpreadsheetNavigateDialogComponent\n" +
+                "  DialogComponent\n" +
+                "    99: Navigate\n" +
+                "    id=navigate-Dialog includeClose=true\n" +
+                "      SpreadsheetCellReferenceComponent\n" +
+                "        ValueTextBoxComponent\n" +
+                "          TextBoxComponent\n" +
+                "            [] id=navigate-home-TextBox\n" +
+                "            Errors\n" +
+                "              End of text at (1,1) expected CELL\n" +
+                "      AnchorListComponent\n" +
+                "        FlexLayoutComponent\n" +
+                "          ROW\n" +
+                "            \"Save\" DISABLED id=navigate-save-Link\n" +
+                "            \"Undo\" [#/1/SpreadsheetName1/row/99/navigate/A1] id=navigate-undo-Link\n" +
+                "            \"Close\" [#/1/SpreadsheetName1/row/99] id=navigate-close-Link\n"
+        );
+    }
+
+    final static class TestAppContext extends FakeAppContext {
+
+        TestAppContext(final HistoryToken historyToken) {
+            this.historyToken = historyToken;
+        }
+
+        @Override
+        public Runnable addHistoryTokenWatcher(final HistoryTokenWatcher watcher) {
+            return this.historyTokenWatchers.add(watcher);
+        }
+
+        private final HistoryTokenWatchers historyTokenWatchers = HistoryTokenWatchers.empty();
+
+        @Override
+        public Runnable addSpreadsheetMetadataFetcherWatcher(final SpreadsheetMetadataFetcherWatcher watcher) {
+            return null;
+        }
+
+        @Override
+        public HistoryToken historyToken() {
+            return historyToken;
+        }
+
+        private final HistoryToken historyToken;
+
+        @Override
+        public SpreadsheetMetadata spreadsheetMetadata() {
+            return SpreadsheetMetadataTesting.METADATA_EN_AU.set(
+                SpreadsheetMetadataPropertyName.SPREADSHEET_ID,
+                SPREADSHEET_ID
+            ).set(
+                SpreadsheetMetadataPropertyName.SPREADSHEET_NAME,
+                SPREADSHEET_NAME
+            ).set(
+                SpreadsheetMetadataPropertyName.VIEWPORT,
+                SpreadsheetViewport.with(
+                    SpreadsheetViewportRectangle.with(
+                        SpreadsheetSelection.A1,
+                        100, // width
+                        200 // height
+                    )
+                )
+            );
+        }
+
+        @Override
+        public void giveFocus(final Runnable focus) {
+            // NOP
+        }
+
+        @Override
+        public String toString() {
+            return this.historyToken.toString();
+        }
+    }
+
+    @Override
+    public SpreadsheetNavigateDialogComponent createSpreadsheetDialogComponentLifecycle(final HistoryToken historyToken) {
+        return SpreadsheetNavigateDialogComponent.with(
+            new FakeSpreadsheetNavigateDialogComponentContext() {
+                @Override
+                public String dialogTitle() {
+                    return "Title123";
+                }
+
+                @Override
+                public Runnable addHistoryTokenWatcher(final HistoryTokenWatcher watcher) {
+                    return null;
+                }
+
+                @Override
+                public Runnable addSpreadsheetMetadataFetcherWatcher(final SpreadsheetMetadataFetcherWatcher watcher) {
+                    return null;
+                }
+
+                @Override
+                public HistoryToken historyToken() {
+                    return historyToken;
+                }
+            }
+        );
+    }
+
+    @Override
+    public void testShouldIgnoreWithSpreadsheetCellSelectHistoryToken() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void testIsMatchWithSpreadsheetCellSelectHistoryToken() {
+        throw new UnsupportedOperationException();
+    }
+
+    // class............................................................................................................
+
+    @Override
+    public Class<SpreadsheetNavigateDialogComponent> type() {
+        return SpreadsheetNavigateDialogComponent.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PUBLIC;
+    }
+}


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/6083
- SpreadsheetXXXNavigateHistoryToken should display Dialog when SpreadsheetViewportHomeNavigationList missing

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/5966
- if SpreadsheetXXXHistoryToken has empty SpreadsheetNavigationList it should prompt user to enter new SpreadsheetViewport home