### PR TITLE
SpreadsheetFormatterFetcher.cellFormatterEditUrl selector url FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/fetcher/SpreadsheetFormatterFetcher.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/fetcher/SpreadsheetFormatterFetcher.java
@@ -107,7 +107,7 @@ public final class SpreadsheetFormatterFetcher extends Fetcher<SpreadsheetFormat
             selector.isEmpty() ?
                 FORMATTER_EDIT :
                 FORMATTER_EDIT.append(
-                    UrlPathName.with(selector)
+                    UrlPath.parse(selector)
                 )
         );
     }


### PR DESCRIPTION
- Closes SpreadsheetFormatterFetcher-cellFormatterEditUrl-selector-url-FIX
- SpreadsheetFormatterFetcher.cellFormatterEditUrl replace UrlPathName with UrlPath