### PR TITLE
ValidatorSelectorDialogComponent display server errors

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/validator/AppContextValidatorSelectorDialogComponentContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/validator/AppContextValidatorSelectorDialogComponentContext.java
@@ -22,6 +22,7 @@ import walkingkooka.spreadsheet.dominokit.AppContext;
 import walkingkooka.spreadsheet.dominokit.dialog.DialogComponentContext;
 import walkingkooka.spreadsheet.dominokit.dialog.DialogComponentContextDelegator;
 import walkingkooka.spreadsheet.dominokit.dialog.DialogComponentContexts;
+import walkingkooka.spreadsheet.dominokit.fetcher.SpreadsheetDeltaFetcherWatcher;
 import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
 import walkingkooka.spreadsheet.dominokit.history.SpreadsheetCellValidatorSaveHistoryToken;
 import walkingkooka.spreadsheet.dominokit.history.SpreadsheetCellValidatorSelectHistoryToken;
@@ -74,6 +75,11 @@ final class AppContextValidatorSelectorDialogComponentContext implements Validat
         }
 
         return selector;
+    }
+
+    @Override
+    public Runnable addSpreadsheetDeltaFetcherWatcher(final SpreadsheetDeltaFetcherWatcher watcher) {
+        return this.context.addSpreadsheetDeltaFetcherWatcher(watcher);
     }
 
     // DialogComponentContext...........................................................................................

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/validator/FakeValidatorSelectorDialogComponentContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/validator/FakeValidatorSelectorDialogComponentContext.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.dominokit.validator;
 
 import walkingkooka.spreadsheet.dominokit.dialog.FakeDialogComponentContext;
+import walkingkooka.spreadsheet.dominokit.fetcher.SpreadsheetDeltaFetcherWatcher;
 import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
 import walkingkooka.validation.provider.ValidatorSelector;
 
@@ -46,6 +47,11 @@ public class FakeValidatorSelectorDialogComponentContext extends FakeDialogCompo
 
     @Override
     public Optional<ValidatorSelector> undo() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Runnable addSpreadsheetDeltaFetcherWatcher(final SpreadsheetDeltaFetcherWatcher watcher) {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/validator/ValidatorSelectorDialogComponentContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/validator/ValidatorSelectorDialogComponentContext.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.dominokit.validator;
 
 import walkingkooka.spreadsheet.dominokit.ComponentLifecycleMatcher;
 import walkingkooka.spreadsheet.dominokit.dialog.DialogComponentContext;
+import walkingkooka.spreadsheet.dominokit.fetcher.SpreadsheetDeltaFetcherWatcher;
 import walkingkooka.validation.provider.ValidatorSelector;
 
 import java.util.Optional;
@@ -28,6 +29,8 @@ import java.util.Optional;
  */
 public interface ValidatorSelectorDialogComponentContext extends ComponentLifecycleMatcher,
     DialogComponentContext {
+
+    Runnable addSpreadsheetDeltaFetcherWatcher(final SpreadsheetDeltaFetcherWatcher watcher);
 
     /**
      * Provides the UNDO text.


### PR DESCRIPTION
- The selector field now displays any errors returned for the selected cell.
- Previously the selector field only showed basic ValidatorSelector.parse error messages.
- ValidatorSelectorDialogComponentContext#addSpreadsheetDeltaFetcherWatcher