### PR TITLE
SpreadsheetLocaleComponent: Missing server locales language tag omit …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,9 +215,13 @@
                             <version>1.0-SNAPSHOT</version>
                         </path>
                     </annotationProcessorPaths>
+                    <!--
+                    If limited locales selected, attempts to resolve server Locales will have broken language-tags
+                    If local only has EN-AU and Server sends EN-NZ, EN-NZ will become NZ
+                    -->
                     <compilerArgs>
                         <arg>-Awalkingkooka.j2cl.java.util.Currency=XXX</arg>
-                        <arg>-Awalkingkooka.j2cl.java.util.Locale=en-AU</arg>
+                        <arg>-Awalkingkooka.j2cl.java.util.Locale=*</arg>
                         <arg>-Awalkingkooka.j2cl.java.util.Locale.DEFAULT=en-AU</arg>
                         <arg>-Awalkingkooka.j2cl.java.util.TimeZone=Australia/Sydney</arg>
                         <arg>-Awalkingkooka.j2cl.java.util.TimeZone.DEFAULT=Australia/Sydney</arg>


### PR DESCRIPTION
…country FIX

- POM: LocaleProvider: select all locales.
- This fixes problem where server locales missing from locale "lose" language leaving only country, eg: Local EN-AU, server sends EN-NZ, which becomes NZ.