### PR TITLE
HistoryContext.menuItem push HistoryToken NullPointerException FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryContext.java
@@ -69,11 +69,12 @@ public interface HistoryContext extends Context {
                 .setTextContent(text)
         );
 
-        menu.addSelectionHandler(
-            (ignored) -> this.pushHistoryToken(
-                historyToken.get()
-            )
-        );
+        final HistoryToken push = historyToken.orElse(null);
+        if (null != push) {
+            menu.addSelectionHandler(
+                (ignored) -> this.pushHistoryToken(push)
+            );
+        }
 
         return menu;
     }


### PR DESCRIPTION
- Previously a NoSuchElementException would be thrown if historyToken was empty