### PR TITLE
SelectComponent with value missing text FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryContext.java
@@ -92,7 +92,8 @@ public interface HistoryContext extends Context {
         return SelectOption.<T>create(
             id, // key
             value.orElse(null), // value
-            (final String k, final T v) -> div(),
+            (final String k, final T v) -> div()
+                .textContent(text),
             (final String k, final T v) -> this.menuItem(
                 id,
                 text,


### PR DESCRIPTION
- Previously the unopen drop down (select) was showing a blank instead of the text for the selected option.