### PR TITLE
SpreadsheetKeyBinding was SpreadsheetKeyBindings

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/key/SpreadsheetKeyBinding.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/key/SpreadsheetKeyBinding.java
@@ -19,7 +19,7 @@ package walkingkooka.spreadsheet.dominokit.key;
 
 import java.util.Set;
 
-public interface SpreadsheetKeyBindings {
+public interface SpreadsheetKeyBinding {
 
     Set<KeyBinding> bold();
 


### PR DESCRIPTION
- Dropped trailing or plural "s"