### PR TITLE
SpreadsheetKeyboardEventListener.dateFormat() "medium-date" was DateF…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/key/SpreadsheetKeyboardEventListener.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/key/SpreadsheetKeyboardEventListener.java
@@ -275,8 +275,7 @@ public class SpreadsheetKeyboardEventListener implements EventListener,
     private void dateFormat(final KeyboardEvent event) {
         this.setCellFormatter(
             Optional.of(
-                SpreadsheetPattern.parseDateFormatPattern("dd/mm/yyyy")
-                    .spreadsheetFormatterSelector()
+                SpreadsheetFormatterName.MEDIUM_DATE.setValueText("")
             )
         );
         event.preventDefault();

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/key/SpreadsheetKeyboardEventListenerTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/key/SpreadsheetKeyboardEventListenerTest.java
@@ -722,8 +722,7 @@ public final class SpreadsheetKeyboardEventListenerTest implements TreePrintable
                 SPREADSHEET_NAME,
                 CELL.setDefaultAnchor(),
                 Optional.of(
-                    SpreadsheetPattern.parseDateFormatPattern("dd/mm/yyyy")
-                        .spreadsheetFormatterSelector()
+                    SpreadsheetFormatterName.MEDIUM_DATE.setValueText("")
                 )
             )
         );
@@ -756,8 +755,7 @@ public final class SpreadsheetKeyboardEventListenerTest implements TreePrintable
                 SPREADSHEET_NAME,
                 CELL.setDefaultAnchor(),
                 Optional.of(
-                    SpreadsheetPattern.parseDateFormatPattern("dd/mm/yyyy")
-                        .spreadsheetFormatterSelector()
+                    SpreadsheetFormatterName.MEDIUM_DATE.setValueText("")
                 )
             )
         );
@@ -783,8 +781,7 @@ public final class SpreadsheetKeyboardEventListenerTest implements TreePrintable
                 SPREADSHEET_NAME,
                 CELL.setDefaultAnchor(),
                 Optional.of(
-                    SpreadsheetPattern.parseDateFormatPattern("dd/mm/yyyy")
-                        .spreadsheetFormatterSelector()
+                    SpreadsheetFormatterName.MEDIUM_DATE.setValueText("")
                 )
             )
         );


### PR DESCRIPTION
…ormatPattern

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/6383
- SpreadsheetKeyboardEventListener.dateFormat should use "medium" format pattern rather than hardcoded dd/mm/yyyy