### PR TITLE
AnchorComponent.addClickAndKeydownEnterListener removed

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/anchor/AnchorComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/anchor/AnchorComponent.java
@@ -17,7 +17,6 @@
 
 package walkingkooka.spreadsheet.dominokit.anchor;
 
-import elemental2.dom.EventListener;
 import elemental2.dom.HTMLAnchorElement;
 import org.dominokit.domino.ui.icons.Icon;
 import walkingkooka.net.Url;
@@ -121,13 +120,6 @@ public interface AnchorComponent<A extends AnchorComponent<A, T>, T> extends Val
     Optional<Icon<?>> iconAfter();
 
     A setIconAfter(final Optional<Icon<?>> icon);
-
-    // events...........................................................................................................
-
-    /**
-     * Adds a {@link EventListener} that receives click and keydown with ENTER events.
-     */
-    A addClickAndKeydownEnterListener(final EventListener listener);
 
     @Override
     default A hideMarginBottom() {

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/anchor/AnchorComponentDelegator.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/anchor/AnchorComponentDelegator.java
@@ -218,13 +218,6 @@ public interface AnchorComponentDelegator<A extends AnchorComponent<A, T>, T> ex
     }
 
     @Override
-    default A addClickAndKeydownEnterListener(final EventListener listener) {
-        this.anchorComponent()
-            .addClickAndKeydownEnterListener(listener);
-        return (A) this;
-    }
-
-    @Override
     default A focus() {
         this.anchorComponent()
             .focus();

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenAnchorComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenAnchorComponent.java
@@ -429,16 +429,6 @@ public final class HistoryTokenAnchorComponent extends HistoryTokenAnchorCompone
         return this;
     }
 
-    /**
-     * Adds a {@link EventListener} that receives click and keydown with ENTER events.
-     */
-    @Override
-    public HistoryTokenAnchorComponent addClickAndKeydownEnterListener(final EventListener listener) {
-        this.element.onKeyPress(e -> e.onEnter(listener));
-
-        return this.addClickListener(listener);
-    }
-
     // focus............................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenAnchorComponentLike.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenAnchorComponentLike.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.dominokit.history;
 
 import elemental2.dom.EventListener;
 import elemental2.dom.HTMLAnchorElement;
+import elemental2.dom.KeyboardEvent;
 import org.dominokit.domino.ui.events.EventType;
 import org.dominokit.domino.ui.icons.Icon;
 import walkingkooka.ToStringBuilder;
@@ -28,10 +29,12 @@ import walkingkooka.net.Url;
 import walkingkooka.spreadsheet.dominokit.anchor.AnchorComponent;
 import walkingkooka.spreadsheet.dominokit.contextmenu.SpreadsheetContextMenu;
 import walkingkooka.spreadsheet.dominokit.contextmenu.SpreadsheetContextMenuTarget;
+import walkingkooka.spreadsheet.dominokit.dom.Key;
 import walkingkooka.spreadsheet.dominokit.tooltip.TooltipComponent;
 import walkingkooka.spreadsheet.dominokit.tooltip.TooltipComponentTarget;
 import walkingkooka.text.printer.IndentingPrinter;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -155,16 +158,27 @@ abstract class HistoryTokenAnchorComponentLike implements AnchorComponent<Histor
      * The {@link #historyToken()} will be pushed if this anchor is clicked or ENTER key downed.
      */
     public final HistoryTokenAnchorComponent addPushHistoryToken(final HistoryContext context) {
-        return this.addClickAndKeydownEnterListener(
-            (e) -> {
-                e.preventDefault();
+        Objects.requireNonNull(context, "context");
 
-                this.historyToken()
-                    .ifPresent(
-                        context::pushHistoryToken
-                    );
+        final EventListener listener = (e) -> {
+            e.preventDefault();
+
+            this.historyToken()
+                .ifPresent(
+                    context::pushHistoryToken
+                );
+        };
+
+        this.addKeyDownListener(
+            e -> {
+                final KeyboardEvent keyboardEvent = (KeyboardEvent) e;
+                if(keyboardEvent.key.equals(Key.Enter)) {
+                    listener.handleEvent(e);
+                }
             }
         );
+
+        return this.addClickListener(listener);
     }
 
     // TooltipComponentTarget................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenAnchorComponent.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenAnchorComponent.java
@@ -245,11 +245,6 @@ public final class HistoryTokenAnchorComponent extends HistoryTokenAnchorCompone
     }
 
     @Override
-    public HistoryTokenAnchorComponent addClickAndKeydownEnterListener(final EventListener listener) {
-        return this;
-    }
-
-    @Override
     HistoryTokenAnchorComponent addEventListener(final EventType eventType,
                                                  final EventListener listener) {
         Objects.requireNonNull(listener, "listener");


### PR DESCRIPTION
- Logic inlined in HistoryTokenAnchorComponentLike.addPushHistoryToken
- Unnecessary to have public method