### PR TITLE
SpreadsheetViewportComponentSpreadsheetSelectionMenuContext.addSpread…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportComponentSpreadsheetSelectionMenuContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportComponentSpreadsheetSelectionMenuContext.java
@@ -241,9 +241,17 @@ final class SpreadsheetViewportComponentSpreadsheetSelectionMenuContext implemen
 
     // ColorComponentContext............................................................................................
 
+    /**
+     * Components within a menu should not react to any {@link walkingkooka.spreadsheet.dominokit.fetcher.FetcherWatcher} events.
+     */
     @Override
     public Runnable addSpreadsheetMetadataFetcherWatcher(final SpreadsheetMetadataFetcherWatcher watcher) {
-        return this.context.addSpreadsheetMetadataFetcherWatcher(watcher);
+        return new Runnable() {
+            @Override
+            public void run() {
+                // nop
+            }
+        };
     }
 
     // Object...........................................................................................................


### PR DESCRIPTION
…sheetMetadataFetcherWatcher nop FIX

- Components that exist within a menu should not refresh themselves because of any FetcherWatcher events

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/6615
- SpreadsheetViewportComponentSpreadsheetSelectionMenuContext#addSpreadsheetMetadataWatcher should ignore requests

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/6613
- ColorComponent should not be SpreadsheetMetadataFetcherWatcher