### PR TITLE
ValidatorSelectorNameAnchorListComponent unimplements SpreadsheetMeta…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/validator/AppContextValidatorSelectorDialogComponentContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/validator/AppContextValidatorSelectorDialogComponentContext.java
@@ -23,7 +23,6 @@ import walkingkooka.spreadsheet.dominokit.dialog.DialogComponentContext;
 import walkingkooka.spreadsheet.dominokit.dialog.DialogComponentContextDelegator;
 import walkingkooka.spreadsheet.dominokit.dialog.DialogComponentContexts;
 import walkingkooka.spreadsheet.dominokit.fetcher.SpreadsheetDeltaFetcherWatcher;
-import walkingkooka.spreadsheet.dominokit.fetcher.SpreadsheetMetadataFetcherWatcher;
 import walkingkooka.spreadsheet.dominokit.viewport.SpreadsheetViewportCache;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.validation.provider.ValidatorSelector;
@@ -71,11 +70,6 @@ final class AppContextValidatorSelectorDialogComponentContext implements Validat
     @Override
     public SpreadsheetMetadata spreadsheetMetadata() {
         return this.context.spreadsheetMetadata();
-    }
-
-    @Override
-    public Runnable addSpreadsheetMetadataFetcherWatcher(final SpreadsheetMetadataFetcherWatcher watcher) {
-        return this.context.addSpreadsheetMetadataFetcherWatcher(watcher);
     }
 
     // DialogComponentContext...........................................................................................

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/validator/FakeValidatorSelectorDialogComponentContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/validator/FakeValidatorSelectorDialogComponentContext.java
@@ -19,7 +19,6 @@ package walkingkooka.spreadsheet.dominokit.validator;
 
 import walkingkooka.spreadsheet.dominokit.dialog.FakeDialogComponentContext;
 import walkingkooka.spreadsheet.dominokit.fetcher.SpreadsheetDeltaFetcherWatcher;
-import walkingkooka.spreadsheet.dominokit.fetcher.SpreadsheetMetadataFetcherWatcher;
 import walkingkooka.spreadsheet.dominokit.viewport.SpreadsheetViewportCache;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.validation.provider.ValidatorSelector;
@@ -44,11 +43,6 @@ public class FakeValidatorSelectorDialogComponentContext extends FakeDialogCompo
 
     @Override
     public Runnable addSpreadsheetDeltaFetcherWatcher(final SpreadsheetDeltaFetcherWatcher watcher) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Runnable addSpreadsheetMetadataFetcherWatcher(final SpreadsheetMetadataFetcherWatcher watcher) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/validator/FakeValidatorSelectorNameAnchorListComponentContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/validator/FakeValidatorSelectorNameAnchorListComponentContext.java
@@ -17,7 +17,6 @@
 
 package walkingkooka.spreadsheet.dominokit.validator;
 
-import walkingkooka.spreadsheet.dominokit.fetcher.SpreadsheetMetadataFetcherWatcher;
 import walkingkooka.spreadsheet.dominokit.history.FakeHistoryContext;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 
@@ -25,11 +24,6 @@ public class FakeValidatorSelectorNameAnchorListComponentContext extends FakeHis
 
     public FakeValidatorSelectorNameAnchorListComponentContext() {
         super();
-    }
-
-    @Override
-    public Runnable addSpreadsheetMetadataFetcherWatcher(final SpreadsheetMetadataFetcherWatcher watcher) {
-        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/validator/ValidatorSelectorNameAnchorListComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/validator/ValidatorSelectorNameAnchorListComponent.java
@@ -70,8 +70,6 @@ public final class ValidatorSelectorNameAnchorListComponent implements ValueComp
             .setId(idPrefix + "links");
         this.value = Optional.empty();
         this.context = context;
-
-        context.addSpreadsheetMetadataFetcherWatcher(this);
     }
 
     private void refresh() {

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/validator/ValidatorSelectorNameAnchorListComponentContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/validator/ValidatorSelectorNameAnchorListComponentContext.java
@@ -17,12 +17,9 @@
 
 package walkingkooka.spreadsheet.dominokit.validator;
 
-import walkingkooka.spreadsheet.dominokit.fetcher.SpreadsheetMetadataFetcherWatcher;
 import walkingkooka.spreadsheet.dominokit.history.HistoryContext;
 import walkingkooka.spreadsheet.meta.HasSpreadsheetMetadata;
 
 public interface ValidatorSelectorNameAnchorListComponentContext extends HistoryContext,
     HasSpreadsheetMetadata {
-
-    Runnable addSpreadsheetMetadataFetcherWatcher(final SpreadsheetMetadataFetcherWatcher watcher);
 }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/validator/ValidatorSelectorDialogComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/validator/ValidatorSelectorDialogComponentTest.java
@@ -232,11 +232,6 @@ public final class ValidatorSelectorDialogComponentTest implements DialogCompone
         }
 
         @Override
-        public Runnable addSpreadsheetMetadataFetcherWatcher(final SpreadsheetMetadataFetcherWatcher watcher) {
-            return this.context.addSpreadsheetMetadataFetcherWatcher(watcher);
-        }
-
-        @Override
         public SpreadsheetMetadata spreadsheetMetadata() {
             return this.context.spreadsheetMetadata();
         }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/validator/ValidatorSelectorNameAnchorListComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/validator/ValidatorSelectorNameAnchorListComponentTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
-import walkingkooka.spreadsheet.dominokit.fetcher.SpreadsheetMetadataFetcherWatcher;
 import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
 import walkingkooka.spreadsheet.dominokit.value.ValueComponentTesting;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
@@ -140,11 +139,6 @@ public final class ValidatorSelectorNameAnchorListComponentTest implements Value
                         SpreadsheetMetadataPropertyName.VALIDATION_VALIDATORS,
                         ValidatorAliasSet.parse("apple-tree, banana, carrot")
                     );
-                }
-
-                @Override
-                public Runnable addSpreadsheetMetadataFetcherWatcher(final SpreadsheetMetadataFetcherWatcher watcher) {
-                    return null;
                 }
             }
         );


### PR DESCRIPTION
…dataFetcherWatcher

- ValidatorSelectorNameAnchorListComponent no longer refreshes itself when not visible

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/6614
- ValidatorSelectorNameAnchorListComponent#onSpreadsheetMetadata is refreshing even when parent dialog is not visible