### PR TITLE
SpreadsheetMetadataPanelComponent anchors clear HistoryToken Spreadsh…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/meta/SpreadsheetMetadataPanelComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/meta/SpreadsheetMetadataPanelComponent.java
@@ -182,10 +182,9 @@ public final class SpreadsheetMetadataPanelComponent implements SpreadsheetFormC
             // eg: /1/SpreadsheetName/metadata/SpreadsheetName
             item.addFocusListener(
                 (e) -> context.pushHistoryToken(
-                    context.historyToken()
-                        .setMetadataPropertyName(
-                            item.propertyName
-                        )
+                    item.historyToken(
+                            context.historyToken()
+                    )
                 )
             );
         }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/meta/SpreadsheetMetadataPanelComponentItem.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/meta/SpreadsheetMetadataPanelComponentItem.java
@@ -26,6 +26,7 @@ import walkingkooka.spreadsheet.dominokit.HtmlComponentDelegator;
 import walkingkooka.spreadsheet.dominokit.dom.HtmlElementComponent;
 import walkingkooka.spreadsheet.dominokit.dom.LiComponent;
 import walkingkooka.spreadsheet.dominokit.dom.UlComponent;
+import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
 import walkingkooka.spreadsheet.dominokit.history.HistoryTokenAnchorComponent;
 import walkingkooka.spreadsheet.dominokit.text.IntegerBoxComponent;
 import walkingkooka.spreadsheet.dominokit.tooltip.TooltipComponent;
@@ -294,6 +295,15 @@ abstract class SpreadsheetMetadataPanelComponentItem<T, C extends SpreadsheetMet
      * The parent {@link SpreadsheetMetadataPanelComponentContext} this will be used primarily to save updated values.
      */
     final SpreadsheetMetadataPanelComponentContext context;
+
+    /**
+     * Returns the {@link HistoryToken} when this item is selected in the {@link SpreadsheetMetadataPanelComponent}.
+     */
+    public final HistoryToken historyToken(final HistoryToken historyToken) {
+        return this instanceof SpreadsheetMetadataPanelComponentItemAnchor ?
+            historyToken.metadataShow() :
+            historyToken.setMetadataPropertyName(this.propertyName);
+    }
 
     // HtmlComponentDelegator...........................................................................................
 


### PR DESCRIPTION
…eetMetadataPropertyName

- Without this fix it was impossible to tab on SpreadsheetMetadataPanelComponentItemAnchor within the SpreadsheetMetadataPanelComponent.