### PR TITLE
HistoryToken-setSaveStringValue Locale empty string FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryToken.java
@@ -4318,8 +4318,10 @@ public abstract class HistoryToken implements HasUrlFragment {
                                         id,
                                         name,
                                         anchoredSpreadsheetSelection,
-                                        Optional.of(
-                                            Locale.forLanguageTag(value)
+                                        Optional.ofNullable(
+                                            value.isEmpty() ?
+                                                null :
+                                                Locale.forLanguageTag(value)
                                         )
                                     );
                                 }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/reference/SpreadsheetSelectionMenuLocaleTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/reference/SpreadsheetSelectionMenuLocaleTest.java
@@ -53,7 +53,7 @@ public final class SpreadsheetSelectionMenuLocaleTest implements TreePrintableTe
             Optional.empty(), // summary
             Lists.empty(),
             "\"Cell A1 Menu\" id=Cell-MenuId\n" +
-                "  (mdi-close) \"Clear...\" [/1/Spreadsheet123/cell/A1/locale/save/und] id=test-locale-clear-MenuItem\n" +
+                "  (mdi-close) \"Clear...\" [/1/Spreadsheet123/cell/A1/locale/save/] id=test-locale-clear-MenuItem\n" +
                 "  -----\n" +
                 "  \"Edit...\" [/1/Spreadsheet123/cell/A1/locale] id=test-locale-edit-MenuItem\n"
         );
@@ -70,7 +70,7 @@ public final class SpreadsheetSelectionMenuLocaleTest implements TreePrintableTe
             Optional.empty(), // summary
             Lists.empty(), // recents
             "\"Cell A1 Menu\" id=Cell-MenuId\n" +
-                "  (mdi-close) \"Clear...\" [/1/Spreadsheet123/cell/A1/locale/save/und] id=test-locale-clear-MenuItem\n" +
+                "  (mdi-close) \"Clear...\" [/1/Spreadsheet123/cell/A1/locale/save/] id=test-locale-clear-MenuItem\n" +
                 "  -----\n" +
                 "  \"Edit...\" [/1/Spreadsheet123/cell/A1/locale] id=test-locale-edit-MenuItem\n"
         );
@@ -94,7 +94,7 @@ public final class SpreadsheetSelectionMenuLocaleTest implements TreePrintableTe
             ),
             Lists.empty(), // recents
             "\"Cell A1 Menu\" id=Cell-MenuId\n" +
-                "  (mdi-close) \"Clear...\" [/1/Spreadsheet123/cell/A1/locale/save/und] id=test-locale-clear-MenuItem\n" +
+                "  (mdi-close) \"Clear...\" [/1/Spreadsheet123/cell/A1/locale/save/] id=test-locale-clear-MenuItem\n" +
                 "  -----\n" +
                 "  \"Edit...\" [/1/Spreadsheet123/cell/A1/locale] id=test-locale-edit-MenuItem\n"
         );
@@ -114,7 +114,7 @@ public final class SpreadsheetSelectionMenuLocaleTest implements TreePrintableTe
                 Locale.forLanguageTag("en-NZ")
             ), // recent,
             "\"Cell A1 Menu\" id=Cell-MenuId\n" +
-                "  (mdi-close) \"Clear...\" [/1/Spreadsheet123/cell/A1/locale/save/und] id=test-locale-clear-MenuItem\n" +
+                "  (mdi-close) \"Clear...\" [/1/Spreadsheet123/cell/A1/locale/save/] id=test-locale-clear-MenuItem\n" +
                 "  -----\n" +
                 "  \"Edit...\" [/1/Spreadsheet123/cell/A1/locale] id=test-locale-edit-MenuItem\n" +
                 "  -----\n" +

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/reference/SpreadsheetSelectionMenuTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/reference/SpreadsheetSelectionMenuTest.java
@@ -1544,7 +1544,7 @@ public final class SpreadsheetSelectionMenuTest implements PublicStaticHelperTes
                 "  (mdi-earth) \"DateTimeSymbols\" [/1/SpreadsheetName-1/cell/A1/dateTimeSymbols] id=test-dateTimeSymbols-MenuItem\n" +
                 "  (mdi-earth) \"DecimalNumberSymbols\" [/1/SpreadsheetName-1/cell/A1/decimalNumberSymbols] id=test-decimalNumberSymbols-MenuItem\n" +
                 "  \"Locale\" id=test-locale-SubMenu\n" +
-                "    (mdi-close) \"Clear...\" [/1/SpreadsheetName-1/cell/A1/locale/save/und] id=test-locale-clear-MenuItem\n" +
+                "    (mdi-close) \"Clear...\" [/1/SpreadsheetName-1/cell/A1/locale/save/] id=test-locale-clear-MenuItem\n" +
                 "    -----\n" +
                 "    \"Edit...\" [/1/SpreadsheetName-1/cell/A1/locale] id=test-locale-edit-MenuItem\n" +
                 "  \"Value type\" id=test-valueType-SubMenu\n" +
@@ -3095,7 +3095,7 @@ public final class SpreadsheetSelectionMenuTest implements PublicStaticHelperTes
                 "  (mdi-earth) \"DateTimeSymbols\" [/1/SpreadsheetName-1/cell/A1/dateTimeSymbols] id=test-dateTimeSymbols-MenuItem\n" +
                 "  (mdi-earth) \"DecimalNumberSymbols\" [/1/SpreadsheetName-1/cell/A1/decimalNumberSymbols] id=test-decimalNumberSymbols-MenuItem\n" +
                 "  \"Locale\" id=test-locale-SubMenu\n" +
-                "    (mdi-close) \"Clear...\" [/1/SpreadsheetName-1/cell/A1/locale/save/und] id=test-locale-clear-MenuItem\n" +
+                "    (mdi-close) \"Clear...\" [/1/SpreadsheetName-1/cell/A1/locale/save/] id=test-locale-clear-MenuItem\n" +
                 "    -----\n" +
                 "    \"Edit...\" [/1/SpreadsheetName-1/cell/A1/locale] id=test-locale-edit-MenuItem\n" +
                 "  \"Value type\" id=test-valueType-SubMenu\n" +
@@ -4648,7 +4648,7 @@ public final class SpreadsheetSelectionMenuTest implements PublicStaticHelperTes
                 "  (mdi-earth) \"DateTimeSymbols\" [/1/SpreadsheetName-1/cell/A1/dateTimeSymbols] CHECKED id=test-dateTimeSymbols-MenuItem\n" +
                 "  (mdi-earth) \"DecimalNumberSymbols\" [/1/SpreadsheetName-1/cell/A1/decimalNumberSymbols] id=test-decimalNumberSymbols-MenuItem\n" +
                 "  \"Locale\" id=test-locale-SubMenu\n" +
-                "    (mdi-close) \"Clear...\" [/1/SpreadsheetName-1/cell/A1/locale/save/und] id=test-locale-clear-MenuItem\n" +
+                "    (mdi-close) \"Clear...\" [/1/SpreadsheetName-1/cell/A1/locale/save/] id=test-locale-clear-MenuItem\n" +
                 "    -----\n" +
                 "    \"Edit...\" [/1/SpreadsheetName-1/cell/A1/locale] id=test-locale-edit-MenuItem\n" +
                 "  \"Value type\" id=test-valueType-SubMenu\n" +
@@ -6200,7 +6200,7 @@ public final class SpreadsheetSelectionMenuTest implements PublicStaticHelperTes
                 "  (mdi-earth) \"DateTimeSymbols\" [/1/SpreadsheetName-1/cell/A1/dateTimeSymbols] id=test-dateTimeSymbols-MenuItem\n" +
                 "  (mdi-earth) \"DecimalNumberSymbols\" [/1/SpreadsheetName-1/cell/A1/decimalNumberSymbols] CHECKED id=test-decimalNumberSymbols-MenuItem\n" +
                 "  \"Locale\" id=test-locale-SubMenu\n" +
-                "    (mdi-close) \"Clear...\" [/1/SpreadsheetName-1/cell/A1/locale/save/und] id=test-locale-clear-MenuItem\n" +
+                "    (mdi-close) \"Clear...\" [/1/SpreadsheetName-1/cell/A1/locale/save/] id=test-locale-clear-MenuItem\n" +
                 "    -----\n" +
                 "    \"Edit...\" [/1/SpreadsheetName-1/cell/A1/locale] id=test-locale-edit-MenuItem\n" +
                 "  \"Value type\" id=test-valueType-SubMenu\n" +
@@ -7752,7 +7752,7 @@ public final class SpreadsheetSelectionMenuTest implements PublicStaticHelperTes
                 "  (mdi-earth) \"DateTimeSymbols\" [/1/SpreadsheetName-1/cell/A1/dateTimeSymbols] id=test-dateTimeSymbols-MenuItem\n" +
                 "  (mdi-earth) \"DecimalNumberSymbols\" [/1/SpreadsheetName-1/cell/A1/decimalNumberSymbols] id=test-decimalNumberSymbols-MenuItem\n" +
                 "  \"Locale\" id=test-locale-SubMenu\n" +
-                "    (mdi-close) \"Clear...\" [/1/SpreadsheetName-1/cell/A1/locale/save/und] id=test-locale-clear-MenuItem\n" +
+                "    (mdi-close) \"Clear...\" [/1/SpreadsheetName-1/cell/A1/locale/save/] id=test-locale-clear-MenuItem\n" +
                 "    -----\n" +
                 "    \"Edit...\" [/1/SpreadsheetName-1/cell/A1/locale] id=test-locale-edit-MenuItem\n" +
                 "  \"Value type\" id=test-valueType-SubMenu\n" +
@@ -9304,7 +9304,7 @@ public final class SpreadsheetSelectionMenuTest implements PublicStaticHelperTes
                 "  (mdi-earth) \"DateTimeSymbols\" [/1/SpreadsheetName-1/cell/A1/dateTimeSymbols] id=test-dateTimeSymbols-MenuItem\n" +
                 "  (mdi-earth) \"DecimalNumberSymbols\" [/1/SpreadsheetName-1/cell/A1/decimalNumberSymbols] id=test-decimalNumberSymbols-MenuItem\n" +
                 "  \"Locale\" id=test-locale-SubMenu\n" +
-                "    (mdi-close) \"Clear...\" [/1/SpreadsheetName-1/cell/A1/locale/save/und] id=test-locale-clear-MenuItem\n" +
+                "    (mdi-close) \"Clear...\" [/1/SpreadsheetName-1/cell/A1/locale/save/] id=test-locale-clear-MenuItem\n" +
                 "    -----\n" +
                 "    \"Edit...\" [/1/SpreadsheetName-1/cell/A1/locale] id=test-locale-edit-MenuItem\n" +
                 "  \"Value type\" id=test-valueType-SubMenu\n" +
@@ -10845,7 +10845,7 @@ public final class SpreadsheetSelectionMenuTest implements PublicStaticHelperTes
                 "  (mdi-earth) \"DateTimeSymbols\" [/1/SpreadsheetName-1/cell/B2:C3/bottom-right/dateTimeSymbols] id=test-dateTimeSymbols-MenuItem\n" +
                 "  (mdi-earth) \"DecimalNumberSymbols\" [/1/SpreadsheetName-1/cell/B2:C3/bottom-right/decimalNumberSymbols] id=test-decimalNumberSymbols-MenuItem\n" +
                 "  \"Locale\" id=test-locale-SubMenu\n" +
-                "    (mdi-close) \"Clear...\" [/1/SpreadsheetName-1/cell/B2:C3/bottom-right/locale/save/und] id=test-locale-clear-MenuItem\n" +
+                "    (mdi-close) \"Clear...\" [/1/SpreadsheetName-1/cell/B2:C3/bottom-right/locale/save/] id=test-locale-clear-MenuItem\n" +
                 "    -----\n" +
                 "    \"Edit...\" [/1/SpreadsheetName-1/cell/B2:C3/bottom-right/locale] id=test-locale-edit-MenuItem\n" +
                 "  \"Value type\" id=test-valueType-SubMenu\n" +
@@ -12481,7 +12481,7 @@ public final class SpreadsheetSelectionMenuTest implements PublicStaticHelperTes
                 "  (mdi-earth) \"DateTimeSymbols\" [/1/SpreadsheetName-1/cell/Label123/dateTimeSymbols] id=test-dateTimeSymbols-MenuItem\n" +
                 "  (mdi-earth) \"DecimalNumberSymbols\" [/1/SpreadsheetName-1/cell/Label123/decimalNumberSymbols] id=test-decimalNumberSymbols-MenuItem\n" +
                 "  \"Locale\" id=test-locale-SubMenu\n" +
-                "    (mdi-close) \"Clear...\" [/1/SpreadsheetName-1/cell/Label123/locale/save/und] id=test-locale-clear-MenuItem\n" +
+                "    (mdi-close) \"Clear...\" [/1/SpreadsheetName-1/cell/Label123/locale/save/] id=test-locale-clear-MenuItem\n" +
                 "    -----\n" +
                 "    \"Edit...\" [/1/SpreadsheetName-1/cell/Label123/locale] id=test-locale-edit-MenuItem\n" +
                 "  \"Value type\" id=test-valueType-SubMenu\n" +
@@ -14022,7 +14022,7 @@ public final class SpreadsheetSelectionMenuTest implements PublicStaticHelperTes
     "  (mdi-earth) \"DateTimeSymbols\" [/1/SpreadsheetName-1/cell/UnknownLabel/dateTimeSymbols] id=test-dateTimeSymbols-MenuItem\n" +
     "  (mdi-earth) \"DecimalNumberSymbols\" [/1/SpreadsheetName-1/cell/UnknownLabel/decimalNumberSymbols] id=test-decimalNumberSymbols-MenuItem\n" +
     "  \"Locale\" id=test-locale-SubMenu\n" +
-    "    (mdi-close) \"Clear...\" [/1/SpreadsheetName-1/cell/UnknownLabel/locale/save/und] id=test-locale-clear-MenuItem\n" +
+    "    (mdi-close) \"Clear...\" [/1/SpreadsheetName-1/cell/UnknownLabel/locale/save/] id=test-locale-clear-MenuItem\n" +
     "    -----\n" +
     "    \"Edit...\" [/1/SpreadsheetName-1/cell/UnknownLabel/locale] id=test-locale-edit-MenuItem\n" +
     "  \"Value type\" id=test-valueType-SubMenu\n" +


### PR DESCRIPTION
- Previously HistoryToken.clearSaveValue's "" would be parsed by Locale.forLanguageTag as UND when the value should be Optional.empty()