### PR TITLE
ValueTextBoxComponent.setValue TextBox setValue unnecessary replace FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/text/TextBoxComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/text/TextBoxComponent.java
@@ -242,10 +242,14 @@ public final class TextBoxComponent extends TextBoxComponentLike
         Validator<Optional<String>> validator = null;
 
         if (false == validators.isEmpty()) {
-            final TextBoxComponentValidator textBoxComponentValidator = (TextBoxComponentValidator)
-                validators.iterator()
-                    .next();
-            validator = textBoxComponentValidator.validator;
+            final Validator<TextBox> textBoxValidator = validators.iterator()
+                .next();
+
+            // check necessary because active validator might be another (internal) Validator.
+            if (textBoxValidator instanceof TextBoxComponentValidator) {
+                final TextBoxComponentValidator textBoxComponentValidator = (TextBoxComponentValidator) textBoxValidator;
+                validator = textBoxComponentValidator.validator;
+            }
         }
 
         return validator;

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/value/ValueTextBoxComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/value/ValueTextBoxComponent.java
@@ -63,6 +63,8 @@ public final class ValueTextBoxComponent<T> implements ValueTextBoxComponentLike
         this.setParser(parser);
         this.setFormatter(formatter);
         this.required();
+
+        this.validatorChange = false; // reset required because required -> setValidator will set #validatorChange=true
     }
 
     /**
@@ -129,7 +131,7 @@ public final class ValueTextBoxComponent<T> implements ValueTextBoxComponentLike
 
     @Override
     public ValueTextBoxComponent<T> optional() {
-        this.textBox.setValidator(
+        this.setTextBoxValidator(
             SpreadsheetValidators.optional(this.validator)
         );
         this.required = false;
@@ -138,7 +140,7 @@ public final class ValueTextBoxComponent<T> implements ValueTextBoxComponentLike
 
     @Override
     public ValueTextBoxComponent<T> required() {
-        this.textBox.setValidator(this.validator);
+        this.setTextBoxValidator(this.validator);
         this.required = true;
         return this;
     }
@@ -155,12 +157,18 @@ public final class ValueTextBoxComponent<T> implements ValueTextBoxComponentLike
     }
 
     public ValueTextBoxComponent<T> setValidator(final Validator<Optional<String>> validator) {
-        this.textBox.setValidator(validator);
+        this.setTextBoxValidator(validator);
         this.validator = validator;
         return this;
     }
 
     private Validator<Optional<String>> validator;
+
+    private void setTextBoxValidator(final Validator<Optional<String>> validator) {
+        this.validatorChange = this.validatorChange | false == validator.equals(this.textBox.validator());
+
+        this.textBox.setValidator(validator);
+    }
 
     @Override
     public ValueTextBoxComponent<T> validate() {
@@ -311,11 +319,22 @@ public final class ValueTextBoxComponent<T> implements ValueTextBoxComponentLike
     public ValueTextBoxComponent<T> setValue(final Optional<T> value) {
         Objects.requireNonNull(value, "value");
 
-        this.textBox.setValue(
-            value.map(this.formatter::apply)
-        );
+        // dont refresh textBox#setValue if value is the "same".
+        if (this.validatorChange || false == value.equals(this.value())) {
+            this.validatorChange = false;
+
+            this.textBox.setValue(
+                value.map(this.formatter::apply)
+            );
+        }
+
         return this;
     }
+
+    /**
+     * If the validator changed setValue must happen, forcing validation and text formatting.
+     */
+    private boolean validatorChange;
 
     @Override //
     public Optional<T> value() {

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/value/ValueTextBoxComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/value/ValueTextBoxComponentTest.java
@@ -63,6 +63,26 @@ public final class ValueTextBoxComponentTest implements ValueTextBoxComponentLik
     }
 
     @Test
+    public void testSetValueDoesntRefreshStringValue() {
+        final ValueTextBoxComponent<SpreadsheetCellReference> component = this.createComponent();
+
+        final String text = "ab12";
+        component.setStringValue(
+            Optional.of(text)
+        );
+
+        this.setValueAndCheck(
+            component,
+            SpreadsheetSelection.parseCell("AB12")
+        );
+
+        this.stringValueAndCheck(
+            component,
+            text
+        );
+    }
+
+    @Test
     public void testSetStringValue() {
         final String text = "AB12";
 


### PR DESCRIPTION
- Previously setValue would always replace the TextBox String value which meant the original user entered text could(would) often be replaced, because the value had multiple text representations.