### PR TITLE
SpreadsheetCellFindDialogComponentSpreadsheetFormulaParserTokenVisito…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/find/SpreadsheetCellFindDialogComponentSpreadsheetParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/find/SpreadsheetCellFindDialogComponentSpreadsheetParserTokenVisitor.java
@@ -104,6 +104,9 @@ final class SpreadsheetCellFindDialogComponentSpreadsheetFormulaParserTokenVisit
             if (this.isCellGetterAndTextMatch(left, right, SpreadsheetExpressionFunctions.CELL_DATE_TIME_SYMBOLS, wizard.dateTimeSymbols)) {
                 break;
             }
+            if (this.isCellGetterAndTextMatch(left, right, SpreadsheetExpressionFunctions.CELL_DECIMAL_NUMBER_SYMBOLS, wizard.decimalNumberSymbols)) {
+                break;
+            }
             if (this.isCellGetterAndTextMatch(left, right, SpreadsheetExpressionFunctions.CELL_FORMATTER, wizard.formatter)) {
                 break;
             }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/find/SpreadsheetCellFindDialogComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/find/SpreadsheetCellFindDialogComponentTest.java
@@ -1745,7 +1745,7 @@ public final class SpreadsheetCellFindDialogComponentTest implements DialogCompo
                 "        TextMatchComponent\n" +
                 "          ValueTextBoxComponent\n" +
                 "            TextBoxComponent\n" +
-                "              decimalNumberSymbols [] id=SpreadsheetCellFind-decimalnumbersymbols-TextBox\n" +
+                "              decimalNumberSymbols [*Hello*] id=SpreadsheetCellFind-decimalnumbersymbols-TextBox\n" +
                 "        TextMatchComponent\n" +
                 "          ValueTextBoxComponent\n" +
                 "            TextBoxComponent\n" +
@@ -1775,7 +1775,7 @@ public final class SpreadsheetCellFindDialogComponentTest implements DialogCompo
                 "      SpreadsheetFormulaComponent\n" +
                 "        ValueTextBoxComponent\n" +
                 "          TextBoxComponent\n" +
-                "            Query [or(textMatch(cellDecimalNumberSymbols(),\"*Hello*\"),1)] id=query-TextBox\n" +
+                "            Query [or(textMatch(\"*Hello*\",cellDecimalNumberSymbols()),1)] id=query-TextBox\n" +
                 "      AnchorListComponent\n" +
                 "        FlexLayoutComponent\n" +
                 "          ROW\n" +


### PR DESCRIPTION
…r.textMatchFunctionParameters missing cellDecimalNumberSymbols FIX

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/7194
- SpreadsheetCellFindDialogComponentSpreadsheetFormulaParserTokenVisitor.textMatchFunctionParameters missing cellDecimalNumberSymbols