### PR TITLE
SpreadsheetViewportComponent: scrollbar desync SpreadsheetMetadata.VI…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/viewport/SpreadsheetViewportComponent.java
@@ -889,6 +889,13 @@ public final class SpreadsheetViewportComponent implements HtmlComponentDelegato
         if (maybeSpreadsheetViewport.isPresent()) {
             final SpreadsheetViewport viewport = maybeSpreadsheetViewport.get();
 
+            // required otherwise scrollbars will have an incorrect "home"
+            this.metadata = this.metadata.set(
+                SpreadsheetMetadataPropertyName.VIEWPORT_HOME,
+                viewport.rectangle()
+                    .home()
+            );
+
             this.synchronizeSpreadsheetDeltaViewportSelectionHistoryToken(viewport);
             this.reloadSpreadsheetMetadataIfViewportChanged(viewport);
         }


### PR DESCRIPTION
…EWPORT_HOME FIX

- Without this fix the scrollbars would keep the last "loaded" SpreadsheetMetadata.VIEWPORT_HOME and were ignoring SpreadsheetDelta.viewportHome refreshes.