### PR TITLE
SpreadsheetNavigateDialogComponent.save click frozen FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellNavigateHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellNavigateHistoryToken.java
@@ -105,7 +105,9 @@ public final class SpreadsheetCellNavigateHistoryToken extends SpreadsheetCellHi
                     ).setIncludeFrozenColumnsRows(true)
                 );
 
-            context.pushHistoryToken(previous);
+            context.pushHistoryToken(
+                this.clearAction()
+            );
         }
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnNavigateHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetColumnNavigateHistoryToken.java
@@ -100,7 +100,9 @@ public final class SpreadsheetColumnNavigateHistoryToken extends SpreadsheetColu
                     ).setIncludeFrozenColumnsRows(true)
                 );
 
-            context.pushHistoryToken(previous);
+            context.pushHistoryToken(
+                this.clear()
+            );
         }
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNavigateHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNavigateHistoryToken.java
@@ -113,7 +113,9 @@ public final class SpreadsheetNavigateHistoryToken extends SpreadsheetNameHistor
                     ).setIncludeFrozenColumnsRows(true)
                 );
 
-            context.pushHistoryToken(previous);
+            context.pushHistoryToken(
+                this.clearAction()
+            );
         }
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowNavigateHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetRowNavigateHistoryToken.java
@@ -117,7 +117,9 @@ public final class SpreadsheetRowNavigateHistoryToken extends SpreadsheetRowHist
                     ).setIncludeFrozenColumnsRows(true)
                 );
 
-            context.pushHistoryToken(previous);
+            context.pushHistoryToken(
+                this.clear()
+            );
         }
     }
 


### PR DESCRIPTION
- The actual problem was each of the SpreadsheetXXXNavigateHistoryToken#onHistoryToken was pushing the wrong history token. This wrong history push would leave the browser "frozen" because the Dominokit dialog background was left over.