### PR TITLE
SpreadsheetMetadataPropertyStyleSelectHistoryToken & SpreadsheetCellS…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryToken.java
@@ -1111,7 +1111,7 @@ public abstract class HistoryToken implements HasUrlFragment {
     public static <T> SpreadsheetCellStyleSelectHistoryToken<T> cellStyle(final SpreadsheetId id,
                                                                           final SpreadsheetName name,
                                                                           final AnchoredSpreadsheetSelection anchoredSelection,
-                                                                          final TextStylePropertyName<T> propertyName) {
+                                                                          final Optional<TextStylePropertyName<T>> propertyName) {
         return SpreadsheetCellStyleSelectHistoryToken.with(
             id,
             name,
@@ -1613,7 +1613,7 @@ public abstract class HistoryToken implements HasUrlFragment {
      */
     public static <T> SpreadsheetMetadataPropertyStyleSelectHistoryToken<T> metadataPropertyStyle(final SpreadsheetId id,
                                                                                                   final SpreadsheetName name,
-                                                                                                  final TextStylePropertyName<T> stylePropertyName) {
+                                                                                                  final Optional<TextStylePropertyName<T>> stylePropertyName) {
         return SpreadsheetMetadataPropertyStyleSelectHistoryToken.with(
             id,
             name,
@@ -5019,28 +5019,28 @@ public abstract class HistoryToken implements HasUrlFragment {
     // STYLE............................................................................................................
 
     public final Optional<TextStylePropertyName<?>> stylePropertyName() {
-        final TextStylePropertyName<?> propertyName;
+        final Optional<TextStylePropertyName<?>> stylePropertyName;
 
-        if(this instanceof SpreadsheetMetadataPropertyStyleHistoryToken) {
-            propertyName = this.cast(SpreadsheetMetadataPropertyStyleHistoryToken.class)
+        if (this instanceof SpreadsheetMetadataPropertyStyleHistoryToken) {
+            stylePropertyName = this.cast(SpreadsheetMetadataPropertyStyleHistoryToken.class)
                 .stylePropertyName;
         } else {
             if (this instanceof SpreadsheetCellStyleHistoryToken) {
-                propertyName = this.cast(SpreadsheetCellStyleHistoryToken.class)
+                stylePropertyName = this.cast(SpreadsheetCellStyleHistoryToken.class)
                     .stylePropertyName;
             } else {
-                propertyName = null;
+                stylePropertyName = Optional.empty();
             }
         }
 
-        return Optional.ofNullable(propertyName);
+        return stylePropertyName;
     }
 
     /**
      * Factory that creates a {@link SpreadsheetNameHistoryToken} with the given {@link TextStylePropertyName} property name.
      */
-    public final HistoryToken setStylePropertyName(final TextStylePropertyName<?> stylePropertyName) {
-        Objects.requireNonNull(stylePropertyName, "stylePropertyName");
+    public final HistoryToken setStylePropertyName(final Optional<TextStylePropertyName<?>> propertyName) {
+        Objects.requireNonNull(propertyName, "stylePropertyName");
 
         HistoryToken historyToken = null;
 
@@ -5053,7 +5053,7 @@ public abstract class HistoryToken implements HasUrlFragment {
                 historyToken = metadataPropertyStyle(
                     id,
                     name,
-                    stylePropertyName
+                    Cast.to(propertyName)
                 );
             } else {
                 if (this instanceof SpreadsheetCellHistoryToken) {
@@ -5062,7 +5062,7 @@ public abstract class HistoryToken implements HasUrlFragment {
                         name,
                         this.cast(SpreadsheetCellHistoryToken.class)
                             .anchoredSelection(),
-                        stylePropertyName
+                        Cast.to(propertyName)
                     );
                 }
             }
@@ -5075,7 +5075,9 @@ public abstract class HistoryToken implements HasUrlFragment {
         Objects.requireNonNull(styleProperty, "styleProperty");
 
         final HistoryToken historyToken = this.setStylePropertyName(
-            styleProperty.name()
+            Optional.of(
+                styleProperty.name()
+            )
         ).setSaveValue(
             styleProperty.value()
         );
@@ -5302,7 +5304,9 @@ public abstract class HistoryToken implements HasUrlFragment {
             historyToken = this.setMetadataPropertyName((SpreadsheetMetadataPropertyName<?>) name);
         } else {
             if (name instanceof TextStylePropertyName) {
-                historyToken = this.setStylePropertyName((TextStylePropertyName<?>) name);
+                historyToken = this.setStylePropertyName(
+                    Optional.of((TextStylePropertyName<?>) name)
+                );
             } else {
                 throw new IllegalArgumentException("Unknown ValueName expected either " + SpreadsheetMetadataPropertyName.class.getSimpleName() + " or " + TextStylePropertyName.class.getSimpleName());
             }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenVisitor.java
@@ -369,7 +369,7 @@ public class HistoryTokenVisitor extends Visitor<HistoryToken> {
     protected void visitCellStyleSelect(final SpreadsheetId id,
                                         final SpreadsheetName name,
                                         final AnchoredSpreadsheetSelection anchoredSelection,
-                                        final TextStylePropertyName<?> stylePropertyName) {
+                                        final Optional<TextStylePropertyName<?>> stylePropertyName) {
         // NOP
     }
 
@@ -580,7 +580,7 @@ public class HistoryTokenVisitor extends Visitor<HistoryToken> {
 
     protected <T> void visitMetadataStyleSelect(final SpreadsheetId id,
                                                 final SpreadsheetName name,
-                                                final TextStylePropertyName<T> stylePropertyName) {
+                                                final Optional<TextStylePropertyName<T>> stylePropertyName) {
         // NOP
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleHistoryToken.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.dominokit.history;
 
+import walkingkooka.Cast;
 import walkingkooka.net.UrlFragment;
 import walkingkooka.spreadsheet.meta.SpreadsheetId;
 import walkingkooka.spreadsheet.meta.SpreadsheetName;
@@ -24,13 +25,14 @@ import walkingkooka.spreadsheet.viewport.AnchoredSpreadsheetSelection;
 import walkingkooka.tree.text.TextStylePropertyName;
 
 import java.util.Objects;
+import java.util.Optional;
 
 abstract public class SpreadsheetCellStyleHistoryToken<T> extends SpreadsheetCellHistoryToken {
 
     SpreadsheetCellStyleHistoryToken(final SpreadsheetId id,
                                      final SpreadsheetName name,
                                      final AnchoredSpreadsheetSelection anchoredSelection,
-                                     final TextStylePropertyName<T> stylePropertyName) {
+                                     final Optional<TextStylePropertyName<T>> stylePropertyName) {
         super(
             id,
             name,
@@ -40,19 +42,31 @@ abstract public class SpreadsheetCellStyleHistoryToken<T> extends SpreadsheetCel
         this.stylePropertyName = Objects.requireNonNull(stylePropertyName, "stylePropertyName");
     }
 
-    final TextStylePropertyName<T> stylePropertyName;
+    final Optional<TextStylePropertyName<T>> stylePropertyName;
 
+    // /1/SpreadsheetName/cell/A1/style/
+    // /1/SpreadsheetName/cell/A1/style/color/
+    // /1/SpreadsheetName/cell/A1/style/color/save/#123
     @Override //
     final UrlFragment cellUrlFragment() {
-        return STYLE.appendSlashThen(
-            this.stylePropertyName.urlFragment()
-        ).appendSlashThen(this.styleUrlFragment());
+        UrlFragment urlFragment = STYLE;
+
+        final TextStylePropertyName<T> stylePropertyNameOrNull = this.stylePropertyName.orElse(null);
+        if (null != stylePropertyNameOrNull) {
+            urlFragment = urlFragment.appendSlashThen(
+                stylePropertyNameOrNull.urlFragment()
+            ).appendSlashThen(this.styleUrlFragment());
+        }
+
+        return urlFragment;
     }
 
     abstract UrlFragment styleUrlFragment();
 
     @Override
     public final HistoryToken clearAction() {
-        return this.setStylePropertyName(this.stylePropertyName);
+        return this.setStylePropertyName(
+            Cast.to(this.stylePropertyName)
+        );
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleSaveHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleSaveHistoryToken.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.dominokit.history;
 
+import walkingkooka.Cast;
 import walkingkooka.Value;
 import walkingkooka.net.UrlFragment;
 import walkingkooka.spreadsheet.dominokit.AppContext;
@@ -63,7 +64,7 @@ final public class SpreadsheetCellStyleSaveHistoryToken<T> extends SpreadsheetCe
             id,
             name,
             anchoredSelection,
-            stylePropertyName
+            Optional.of(stylePropertyName)
         );
         this.stylePropertyValue = Objects.requireNonNull(stylePropertyValue, "stylePropertyValue");
 
@@ -93,9 +94,7 @@ final public class SpreadsheetCellStyleSaveHistoryToken<T> extends SpreadsheetCe
             name,
             anchoredSelection
         ).setStyleProperty(
-            this.stylePropertyName.setValue(
-                this.value()
-            )
+            this.textStyleProperty()
         );
     }
 
@@ -109,14 +108,16 @@ final public class SpreadsheetCellStyleSaveHistoryToken<T> extends SpreadsheetCe
                 this.id,
                 this.anchoredSelection()
                     .selection(),
-                this.stylePropertyName,
+                this.stylePropertyName.get(),
                 this.value()
             );
     }
 
     public TextStyleProperty<T> textStyleProperty() {
         return TextStyleProperty.with(
-            this.stylePropertyName,
+            this.stylePropertyName.orElseThrow(
+                () -> new IllegalStateException("Missing stylePropertyName")
+            ),
             this.value()
         );
     }
@@ -129,7 +130,7 @@ final public class SpreadsheetCellStyleSaveHistoryToken<T> extends SpreadsheetCe
             this.id,
             this.name,
             this.anchoredSelection,
-            this.stylePropertyName,
+            this.stylePropertyName.get(),
             this.value()
         );
     }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleSelectHistoryToken.java
@@ -17,12 +17,15 @@
 
 package walkingkooka.spreadsheet.dominokit.history;
 
+import walkingkooka.Cast;
 import walkingkooka.net.UrlFragment;
 import walkingkooka.spreadsheet.dominokit.AppContext;
 import walkingkooka.spreadsheet.meta.SpreadsheetId;
 import walkingkooka.spreadsheet.meta.SpreadsheetName;
 import walkingkooka.spreadsheet.viewport.AnchoredSpreadsheetSelection;
 import walkingkooka.tree.text.TextStylePropertyName;
+
+import java.util.Optional;
 
 /**
  * Selects one of the available style toolbar links.
@@ -35,7 +38,7 @@ final public class SpreadsheetCellStyleSelectHistoryToken<T> extends Spreadsheet
     static <T> SpreadsheetCellStyleSelectHistoryToken<T> with(final SpreadsheetId id,
                                                               final SpreadsheetName name,
                                                               final AnchoredSpreadsheetSelection anchoredSelection,
-                                                              final TextStylePropertyName<T> propertyName) {
+                                                              final Optional<TextStylePropertyName<T>> propertyName) {
         return new SpreadsheetCellStyleSelectHistoryToken<>(
             id,
             name,
@@ -47,7 +50,7 @@ final public class SpreadsheetCellStyleSelectHistoryToken<T> extends Spreadsheet
     private SpreadsheetCellStyleSelectHistoryToken(final SpreadsheetId id,
                                                    final SpreadsheetName name,
                                                    final AnchoredSpreadsheetSelection anchoredSelection,
-                                                   final TextStylePropertyName<T> propertyName) {
+                                                   final Optional<TextStylePropertyName<T>> propertyName) {
         super(
             id,
             name,
@@ -69,7 +72,9 @@ final public class SpreadsheetCellStyleSelectHistoryToken<T> extends Spreadsheet
             id,
             name,
             anchoredSelection
-        ).setStylePropertyName(this.stylePropertyName);
+        ).setStylePropertyName(
+            Cast.to(this.stylePropertyName)
+        );
     }
 
     @Override
@@ -86,7 +91,7 @@ final public class SpreadsheetCellStyleSelectHistoryToken<T> extends Spreadsheet
             this.id,
             this.name,
             this.anchoredSelection,
-            this.stylePropertyName
+            Cast.to(this.stylePropertyName)
         );
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleHistoryToken.java
@@ -25,12 +25,13 @@ import walkingkooka.tree.text.TextStyle;
 import walkingkooka.tree.text.TextStylePropertyName;
 
 import java.util.Objects;
+import java.util.Optional;
 
 public abstract class SpreadsheetMetadataPropertyStyleHistoryToken<T> extends SpreadsheetMetadataPropertyHistoryToken<TextStyle> {
 
     SpreadsheetMetadataPropertyStyleHistoryToken(final SpreadsheetId id,
                                                  final SpreadsheetName name,
-                                                 final TextStylePropertyName<T> stylePropertyName) {
+                                                 final Optional<TextStylePropertyName<T>> stylePropertyName) {
         super(
             id,
             name,
@@ -40,12 +41,17 @@ public abstract class SpreadsheetMetadataPropertyStyleHistoryToken<T> extends Sp
         this.stylePropertyName = Objects.requireNonNull(stylePropertyName, "stylePropertyName");
     }
 
-    final TextStylePropertyName<T> stylePropertyName;
+    final Optional<TextStylePropertyName<T>> stylePropertyName;
 
+    // /1/SpreadsheetName111/metadata/style
+    // /1/SpreadsheetName111/metadata/style/color
+    // /1/SpreadsheetName111/metadata/style/color/save/BLACK
     @Override//
     final UrlFragment metadataPropertyUrlFragment() {
-        return this.stylePropertyName.urlFragment()
-            .appendSlashThen(this.styleUrlFragment());
+        return this.stylePropertyName.map(
+            (TextStylePropertyName<T> s) -> s.urlFragment()
+                .appendSlashThen(this.styleUrlFragment())
+        ).orElse(UrlFragment.EMPTY);
     }
 
     abstract UrlFragment styleUrlFragment();

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSaveHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSaveHistoryToken.java
@@ -52,7 +52,7 @@ public final class SpreadsheetMetadataPropertyStyleSaveHistoryToken<T> extends S
         super(
             id,
             name,
-            stylePropertyName
+            Optional.of(stylePropertyName)
         );
 
         this.stylePropertyValue = Objects.requireNonNull(stylePropertyValue, "stylePropertyValue");
@@ -90,7 +90,7 @@ public final class SpreadsheetMetadataPropertyStyleSaveHistoryToken<T> extends S
         return with(
             id,
             name,
-            this.stylePropertyName,
+            this.stylePropertyName.get(),
             this.value()
         );
     }
@@ -107,7 +107,7 @@ public final class SpreadsheetMetadataPropertyStyleSaveHistoryToken<T> extends S
                 SpreadsheetMetadata.EMPTY.set(
                     SpreadsheetMetadataPropertyName.STYLE,
                     TextStyle.EMPTY.setOrRemove(
-                        this.stylePropertyName,
+                        this.stylePropertyName.get(),
                         this.value()
                             .orElse(null)
                     )
@@ -122,7 +122,7 @@ public final class SpreadsheetMetadataPropertyStyleSaveHistoryToken<T> extends S
         visitor.visitMetadataStyleSave(
             this.id,
             this.name,
-            this.stylePropertyName,
+            this.stylePropertyName.get(),
             this.stylePropertyValue
         );
     }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSelectHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSelectHistoryToken.java
@@ -23,11 +23,13 @@ import walkingkooka.spreadsheet.meta.SpreadsheetId;
 import walkingkooka.spreadsheet.meta.SpreadsheetName;
 import walkingkooka.tree.text.TextStylePropertyName;
 
+import java.util.Optional;
+
 public final class SpreadsheetMetadataPropertyStyleSelectHistoryToken<T> extends SpreadsheetMetadataPropertyStyleHistoryToken<T> {
 
     static <T> SpreadsheetMetadataPropertyStyleSelectHistoryToken<T> with(final SpreadsheetId id,
                                                                           final SpreadsheetName name,
-                                                                          final TextStylePropertyName<T> stylePropertyName) {
+                                                                          final Optional<TextStylePropertyName<T>> stylePropertyName) {
         return new SpreadsheetMetadataPropertyStyleSelectHistoryToken<>(
             id,
             name,
@@ -37,7 +39,7 @@ public final class SpreadsheetMetadataPropertyStyleSelectHistoryToken<T> extends
 
     private SpreadsheetMetadataPropertyStyleSelectHistoryToken(final SpreadsheetId id,
                                                                final SpreadsheetName name,
-                                                               final TextStylePropertyName<T> stylePropertyName) {
+                                                               final Optional<TextStylePropertyName<T>> stylePropertyName) {
         super(
             id,
             name,

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNameHistoryToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetNameHistoryToken.java
@@ -69,17 +69,12 @@ public abstract class SpreadsheetNameHistoryToken extends SpreadsheetIdHistoryTo
     }
 
     final HistoryToken parseStyle(final TextCursor cursor) {
-        HistoryToken result = this;
-
-        final Optional<String> style = parseComponent(cursor);
-        if (style.isPresent()) {
-            result = this.setStylePropertyName(
-                TextStylePropertyName.with(
-                    style.get()
+        return this.setStylePropertyName(
+            parseComponent(cursor)
+                .map(
+                    TextStylePropertyName::with
                 )
-            );
-        }
-        return result;
+        );
     }
 
     // HasUrlFragment...................................................................................................

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/reference/SpreadsheetSelectionMenuValuesStyle.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/reference/SpreadsheetSelectionMenuValuesStyle.java
@@ -348,7 +348,9 @@ final class SpreadsheetSelectionMenuValuesStyle extends SpreadsheetSelectionMenu
             ColorComponent.with(
                 id + "-",
                 (h) -> Optional.of(
-                    h.setStylePropertyName(color)
+                    h.setStylePropertyName(
+                        Optional.of(color)
+                    )
                 ),
                 context
             )

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/toolbar/ToolbarComponentItemAnchorTextStyleClear.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/toolbar/ToolbarComponentItemAnchorTextStyleClear.java
@@ -63,7 +63,7 @@ final class ToolbarComponentItemAnchorTextStyleClear extends ToolbarComponentIte
         context.historyToken()
             .anchoredSelectionHistoryTokenOrEmpty()
             .map(
-                t -> t.setStylePropertyName(PROPERTY)
+                t -> t.setStylePropertyName(OPTIONAL_PROPERTY)
             ).ifPresent(context::pushHistoryToken);
     }
 
@@ -85,4 +85,6 @@ final class ToolbarComponentItemAnchorTextStyleClear extends ToolbarComponentIte
     }
 
     private static final TextStylePropertyName<Void> PROPERTY = TextStylePropertyName.WILDCARD;
+
+    private static final Optional<TextStylePropertyName<?>> OPTIONAL_PROPERTY = Optional.of(PROPERTY);
 }

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/toolbar/ToolbarComponentItemAnchorTextStyleProperty.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/toolbar/ToolbarComponentItemAnchorTextStyleProperty.java
@@ -88,7 +88,9 @@ final class ToolbarComponentItemAnchorTextStyleProperty<T> extends ToolbarCompon
         context.historyToken()
             .anchoredSelectionHistoryTokenOrEmpty()
             .map(
-                t -> t.setStylePropertyName(this.propertyName)
+                t -> t.setStylePropertyName(
+                    Optional.of(this.propertyName)
+                )
             ).ifPresent(context::pushHistoryToken);
     }
 
@@ -110,14 +112,15 @@ final class ToolbarComponentItemAnchorTextStyleProperty<T> extends ToolbarCompon
             context.historyToken()
                 .anchoredSelectionHistoryTokenOrEmpty()
                 .map(
-                    t -> t.setStylePropertyName(propertyName)
-                        .setSaveStringValue(
-                            save(
-                                selected ?
-                                    null :
-                                    propertyValue
-                            )
+                    t -> t.setStylePropertyName(
+                        Optional.of(propertyName)
+                    ).setSaveStringValue(
+                        save(
+                            selected ?
+                                null :
+                                propertyValue
                         )
+                    )
                 )
         ).setChecked(selected);
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/color/ColorComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/color/ColorComponentTest.java
@@ -42,7 +42,9 @@ public final class ColorComponentTest implements ValueComponentTesting<HTMLTable
     private final static String ID_PREFIX = "TestColorPicker-";
 
     private final static Function<HistoryToken, Optional<HistoryToken>> HISTORY_TOKEN_PREPARER = (h) -> Optional.of(
-        h.setStylePropertyName(TextStylePropertyName.COLOR)
+        h.setStylePropertyName(
+            Optional.of(TextStylePropertyName.COLOR)
+        )
     );
 
     @Test
@@ -300,7 +302,7 @@ public final class ColorComponentTest implements ValueComponentTesting<HTMLTable
                         SpreadsheetId.with(1),
                         SpreadsheetName.with("SpreadsheetName1"),
                         SpreadsheetSelection.A1.setDefaultAnchor(),
-                        TextStylePropertyName.COLOR
+                        Optional.of(TextStylePropertyName.COLOR)
                     );
                 }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/dialog/DialogComponentContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/dialog/DialogComponentContextTest.java
@@ -215,7 +215,7 @@ public final class DialogComponentContextTest implements ClassTesting<DialogComp
                         ID,
                         NAME,
                         selection.setDefaultAnchor(),
-                        propertyName
+                        Optional.of(propertyName)
                     );
                 }
             }.selectionTextStylePropertyDialogTitle(propertyName),

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/HistoryTokenTest.java
@@ -1958,7 +1958,9 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>,
         final HistoryToken historyToken = HistoryToken.unknown(UrlFragment.parse("/something else"));
 
         assertSame(
-            historyToken.setStylePropertyName(TextStylePropertyName.COLOR),
+            historyToken.setStylePropertyName(
+                Optional.of(TextStylePropertyName.COLOR)
+            ),
             historyToken
         );
     }
@@ -1970,12 +1972,14 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>,
         final HistoryToken historyToken = HistoryToken.cellSelect(ID, NAME, viewport);
 
         this.checkEquals(
-            historyToken.setStylePropertyName(property),
+            historyToken.setStylePropertyName(
+                Optional.of(property)
+            ),
             HistoryToken.cellStyle(
                 ID,
                 NAME,
                 viewport,
-                property
+                Optional.of(property)
             )
         );
     }
@@ -1987,12 +1991,14 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>,
         final HistoryToken historyToken = HistoryToken.cellSelect(ID, NAME, viewport);
 
         this.checkEquals(
-            historyToken.setStylePropertyName(property),
+            historyToken.setStylePropertyName(
+                Optional.of(property)
+            ),
             HistoryToken.cellStyle(
                 ID,
                 NAME,
                 viewport,
-                property
+                Optional.of(property)
             )
         );
     }
@@ -2004,7 +2010,9 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>,
         final HistoryToken historyToken = HistoryToken.columnSelect(ID, NAME, viewport);
 
         assertSame(
-            historyToken.setStylePropertyName(property),
+            historyToken.setStylePropertyName(
+                Optional.of(property)
+            ),
             historyToken
         );
     }
@@ -2016,7 +2024,9 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>,
         final HistoryToken historyToken = HistoryToken.rowSelect(ID, NAME, viewport);
 
         assertSame(
-            historyToken.setStylePropertyName(property),
+            historyToken.setStylePropertyName(
+                Optional.of(property)
+            ),
             historyToken
         );
     }
@@ -3394,18 +3404,23 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>,
     // cell/style.......................................................................................................
 
     @Test
-    public void testParseSpreadsheetIdSpreadsheetNameCellStyleMissingStyleProperty() {
+    public void testParseSpreadsheetIdSpreadsheetNameCellStyleInvalidPropertyName() {
         this.parseStringAndCheck(
-            "/123/SpreadsheetName456/cell/A1/style",
+            "/123/SpreadsheetName456/cell/A1/style/!invalid",
             CELL_TOKEN
         );
     }
 
     @Test
-    public void testParseSpreadsheetIdSpreadsheetNameCellStyleInvalidPropertyName() {
+    public void testParseSpreadsheetIdSpreadsheetNameCellStyle() {
         this.parseStringAndCheck(
-            "/123/SpreadsheetName456/cell/A1/style/!invalid",
-            CELL_TOKEN
+            "/123/SpreadsheetName456/cell/A1/style",
+            HistoryToken.cellStyle(
+                ID,
+                NAME,
+                CELL.setDefaultAnchor(),
+                Optional.empty()
+            )
         );
     }
 
@@ -3417,7 +3432,7 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>,
                 ID,
                 NAME,
                 CELL.setDefaultAnchor(),
-                TextStylePropertyName.COLOR
+                Optional.of(TextStylePropertyName.COLOR)
             )
         );
     }
@@ -4593,13 +4608,25 @@ public final class HistoryTokenTest implements ClassTesting<HistoryToken>,
     }
 
     @Test
+    public void testParseSpreadsheetIdSpreadsheetNameMetadataStyle() {
+        this.parseStringAndCheck(
+            "/123/SpreadsheetName456/spreadsheet/style",
+            HistoryToken.metadataPropertyStyle(
+                ID,
+                NAME,
+                Optional.empty() // stylePropertyName
+            )
+        );
+    }
+
+    @Test
     public void testParseSpreadsheetIdSpreadsheetNameMetadataStylePropertyName() {
         this.parseStringAndCheck(
             "/123/SpreadsheetName456/spreadsheet/style/color",
             HistoryToken.metadataPropertyStyle(
                 ID,
                 NAME,
-                TextStylePropertyName.COLOR
+                Optional.of(TextStylePropertyName.COLOR)
             )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellHistoryTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellHistoryTokenTestCase.java
@@ -497,7 +497,7 @@ public abstract class SpreadsheetCellHistoryTokenTestCase<T extends SpreadsheetC
                 SPREADSHEET_ID,
                 SPREADSHEET_NAME,
                 CELL.setDefaultAnchor(),
-                stylePropertyName
+                Optional.of(stylePropertyName)
             )
         );
     }
@@ -513,7 +513,7 @@ public abstract class SpreadsheetCellHistoryTokenTestCase<T extends SpreadsheetC
                 SPREADSHEET_ID,
                 SPREADSHEET_NAME,
                 CELL.setDefaultAnchor(),
-                stylePropertyName
+                Optional.of(stylePropertyName)
             )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleSaveHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleSaveHistoryTokenTest.java
@@ -200,7 +200,7 @@ public final class SpreadsheetCellStyleSaveHistoryTokenTest extends SpreadsheetC
                 SPREADSHEET_ID,
                 SPREADSHEET_NAME,
                 SELECTION,
-                STYLE_PROPERTY_NAME
+                Optional.of(STYLE_PROPERTY_NAME)
             )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleSelectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetCellStyleSelectHistoryTokenTest.java
@@ -38,7 +38,12 @@ public final class SpreadsheetCellStyleSelectHistoryTokenTest extends Spreadshee
         final AnchoredSpreadsheetSelection selection = CELL.setDefaultAnchor();
         final TextStylePropertyName<Color> propertyName = TextStylePropertyName.BACKGROUND_COLOR;
         final String value = "#123456";
-        final HistoryToken historyToken = HistoryToken.cellStyle(SPREADSHEET_ID, SPREADSHEET_NAME, selection, propertyName);
+        final HistoryToken historyToken = HistoryToken.cellStyle(
+            SPREADSHEET_ID,
+            SPREADSHEET_NAME,
+            selection,
+            Optional.of(propertyName)
+        );
 
         this.setSaveStringValueAndCheck(
             historyToken,
@@ -58,7 +63,12 @@ public final class SpreadsheetCellStyleSelectHistoryTokenTest extends Spreadshee
         final AnchoredSpreadsheetSelection selection = CELL.setDefaultAnchor();
         final TextStylePropertyName<Color> propertyName = TextStylePropertyName.BACKGROUND_COLOR;
         final String value = "";
-        final HistoryToken historyToken = HistoryToken.cellStyle(SPREADSHEET_ID, SPREADSHEET_NAME, selection, propertyName);
+        final HistoryToken historyToken = HistoryToken.cellStyle(
+            SPREADSHEET_ID,
+            SPREADSHEET_NAME,
+            selection,
+            Optional.of(propertyName)
+        );
 
         this.setSaveStringValueAndCheck(
             historyToken,
@@ -76,13 +86,26 @@ public final class SpreadsheetCellStyleSelectHistoryTokenTest extends Spreadshee
     // urlFragment.....................................................................................................
 
     @Test
+    public void testUrlFragmentCellWithoutTextStylePropertyName() {
+        this.urlFragmentAndCheck(
+            SpreadsheetCellStyleSelectHistoryToken.with(
+                SPREADSHEET_ID,
+                SPREADSHEET_NAME,
+                CELL.setDefaultAnchor(),
+                Optional.empty()
+            ),
+            "/123/SpreadsheetName456/cell/A1/style"
+        );
+    }
+
+    @Test
     public void testUrlFragmentCellWildcard() {
         this.urlFragmentAndCheck(
             SpreadsheetCellStyleSelectHistoryToken.with(
                 SPREADSHEET_ID,
                 SPREADSHEET_NAME,
                 CELL.setDefaultAnchor(),
-                TextStylePropertyName.WILDCARD
+                Optional.of(TextStylePropertyName.WILDCARD)
             ),
             "/123/SpreadsheetName456/cell/A1/style/*"
         );
@@ -124,7 +147,7 @@ public final class SpreadsheetCellStyleSelectHistoryTokenTest extends Spreadshee
                 SPREADSHEET_ID,
                 SPREADSHEET_NAME,
                 CELL.setDefaultAnchor(),
-                propertyName
+                Optional.of(propertyName)
             );
             this.urlFragmentAndCheck(
                 token,
@@ -139,7 +162,7 @@ public final class SpreadsheetCellStyleSelectHistoryTokenTest extends Spreadshee
             SPREADSHEET_ID,
             SPREADSHEET_NAME,
             CELL.setDefaultAnchor(),
-            TextStylePropertyName.WILDCARD
+            Optional.of(TextStylePropertyName.WILDCARD)
         );
         this.urlFragmentAndCheck(
             token,
@@ -154,7 +177,7 @@ public final class SpreadsheetCellStyleSelectHistoryTokenTest extends Spreadshee
                 SPREADSHEET_ID,
                 SPREADSHEET_NAME,
                 CELL.setDefaultAnchor(),
-                propertyName
+                Optional.of(propertyName)
             );
             this.parseAndCheck(
                 token.urlFragment(),
@@ -169,7 +192,7 @@ public final class SpreadsheetCellStyleSelectHistoryTokenTest extends Spreadshee
             SPREADSHEET_ID,
             SPREADSHEET_NAME,
             CELL.setDefaultAnchor(),
-            TextStylePropertyName.WILDCARD
+            Optional.of(TextStylePropertyName.WILDCARD)
         );
         this.parseAndCheck(
             token.urlFragment(),
@@ -193,7 +216,7 @@ public final class SpreadsheetCellStyleSelectHistoryTokenTest extends Spreadshee
             id,
             name,
             selection,
-            STYLE_PROPERTY_NAME
+            Optional.of(STYLE_PROPERTY_NAME)
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySelectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertySelectHistoryTokenTest.java
@@ -99,12 +99,13 @@ public final class SpreadsheetMetadataPropertySelectHistoryTokenTest extends Spr
     }
 
     @Test
-    public void testParseStyle() {
+    public void testParseStyleMissingTextStylePropertyName() {
         this.parseAndCheck(
             "/123/SpreadsheetName456/spreadsheet/style",
-            HistoryToken.spreadsheetSelect(
+            HistoryToken.metadataPropertyStyle(
                 SPREADSHEET_ID,
-                SPREADSHEET_NAME
+                SPREADSHEET_NAME,
+                Optional.empty()
             )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSaveHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSaveHistoryTokenTest.java
@@ -153,7 +153,7 @@ public final class SpreadsheetMetadataPropertyStyleSaveHistoryTokenTest extends 
             HistoryToken.metadataPropertyStyle(
                 SPREADSHEET_ID,
                 SPREADSHEET_NAME,
-                STYLE_PROPERTY_NAME
+                Optional.of(STYLE_PROPERTY_NAME)
             )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSelectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataPropertyStyleSelectHistoryTokenTest.java
@@ -115,6 +115,18 @@ public final class SpreadsheetMetadataPropertyStyleSelectHistoryTokenTest extend
     // urlFragment......................................................................................................
 
     @Test
+    public void testUrlFragmentWithoutTextStylePropertyName() {
+        this.urlFragmentAndCheck(
+            SpreadsheetMetadataPropertyStyleSelectHistoryToken.with(
+                SPREADSHEET_ID,
+                SPREADSHEET_NAME,
+                Optional.empty()
+            ),
+            "/123/SpreadsheetName456/spreadsheet/style"
+        );
+    }
+
+    @Test
     public void testUrlFragmentColor() {
         this.urlFragmentAndCheck("/123/SpreadsheetName456/spreadsheet/style/color");
     }
@@ -125,7 +137,7 @@ public final class SpreadsheetMetadataPropertyStyleSelectHistoryTokenTest extend
             SpreadsheetMetadataPropertyStyleSelectHistoryToken.with(
                 SPREADSHEET_ID,
                 SPREADSHEET_NAME,
-                TextStylePropertyName.FONT_FAMILY
+                Optional.of(TextStylePropertyName.FONT_FAMILY)
             ),
             "/123/SpreadsheetName456/spreadsheet/style/font-family"
         );
@@ -137,7 +149,7 @@ public final class SpreadsheetMetadataPropertyStyleSelectHistoryTokenTest extend
             SpreadsheetMetadataPropertyStyleSelectHistoryToken.with(
                 SPREADSHEET_ID,
                 SPREADSHEET_NAME,
-                TextStylePropertyName.FONT_STYLE
+                Optional.of(TextStylePropertyName.FONT_STYLE)
             ),
             "/123/SpreadsheetName456/spreadsheet/style/font-style"
         );
@@ -150,7 +162,7 @@ public final class SpreadsheetMetadataPropertyStyleSelectHistoryTokenTest extend
             SpreadsheetMetadataPropertyStyleSelectHistoryToken.with(
                 SPREADSHEET_ID,
                 SPREADSHEET_NAME,
-                TextStylePropertyName.BACKGROUND_COLOR
+                Optional.of(TextStylePropertyName.BACKGROUND_COLOR)
             )
         );
     }
@@ -162,7 +174,7 @@ public final class SpreadsheetMetadataPropertyStyleSelectHistoryTokenTest extend
             SpreadsheetMetadataPropertyStyleSelectHistoryToken.with(
                 SPREADSHEET_ID,
                 SPREADSHEET_NAME,
-                TextStylePropertyName.FONT_FAMILY
+                Optional.of(TextStylePropertyName.FONT_FAMILY)
             )
         );
     }
@@ -192,7 +204,7 @@ public final class SpreadsheetMetadataPropertyStyleSelectHistoryTokenTest extend
         return SpreadsheetMetadataPropertyStyleSelectHistoryToken.with(
             id,
             name,
-            STYLE_PROPERTY_NAME
+            Optional.of(STYLE_PROPERTY_NAME)
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataSelectHistoryTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/history/SpreadsheetMetadataSelectHistoryTokenTest.java
@@ -22,6 +22,8 @@ import walkingkooka.spreadsheet.meta.SpreadsheetId;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.spreadsheet.meta.SpreadsheetName;
 
+import java.util.Optional;
+
 public final class SpreadsheetMetadataSelectHistoryTokenTest extends SpreadsheetMetadataHistoryTokenTestCase<SpreadsheetMetadataSelectHistoryToken> {
 
     @Test
@@ -41,12 +43,13 @@ public final class SpreadsheetMetadataSelectHistoryTokenTest extends Spreadsheet
     }
 
     @Test
-    public void testParseStyle() {
+    public void testParseStyleMissingTextStylePropertyName() {
         this.parseAndCheck(
             "/123/SpreadsheetName456/spreadsheet/style",
-            HistoryToken.spreadsheetSelect(
+            HistoryToken.metadataPropertyStyle(
                 SPREADSHEET_ID,
-                SPREADSHEET_NAME
+                SPREADSHEET_NAME,
+                Optional.empty()
             )
         );
     }


### PR DESCRIPTION
…tyleSelectHistoryToken optional TextStylePropertyName

- Previously TextStylePropertyName was required.
- Now optional so a general show all TextStyle properties dialog

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/7563
- SpreadsheetCellStyleSelectHistoryToken optional TextStylePropertyName was required