### PR TITLE
DialogAnchorListComponentContextDialogOpenAware

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/dialog/DialogAnchorListComponentContextDialogOpenAware.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/dialog/DialogAnchorListComponentContextDialogOpenAware.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.dominokit.dialog;
+
+import walkingkooka.spreadsheet.dominokit.history.HistoryContext;
+import walkingkooka.spreadsheet.dominokit.history.HistoryContextDelegator;
+import walkingkooka.spreadsheet.dominokit.history.HistoryTokenWatcher;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BooleanSupplier;
+
+/**
+ * A {@link DialogAnchorListComponentContext} that wraps another, filtering (skipping) {@link walkingkooka.spreadsheet.dominokit.history.HistoryTokenWatcher}
+ * if the enclosing {@link DialogComponent} is closed.
+ */
+final class DialogAnchorListComponentContextDialogOpenAware<T> implements DialogAnchorListComponentContext<T>,
+    HistoryContextDelegator {
+
+    static <T> DialogAnchorListComponentContextDialogOpenAware<T> with(final BooleanSupplier isDialogOpen,
+                                                                       final DialogAnchorListComponentContext<T> context) {
+        return new DialogAnchorListComponentContextDialogOpenAware<>(
+            Objects.requireNonNull(isDialogOpen, "isDialogOpen"),
+            Objects.requireNonNull(context, "context")
+        );
+    }
+
+    private DialogAnchorListComponentContextDialogOpenAware(final BooleanSupplier isDialogOpen,
+                                                            final DialogAnchorListComponentContext<T> context) {
+        super();
+        this.isDialogOpen = isDialogOpen;
+        this.context = context;
+    }
+
+    @Override
+    public Optional<T> undo() {
+        return this.context.undo();
+    }
+
+    // HistoryContextDelegator..........................................................................................
+
+    @Override
+    public Runnable addHistoryTokenWatcher(final HistoryTokenWatcher watcher) {
+        return this.context.addHistoryTokenWatcher(
+            DialogAnchorListComponentContextDialogOpenAwareHistoryTokenWatcher.with(
+                this.isDialogOpen,
+                watcher
+            )
+        );
+    }
+
+    @Override
+    public Runnable addHistoryTokenWatcherOnce(final HistoryTokenWatcher watcher) {
+        return this.context.addHistoryTokenWatcherOnce(
+            DialogAnchorListComponentContextDialogOpenAwareHistoryTokenWatcher.with(
+                this.isDialogOpen,
+                watcher
+            )
+        );
+    }
+
+    private final BooleanSupplier isDialogOpen;
+
+    @Override
+    public HistoryContext historyContext() {
+        return this.context;
+    }
+
+    private final DialogAnchorListComponentContext<T> context;
+
+    // Object...........................................................................................................
+
+    @Override
+    public String toString() {
+        return this.context.toString();
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/dialog/DialogAnchorListComponentContextDialogOpenAwareHistoryTokenWatcher.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/dialog/DialogAnchorListComponentContextDialogOpenAwareHistoryTokenWatcher.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.dominokit.dialog;
+
+import walkingkooka.spreadsheet.dominokit.AppContext;
+import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
+import walkingkooka.spreadsheet.dominokit.history.HistoryTokenWatcher;
+
+import java.util.Objects;
+import java.util.function.BooleanSupplier;
+
+final class DialogAnchorListComponentContextDialogOpenAwareHistoryTokenWatcher implements HistoryTokenWatcher {
+
+    static DialogAnchorListComponentContextDialogOpenAwareHistoryTokenWatcher with(final BooleanSupplier isDialogOpen,
+                                                                                   final HistoryTokenWatcher watcher) {
+        return new DialogAnchorListComponentContextDialogOpenAwareHistoryTokenWatcher(
+            isDialogOpen,
+            Objects.requireNonNull(watcher, "watcher")
+        );
+    }
+
+    private DialogAnchorListComponentContextDialogOpenAwareHistoryTokenWatcher(final BooleanSupplier isDialogOpen,
+                                                                               final HistoryTokenWatcher watcher) {
+        super();
+
+        this.isDialogOpen = isDialogOpen;
+        this.watcher = watcher;
+    }
+
+    @Override
+    public void onHistoryTokenChange(final HistoryToken previous,
+                                     final AppContext context) {
+        if (this.isDialogOpen.getAsBoolean()) {
+            this.watcher.onHistoryTokenChange(
+                previous,
+                context
+            );
+        }
+    }
+
+    private final BooleanSupplier isDialogOpen;
+
+    private final HistoryTokenWatcher watcher;
+
+    // Object...........................................................................................................
+
+    @Override
+    public String toString() {
+        return this.watcher.toString();
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/dialog/DialogAnchorListComponentContexts.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/dialog/DialogAnchorListComponentContexts.java
@@ -19,7 +19,20 @@ package walkingkooka.spreadsheet.dominokit.dialog;
 
 import walkingkooka.reflect.PublicStaticHelper;
 
+import java.util.function.BooleanSupplier;
+
 public final class DialogAnchorListComponentContexts implements PublicStaticHelper {
+
+    /**
+     * {@see DialogAnchorListComponentContextDialogOpenAware}
+     */
+    public static <T> DialogAnchorListComponentContext<T> isDialogOpen(final BooleanSupplier isDialogOpen,
+                                                                       final DialogAnchorListComponentContext<T> context) {
+        return DialogAnchorListComponentContextDialogOpenAware.with(
+            isDialogOpen,
+            context
+        );
+    }
 
     /**
      * {@see FakeDialogAnchorListComponentContext}

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/dialog/DialogAnchorListComponentContextDialogOpenAwareHistoryTokenWatcherTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/dialog/DialogAnchorListComponentContextDialogOpenAwareHistoryTokenWatcherTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.dominokit.dialog;
+
+import walkingkooka.reflect.ClassTesting2;
+import walkingkooka.reflect.JavaVisibility;
+
+public final class DialogAnchorListComponentContextDialogOpenAwareHistoryTokenWatcherTest implements ClassTesting2<DialogAnchorListComponentContextDialogOpenAwareHistoryTokenWatcher> {
+
+    @Override
+    public Class<DialogAnchorListComponentContextDialogOpenAwareHistoryTokenWatcher> type() {
+        return DialogAnchorListComponentContextDialogOpenAwareHistoryTokenWatcher.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PACKAGE_PRIVATE;
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/dialog/DialogAnchorListComponentContextDialogOpenAwareTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/dialog/DialogAnchorListComponentContextDialogOpenAwareTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2023 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.dominokit.dialog;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.spreadsheet.dominokit.AppContext;
+import walkingkooka.spreadsheet.dominokit.AppContexts;
+import walkingkooka.spreadsheet.dominokit.history.HistoryToken;
+import walkingkooka.spreadsheet.dominokit.history.HistoryTokenWatcher;
+import walkingkooka.spreadsheet.dominokit.history.HistoryTokenWatchers;
+import walkingkooka.spreadsheet.meta.SpreadsheetId;
+import walkingkooka.spreadsheet.meta.SpreadsheetName;
+
+public final class DialogAnchorListComponentContextDialogOpenAwareTest implements DialogAnchorListComponentContextTesting<DialogAnchorListComponentContextDialogOpenAware<String>, String> {
+
+    @Test
+    public void testAddHistoryTokenWatcherOnHistoryTokenDialogOpen() {
+        this.fired = false;
+
+        final DialogAnchorListComponentContextDialogOpenAware<String> context = this.createContext(true);
+        context.addHistoryTokenWatcher(
+            (final HistoryToken previous,
+             final AppContext appContext) -> DialogAnchorListComponentContextDialogOpenAwareTest.this.fired = true
+        );
+        context.fireCurrentHistoryToken();
+
+        this.checkEquals(
+            true,
+            this.fired
+        );
+    }
+
+    @Test
+    public void testAddHistoryTokenWatcherOnHistoryTokenDialogClose() {
+        final DialogAnchorListComponentContextDialogOpenAware<String> context = this.createContext(false);
+        context.addHistoryTokenWatcher(
+            (final HistoryToken previous,
+             final AppContext appContext) -> {
+                throw new UnsupportedOperationException();
+            }
+        );
+        context.fireCurrentHistoryToken();
+    }
+
+    @Test
+    public void testAddHistoryTokenWatcherOnceOnHistoryTokenDialogOpen() {
+        this.fired = false;
+
+        final DialogAnchorListComponentContextDialogOpenAware<String> context = this.createContext(true);
+        context.addHistoryTokenWatcherOnce(
+            (final HistoryToken previous,
+             final AppContext appContext) -> DialogAnchorListComponentContextDialogOpenAwareTest.this.fired = true
+        );
+        context.fireCurrentHistoryToken();
+
+        this.checkEquals(
+            true,
+            this.fired
+        );
+    }
+
+    @Test
+    public void testAddHistoryTokenWatcherOnceOnHistoryTokenDialogClose() {
+        final DialogAnchorListComponentContextDialogOpenAware<String> context = this.createContext(false);
+        context.addHistoryTokenWatcherOnce(
+            (final HistoryToken previous,
+             final AppContext appContext) -> {
+                throw new UnsupportedOperationException();
+            }
+        );
+        context.fireCurrentHistoryToken();
+    }
+
+    private boolean fired;
+
+    @Override
+    public void testPushHistoryTokenWithNullFails() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DialogAnchorListComponentContextDialogOpenAware<String> createContext() {
+        return this.createContext(true);
+    }
+
+    private DialogAnchorListComponentContextDialogOpenAware<String> createContext(final boolean isDialogOpen) {
+        return DialogAnchorListComponentContextDialogOpenAware.with(
+            () -> isDialogOpen,
+            new FakeDialogAnchorListComponentContext<>() {
+
+                @Override
+                public Runnable addHistoryTokenWatcher(final HistoryTokenWatcher watcher) {
+                    return this.watcher.add(watcher);
+                }
+
+                @Override
+                public Runnable addHistoryTokenWatcherOnce(final HistoryTokenWatcher watcher) {
+                    return this.watcher.addOnce(watcher);
+                }
+
+                private final HistoryTokenWatchers watcher = HistoryTokenWatchers.empty();
+
+                @Override
+                public void fireCurrentHistoryToken() {
+                    this.watcher.onHistoryTokenChange(
+                        HistoryToken.spreadsheetSelect(
+                            SpreadsheetId.with(1),
+                            SpreadsheetName.with("SpreadsheetName1")
+                        ),
+                        AppContexts.fake()
+                    );
+                }
+            }
+        );
+    }
+
+    @Override
+    public String typeNamePrefix() {
+        return DialogAnchorListComponentContext.class.getSimpleName();
+    }
+
+    @Override
+    public String typeNameSuffix() {
+        return "";
+    }
+
+    @Override
+    public Class<DialogAnchorListComponentContextDialogOpenAware<String>> type() {
+        return Cast.to(DialogAnchorListComponentContextDialogOpenAware.class);
+    }
+}


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/7629
- DialogAnchorListComponent#onHistoryToken should only fire when enclosing DialogComponent is open