### PR TITLE
SpreadsheetContextMenu item/separator FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/contextmenu/SpreadsheetContextMenuNative.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/contextmenu/SpreadsheetContextMenuNative.java
@@ -155,7 +155,7 @@ final class SpreadsheetContextMenuNative {
         menuItem.setDisabled(false == item.enabled);
 
         // NOTE: Cast to raw type needed so compiler selects appendChild(AbstractMenuItem) and not appendChild(Node)
-        menu.menu.appendChild((AbstractMenuItem<?>) menuItem);
+        menu.menu.appendChild((AbstractMenuItem) menuItem);
     }
 
     static void menuAppendChildIsElement(final IsElement<?> isElement,


### PR DESCRIPTION
- SpreadsheetContextMenuNative.menuAppendChildSpreadsheetContextMenuItem must use Menu.appendChild(AbstractMenuItem) raw not with type-parameter.