### PR TITLE
ValueTextBoxComponent.addValueWatcher fire FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/value/ValueTextBoxComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/value/ValueTextBoxComponent.java
@@ -63,6 +63,15 @@ public final class ValueTextBoxComponent<T> implements ValueTextBoxComponentLike
             .enterFiresValueChange();
         this.setParser(parser);
         this.setFormatter(formatter);
+
+        this.textBox.addValueWatcher(
+            (Optional<String> text) -> {
+                this.validate();
+                this.valueWatchers.onValue(
+                    this.value()
+                );
+            }
+        );
     }
 
     /**
@@ -315,12 +324,15 @@ public final class ValueTextBoxComponent<T> implements ValueTextBoxComponentLike
     public Runnable addValueWatcher(final ValueWatcher<T> watcher) {
         Objects.requireNonNull(watcher, "watcher");
 
-        return this.textBox.addValueWatcher(
-            (v) -> watcher.onValue(
-                ValueTextBoxComponent.this.value()
-            )
-        );
+//        return this.textBox.addValueWatcher(
+//            (v) -> watcher.onValue(
+//                ValueTextBoxComponent.this.value()
+//            )
+//        );
+        return this.valueWatchers.add(watcher);
     }
+
+    private final ValueWatchers<T> valueWatchers = ValueWatchers.empty();
 
     // HtmlComponentDelegator...........................................................................................
 

--- a/src/test/java/walkingkooka/spreadsheet/dominokit/value/ValueTextBoxComponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/dominokit/value/ValueTextBoxComponentTest.java
@@ -84,6 +84,21 @@ public final class ValueTextBoxComponentTest implements ValueTextBoxComponentLik
     }
 
     @Test
+    public void testSetStringValueWithInvalidFails() {
+        this.treePrintAndCheck(
+            this.createComponent()
+                .setStringValue(
+                    Optional.of("A!")
+                ),
+            "ValueTextBoxComponent\n" +
+                "  TextBoxComponent\n" +
+                "    [A!] icons=mdi-close-circle REQUIRED\n" +
+                "    Errors\n" +
+                "      Invalid character '!' at 1\n"
+        );
+    }
+
+    @Test
     public void testSetStringValue() {
         final String text = "AB12";
 


### PR DESCRIPTION
- Validation was potentially broken for more complex parsing such as Margin. Validation was not happening and errors not always displayed.