### PR TITLE
TextStylePropertyComponent.setIdPrefix suffix parameter

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/dominokit/value/textstyle/TextStyleLengthPropertyComponentLike.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/value/textstyle/TextStyleLengthPropertyComponentLike.java
@@ -22,6 +22,7 @@ import elemental2.dom.HTMLFieldSetElement;
 import org.dominokit.domino.ui.icons.Icon;
 import org.dominokit.domino.ui.utils.HasChangeListeners.ChangeListener;
 import walkingkooka.spreadsheet.dominokit.HtmlComponent;
+import walkingkooka.spreadsheet.dominokit.SpreadsheetElementIds;
 import walkingkooka.spreadsheet.dominokit.value.ValueTextBoxComponentLike;
 import walkingkooka.spreadsheet.dominokit.value.textstyle.length.LengthComponentDelegator;
 import walkingkooka.tree.text.Length;
@@ -32,6 +33,13 @@ public interface TextStyleLengthPropertyComponentLike<C extends TextStyleLengthP
     extends TextStylePropertyComponent<HTMLFieldSetElement, Length<?>, C>,
     ValueTextBoxComponentLike<C, Length<?>>,
     LengthComponentDelegator<C> {
+
+    default C setIdPrefix(final String idPrefix) {
+        return this.setIdPrefix(
+            idPrefix,
+            SpreadsheetElementIds.TEXT_BOX
+        );
+    }
 
     @Override
     default Optional<String> stringValue() {

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/value/textstyle/TextStylePropertyComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/value/textstyle/TextStylePropertyComponent.java
@@ -19,7 +19,6 @@ package walkingkooka.spreadsheet.dominokit.value.textstyle;
 
 import elemental2.dom.HTMLElement;
 import walkingkooka.naming.HasName;
-import walkingkooka.spreadsheet.dominokit.SpreadsheetElementIds;
 import walkingkooka.spreadsheet.dominokit.value.FormValueComponent;
 import walkingkooka.spreadsheet.dominokit.value.ValueWatcher;
 import walkingkooka.text.CaseKind;
@@ -38,7 +37,8 @@ public interface TextStylePropertyComponent<E extends HTMLElement, V, C extends 
     extends FormValueComponent<E, V, C>,
     HasName<TextStylePropertyName<V>> {
 
-    default C setIdPrefix(final String idPrefix) {
+    default C setIdPrefix(final String idPrefix,
+                          final String suffix) {
         CharSequences.failIfNullOrEmpty(idPrefix, "idPrefix");
 
         return this.setId(
@@ -48,7 +48,7 @@ public interface TextStylePropertyComponent<E extends HTMLElement, V, C extends 
                         .text(),
                     CaseKind.CAMEL
                 ) +
-                SpreadsheetElementIds.TEXT_BOX
+                suffix
         );
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/value/textstyle/color/TextStylePropertyColorComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/value/textstyle/color/TextStylePropertyColorComponent.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.dominokit.value.textstyle.color;
 
 import elemental2.dom.HTMLFieldSetElement;
 import walkingkooka.color.Color;
+import walkingkooka.spreadsheet.dominokit.SpreadsheetElementIds;
 import walkingkooka.spreadsheet.dominokit.value.FormValueComponent;
 import walkingkooka.spreadsheet.dominokit.value.FormValueComponentDelegator;
 import walkingkooka.spreadsheet.dominokit.value.textstyle.TextStylePropertyComponent;
@@ -56,7 +57,10 @@ public final class TextStylePropertyColorComponent implements TextStylePropertyC
             )
         );
 
-        this.setIdPrefix(idPrefix);
+        this.setIdPrefix(
+            idPrefix,
+            SpreadsheetElementIds.TEXT_BOX
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/value/textstyle/color/TextStylePropertyColorComponentDelegator.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/value/textstyle/color/TextStylePropertyColorComponentDelegator.java
@@ -20,6 +20,7 @@ package walkingkooka.spreadsheet.dominokit.value.textstyle.color;
 import elemental2.dom.HTMLFieldSetElement;
 import walkingkooka.color.Color;
 import walkingkooka.naming.HasName;
+import walkingkooka.spreadsheet.dominokit.SpreadsheetElementIds;
 import walkingkooka.spreadsheet.dominokit.value.FormValueComponentDelegator;
 import walkingkooka.spreadsheet.dominokit.value.ValueWatcher;
 import walkingkooka.spreadsheet.dominokit.value.textstyle.TextStylePropertyComponent;
@@ -31,6 +32,13 @@ public interface TextStylePropertyColorComponentDelegator<C extends TextStylePro
     extends TextStylePropertyComponent<HTMLFieldSetElement, Color, C>,
     FormValueComponentDelegator<HTMLFieldSetElement, Color, C>,
     HasName<TextStylePropertyName<Color>> {
+
+    default C setIdPrefix(final String idPrefix) {
+        return this.setIdPrefix(
+            idPrefix,
+            SpreadsheetElementIds.TEXT_BOX
+        );
+    }
 
     @Override
     default TextStylePropertyName<Color> name() {

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/value/textstyle/fontweight/FontWeightComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/value/textstyle/fontweight/FontWeightComponent.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.dominokit.value.textstyle.fontweight;
 
 import elemental2.dom.HTMLFieldSetElement;
+import walkingkooka.spreadsheet.dominokit.SpreadsheetElementIds;
 import walkingkooka.spreadsheet.dominokit.value.ValueTextBoxComponent;
 import walkingkooka.spreadsheet.dominokit.value.ValueTextBoxComponentDelegator;
 import walkingkooka.spreadsheet.dominokit.value.textstyle.TextStylePropertyComponent;
@@ -40,7 +41,10 @@ public final class FontWeightComponent implements TextStylePropertyComponent<HTM
             FontWeight::parse,
             FontWeight::toString
         );
-        this.setIdPrefix(idPrefix);
+        this.setIdPrefix(
+            idPrefix,
+            SpreadsheetElementIds.TEXT_BOX
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/value/textstyle/margin/MarginComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/value/textstyle/margin/MarginComponent.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.dominokit.value.textstyle.margin;
 
 import elemental2.dom.HTMLFieldSetElement;
+import walkingkooka.spreadsheet.dominokit.SpreadsheetElementIds;
 import walkingkooka.spreadsheet.dominokit.value.ValueTextBoxComponent;
 import walkingkooka.spreadsheet.dominokit.value.ValueTextBoxComponentDelegator;
 import walkingkooka.spreadsheet.dominokit.value.textstyle.TextStylePropertyComponent;
@@ -42,7 +43,10 @@ public final class MarginComponent implements TextStylePropertyComponent<HTMLFie
             (Margin margin) -> margin.setEdge(BoxEdge.ALL)
                 .text()
         );
-        this.setIdPrefix(idPrefix);
+        this.setIdPrefix(
+            idPrefix,
+            SpreadsheetElementIds.TEXT_BOX
+        );
     }
 
     // HasName..........................................................................................................

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/value/textstyle/opacity/OpacityComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/value/textstyle/opacity/OpacityComponent.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.dominokit.value.textstyle.opacity;
 
 import elemental2.dom.HTMLFieldSetElement;
+import walkingkooka.spreadsheet.dominokit.SpreadsheetElementIds;
 import walkingkooka.spreadsheet.dominokit.value.ValueTextBoxComponent;
 import walkingkooka.spreadsheet.dominokit.value.ValueTextBoxComponentDelegator;
 import walkingkooka.spreadsheet.dominokit.value.textstyle.TextStylePropertyComponent;
@@ -40,7 +41,10 @@ public final class OpacityComponent implements TextStylePropertyComponent<HTMLFi
             Opacity::parse,
             Opacity::text
         );
-        this.setIdPrefix(idPrefix);
+        this.setIdPrefix(
+            idPrefix,
+            SpreadsheetElementIds.TEXT_BOX
+        );
     }
 
     // HasName..........................................................................................................

--- a/src/main/java/walkingkooka/spreadsheet/dominokit/value/textstyle/padding/PaddingComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/dominokit/value/textstyle/padding/PaddingComponent.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.dominokit.value.textstyle.padding;
 
 import elemental2.dom.HTMLFieldSetElement;
+import walkingkooka.spreadsheet.dominokit.SpreadsheetElementIds;
 import walkingkooka.spreadsheet.dominokit.value.ValueTextBoxComponent;
 import walkingkooka.spreadsheet.dominokit.value.ValueTextBoxComponentDelegator;
 import walkingkooka.spreadsheet.dominokit.value.textstyle.TextStylePropertyComponent;
@@ -42,7 +43,10 @@ public final class PaddingComponent implements TextStylePropertyComponent<HTMLFi
             (Padding padding) -> padding.setEdge(BoxEdge.ALL)
                 .text()
         );
-        this.setIdPrefix(idPrefix);
+        this.setIdPrefix(
+            idPrefix,
+            SpreadsheetElementIds.TEXT_BOX
+        );
     }
 
     // HasName..........................................................................................................


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/8046
- TextStylePropertyComponent.setIdPrefix assumes SpreadsheetElementIds.TEXT_BOX